### PR TITLE
refactor: update extension group info structure and related functionality

### DIFF
--- a/core/include_internal/ten_runtime/extension_group/extension_group_info/extension_group_info.h
+++ b/core/include_internal/ten_runtime/extension_group/extension_group_info/extension_group_info.h
@@ -8,9 +8,9 @@
 
 #include "ten_runtime/ten_config.h"
 
-#include "include_internal/ten_runtime/common/loc.h"
 #include "ten_utils/lib/signature.h"
 #include "ten_utils/lib/string.h"
+#include "ten_utils/value/value.h"
 
 #define TEN_EXTENSION_GROUP_INFO_SIGNATURE 0xBC5114352AFF63AEU
 

--- a/core/include_internal/ten_runtime/extension_group/extension_group_info/extension_group_info.h
+++ b/core/include_internal/ten_runtime/extension_group/extension_group_info/extension_group_info.h
@@ -24,7 +24,10 @@ typedef struct ten_extension_group_info_t {
   ten_signature_t signature;
 
   ten_string_t extension_group_addon_name;
-  ten_loc_t loc;
+
+  ten_string_t app_uri;
+  ten_string_t graph_id;
+  ten_string_t extension_group_name;
 
   // The definition of properties in the graph related to the current extension
   // group.

--- a/core/src/ten_runtime/extension_context/extension_context.c
+++ b/core/src/ten_runtime/extension_context/extension_context.c
@@ -290,11 +290,9 @@ ten_extension_context_get_extension_group_info_by_name(
     ten_extension_group_info_t *extension_group_info =
         ten_shared_ptr_get_data(ten_smart_ptr_listnode_get(iter.node));
 
-    if (ten_string_is_equal_c_str(&extension_group_info->loc.app_uri,
-                                  app_uri) &&
-        ten_string_is_equal_c_str(
-            &extension_group_info->loc.extension_group_name,
-            extension_group_name)) {
+    if (ten_string_is_equal_c_str(&extension_group_info->app_uri, app_uri) &&
+        ten_string_is_equal_c_str(&extension_group_info->extension_group_name,
+                                  extension_group_name)) {
       result = extension_group_info;
       break;
     }
@@ -429,7 +427,7 @@ static void ten_extension_context_create_extension_group_done(
     ten_extension_group_info_t *extension_group_info =
         ten_shared_ptr_get_data(ten_smart_ptr_listnode_get(iter.node));
 
-    if (ten_string_is_equal(&extension_group_info->loc.app_uri,
+    if (ten_string_is_equal(&extension_group_info->app_uri,
                             &engine->app->uri)) {
       ++extension_groups_cnt_of_the_current_app;
     }
@@ -511,14 +509,13 @@ bool ten_extension_context_start_extension_group(ten_extension_context_t *self,
 
     // Check whether the current `extension_group` is located within the current
     // `app`.
-    if (ten_string_is_equal(&extension_group_info->loc.app_uri,
+    if (ten_string_is_equal(&extension_group_info->app_uri,
                             &self->engine->app->uri)) {
       bool res = ten_addon_create_extension_group(
           ten_env,
           ten_string_get_raw_str(
               &extension_group_info->extension_group_addon_name),
-          ten_string_get_raw_str(
-              &extension_group_info->loc.extension_group_name),
+          ten_string_get_raw_str(&extension_group_info->extension_group_name),
           (ten_env_addon_create_instance_done_cb_t)
               ten_extension_context_create_extension_group_done,
           NULL);

--- a/core/src/ten_runtime/extension_group/extension_group_info/json.c
+++ b/core/src/ten_runtime/extension_group/extension_group_info/json.c
@@ -24,15 +24,14 @@ bool ten_extension_group_info_to_json(ten_extension_group_info_t *self,
   ten_json_object_set_string(json, TEN_STR_TYPE, TEN_STR_EXTENSION_GROUP);
 
   ten_json_object_set_string(
-      json, TEN_STR_NAME,
-      ten_string_get_raw_str(&self->loc.extension_group_name));
+      json, TEN_STR_NAME, ten_string_get_raw_str(&self->extension_group_name));
 
   ten_json_object_set_string(
       json, TEN_STR_ADDON,
       ten_string_get_raw_str(&self->extension_group_addon_name));
 
   ten_json_object_set_string(json, TEN_STR_APP,
-                             ten_string_get_raw_str(&self->loc.app_uri));
+                             ten_string_get_raw_str(&self->app_uri));
 
   if (self->property) {
     ten_json_t property_json = TEN_JSON_INIT_VAL(json->ctx, false);

--- a/core/src/ten_runtime/msg/cmd_base/cmd/start_graph/cmd.c
+++ b/core/src/ten_runtime/msg/cmd_base/cmd/start_graph/cmd.c
@@ -365,10 +365,9 @@ static void ten_raw_cmd_start_graph_add_missing_extension_group_node(
           ten_extension_group_info_from_smart_ptr(
               ten_smart_ptr_listnode_get(iter_extension_group.node));
 
-      if (ten_string_is_equal(
-              extension_group_name,
-              &extension_group_info->loc.extension_group_name) &&
-          ten_string_is_equal(app_uri, &extension_group_info->loc.app_uri)) {
+      if (ten_string_is_equal(extension_group_name,
+                              &extension_group_info->extension_group_name) &&
+          ten_string_is_equal(app_uri, &extension_group_info->app_uri)) {
         group_found = true;
         break;
       }
@@ -387,10 +386,12 @@ static void ten_raw_cmd_start_graph_add_missing_extension_group_node(
     ten_string_set_formatted(&extension_group_info->extension_group_addon_name,
                              TEN_STR_DEFAULT_EXTENSION_GROUP);
 
-    ten_loc_set(
-        &extension_group_info->loc,
-        ten_string_get_raw_str(&extension_info->loc.app_uri), "",
-        ten_string_get_raw_str(&extension_info->loc.extension_group_name), "");
+    ten_string_set_formatted(
+        &extension_group_info->app_uri, "%s",
+        ten_string_get_raw_str(&extension_info->loc.app_uri));
+    ten_string_set_formatted(
+        &extension_group_info->extension_group_name, "%s",
+        ten_string_get_raw_str(&extension_info->loc.extension_group_name));
 
     ten_shared_ptr_t *shared_group = ten_shared_ptr_create(
         extension_group_info, ten_extension_group_info_destroy);


### PR DESCRIPTION
- Replaced 'loc' structure with direct fields for app_uri, graph_id, and extension_group_name
in extension_group_info.
- Updated related functions and checks to use the new structure.
- Adjusted JSON serialization to reflect the new field structure.