### PR TITLE
refactor: remove extension group name from loc structure and related functions

### DIFF
--- a/core/include_internal/ten_runtime/common/loc.h
+++ b/core/include_internal/ten_runtime/common/loc.h
@@ -39,7 +39,6 @@ typedef struct ten_loc_t {
 
   ten_string_t app_uri;
   ten_string_t graph_id;
-  ten_string_t extension_group_name;
   ten_string_t extension_name;
 } ten_loc_t;
 
@@ -49,7 +48,6 @@ TEN_RUNTIME_PRIVATE_API ten_loc_t *ten_loc_create_empty(void);
 
 TEN_RUNTIME_API ten_loc_t *ten_loc_create(const char *app_uri,
                                           const char *graph_id,
-                                          const char *extension_group_name,
                                           const char *extension_name);
 
 TEN_RUNTIME_PRIVATE_API ten_loc_t *ten_loc_create_from_value(
@@ -65,7 +63,6 @@ TEN_RUNTIME_PRIVATE_API void ten_loc_init_empty(ten_loc_t *self);
 
 TEN_RUNTIME_PRIVATE_API void ten_loc_init(ten_loc_t *self, const char *app_uri,
                                           const char *graph_id,
-                                          const char *extension_group_name,
                                           const char *extension_name);
 
 TEN_RUNTIME_PRIVATE_API void ten_loc_init_from_loc(ten_loc_t *self,
@@ -78,7 +75,6 @@ TEN_RUNTIME_PRIVATE_API void ten_loc_deinit(ten_loc_t *self);
 
 TEN_RUNTIME_PRIVATE_API void ten_loc_set(ten_loc_t *self, const char *app_uri,
                                          const char *graph_id,
-                                         const char *extension_group_name,
                                          const char *extension_name);
 
 TEN_RUNTIME_PRIVATE_API void ten_loc_set_from_loc(ten_loc_t *self,
@@ -96,7 +92,7 @@ TEN_RUNTIME_PRIVATE_API bool ten_loc_is_equal(ten_loc_t *self,
 
 TEN_RUNTIME_PRIVATE_API bool ten_loc_is_equal_with_value(
     ten_loc_t *self, const char *app_uri, const char *graph_id,
-    const char *extension_group_name, const char *extension_name);
+    const char *extension_name);
 
 TEN_RUNTIME_PRIVATE_API void ten_loc_to_string(ten_loc_t *self,
                                                ten_string_t *result);

--- a/core/include_internal/ten_runtime/msg/msg.h
+++ b/core/include_internal/ten_runtime/msg/msg.h
@@ -85,9 +85,6 @@ TEN_RUNTIME_PRIVATE_API void ten_msg_set_src_to_engine(ten_shared_ptr_t *self,
 TEN_RUNTIME_PRIVATE_API void ten_msg_set_src_to_extension(
     ten_shared_ptr_t *self, ten_extension_t *extension);
 
-TEN_RUNTIME_PRIVATE_API void ten_msg_set_src_to_extension_group(
-    ten_shared_ptr_t *self, ten_extension_group_t *extension_group);
-
 TEN_RUNTIME_PRIVATE_API void ten_msg_clear_and_set_dest_from_msg_src(
     ten_shared_ptr_t *self, ten_shared_ptr_t *cmd);
 
@@ -117,7 +114,6 @@ TEN_RUNTIME_PRIVATE_API ten_loc_t *ten_raw_msg_get_first_dest_loc(
 TEN_RUNTIME_PRIVATE_API void ten_msg_set_src(ten_shared_ptr_t *self,
                                              const char *app_uri,
                                              const char *graph_id,
-                                             const char *extension_group_name,
                                              const char *extension_name);
 
 TEN_RUNTIME_PRIVATE_API void ten_msg_set_src_uri(ten_shared_ptr_t *self,

--- a/core/src/ten_runtime/common/loc.c
+++ b/core/src/ten_runtime/common/loc.c
@@ -38,11 +38,10 @@ ten_loc_t *ten_loc_create_empty(void) {
 }
 
 ten_loc_t *ten_loc_create(const char *app_uri, const char *graph_id,
-                          const char *extension_group_name,
                           const char *extension_name) {
   ten_loc_t *self = ten_loc_create_empty();
 
-  ten_loc_set(self, app_uri, graph_id, extension_group_name, extension_name);
+  ten_loc_set(self, app_uri, graph_id, extension_name);
   TEN_ASSERT(ten_loc_check_integrity(self), "Should not happen.");
 
   return self;
@@ -66,7 +65,6 @@ ten_loc_t *ten_loc_clone(ten_loc_t *src) {
   ten_loc_t *self =
       ten_loc_create(ten_string_get_raw_str(&src->app_uri),
                      ten_string_get_raw_str(&src->graph_id),
-                     ten_string_get_raw_str(&src->extension_group_name),
                      ten_string_get_raw_str(&src->extension_name));
 
   TEN_ASSERT(ten_loc_check_integrity(self), "Should not happen.");
@@ -95,7 +93,6 @@ void ten_loc_init_empty(ten_loc_t *self) {
 
   TEN_STRING_INIT(self->app_uri);
   TEN_STRING_INIT(self->graph_id);
-  TEN_STRING_INIT(self->extension_group_name);
   TEN_STRING_INIT(self->extension_name);
 }
 
@@ -106,7 +103,6 @@ void ten_loc_init_from_loc(ten_loc_t *self, ten_loc_t *src) {
 
   ten_loc_init(self, ten_string_get_raw_str(&src->app_uri),
                ten_string_get_raw_str(&src->graph_id),
-               ten_string_get_raw_str(&src->extension_group_name),
                ten_string_get_raw_str(&src->extension_name));
 
   TEN_ASSERT(ten_loc_check_integrity(self), "Should not happen.");
@@ -118,7 +114,6 @@ void ten_loc_set_from_loc(ten_loc_t *self, ten_loc_t *src) {
 
   ten_loc_set(self, ten_string_get_raw_str(&src->app_uri),
               ten_string_get_raw_str(&src->graph_id),
-              ten_string_get_raw_str(&src->extension_group_name),
               ten_string_get_raw_str(&src->extension_name));
 }
 
@@ -129,19 +124,15 @@ void ten_loc_deinit(ten_loc_t *self) {
 
   ten_string_deinit(&self->app_uri);
   ten_string_deinit(&self->graph_id);
-  ten_string_deinit(&self->extension_group_name);
   ten_string_deinit(&self->extension_name);
 }
 
 void ten_loc_init(ten_loc_t *self, const char *app_uri, const char *graph_id,
-                  const char *extension_group_name,
                   const char *extension_name) {
   TEN_ASSERT(self, "Should not happen.");
 
   ten_string_init_formatted(&self->app_uri, "%s", app_uri ? app_uri : "");
   ten_string_init_formatted(&self->graph_id, "%s", graph_id ? graph_id : "");
-  ten_string_init_formatted(&self->extension_group_name, "%s",
-                            extension_group_name ? extension_group_name : "");
   ten_string_init_formatted(&self->extension_name, "%s",
                             extension_name ? extension_name : "");
 
@@ -149,13 +140,11 @@ void ten_loc_init(ten_loc_t *self, const char *app_uri, const char *graph_id,
 }
 
 void ten_loc_set(ten_loc_t *self, const char *app_uri, const char *graph_id,
-                 const char *extension_group_name, const char *extension_name) {
+                 const char *extension_name) {
   TEN_ASSERT(self, "Should not happen.");
 
   ten_string_set_formatted(&self->app_uri, "%s", app_uri ? app_uri : "");
   ten_string_set_formatted(&self->graph_id, "%s", graph_id ? graph_id : "");
-  ten_string_set_formatted(&self->extension_group_name, "%s",
-                           extension_group_name ? extension_group_name : "");
   ten_string_set_formatted(&self->extension_name, "%s",
                            extension_name ? extension_name : "");
 
@@ -167,7 +156,6 @@ bool ten_loc_is_empty(ten_loc_t *self) {
 
   if (ten_string_is_empty(&self->app_uri) &&
       ten_string_is_empty(&self->graph_id) &&
-      ten_string_is_empty(&self->extension_group_name) &&
       ten_string_is_empty(&self->extension_name)) {
     return true;
   }
@@ -179,7 +167,6 @@ void ten_loc_clear(ten_loc_t *self) {
 
   ten_string_clear(&self->app_uri);
   ten_string_clear(&self->graph_id);
-  ten_string_clear(&self->extension_group_name);
   ten_string_clear(&self->extension_name);
 }
 
@@ -193,10 +180,8 @@ bool ten_loc_is_equal(ten_loc_t *self, ten_loc_t *other) {
 
 bool ten_loc_is_equal_with_value(ten_loc_t *self, const char *app_uri,
                                  const char *graph_id,
-                                 const char *extension_group_name,
                                  const char *extension_name) {
-  TEN_ASSERT(self && app_uri && extension_group_name && extension_name,
-             "Should not happen.");
+  TEN_ASSERT(self && app_uri && extension_name, "Should not happen.");
 
   return ten_string_is_equal_c_str(&self->app_uri, app_uri) &&
          ten_string_is_equal_c_str(&self->graph_id, graph_id) &&
@@ -225,11 +210,9 @@ void ten_loc_to_string(ten_loc_t *self, ten_string_t *result) {
              "Invalid parameters or corrupted location structure.");
   TEN_ASSERT(result, "Invalid parameters or corrupted location structure.");
 
-  ten_string_set_formatted(result,
-                           "app: %s, graph: %s, group: %s, extension: %s",
+  ten_string_set_formatted(result, "app: %s, graph: %s, extension: %s",
                            ten_string_get_raw_str(&self->app_uri),
                            ten_string_get_raw_str(&self->graph_id),
-                           ten_string_get_raw_str(&self->extension_group_name),
                            ten_string_get_raw_str(&self->extension_name));
 }
 
@@ -255,15 +238,6 @@ static bool ten_loc_set_value(ten_loc_t *self, ten_value_t *value) {
         ten_value_kv_create(
             TEN_STR_GRAPH,
             ten_value_create_string(ten_string_get_raw_str(&self->graph_id))),
-        (ten_ptr_listnode_destroy_func_t)ten_value_kv_destroy);
-  }
-
-  if (!ten_string_is_empty(&self->extension_group_name)) {
-    ten_list_push_ptr_back(
-        &loc_fields,
-        ten_value_kv_create(TEN_STR_EXTENSION_GROUP,
-                            ten_value_create_string(ten_string_get_raw_str(
-                                &self->extension_group_name))),
         (ten_ptr_listnode_destroy_func_t)ten_value_kv_destroy);
   }
 
@@ -301,8 +275,6 @@ void ten_loc_set_from_value(ten_loc_t *self, ten_value_t *value) {
 
   ten_value_t *app_value = ten_value_object_peek(value, TEN_STR_APP);
   ten_value_t *graph_value = ten_value_object_peek(value, TEN_STR_GRAPH);
-  ten_value_t *extension_group_value =
-      ten_value_object_peek(value, TEN_STR_EXTENSION_GROUP);
   ten_value_t *extension_value =
       ten_value_object_peek(value, TEN_STR_EXTENSION);
 
@@ -321,17 +293,6 @@ void ten_loc_set_from_value(ten_loc_t *self, ten_value_t *value) {
     const char *graph_str = ten_value_peek_raw_str(graph_value, NULL);
     if (graph_str && strlen(graph_str) > 0) {
       ten_string_set_from_c_str(&self->graph_id, graph_str);
-    }
-  }
-
-  if (extension_group_value) {
-    TEN_ASSERT(ten_value_is_string(extension_group_value),
-               "Should not happen.");
-
-    const char *group_name_str =
-        ten_value_peek_raw_str(extension_group_value, NULL);
-    if (group_name_str && strlen(group_name_str) > 0) {
-      ten_string_set_from_c_str(&self->extension_group_name, group_name_str);
     }
   }
 

--- a/core/src/ten_runtime/extension/extension_info/extension_info.c
+++ b/core/src/ten_runtime/extension/extension_info/extension_info.c
@@ -199,7 +199,7 @@ ten_shared_ptr_t *get_extension_info_in_extensions_info(
   ten_string_set_formatted(&self->extension_group_name, "%s",
                            extension_group_name);
 
-  ten_loc_set(&self->loc, app_uri, graph_id, NULL, extension_instance_name);
+  ten_loc_set(&self->loc, app_uri, graph_id, extension_instance_name);
 
   ten_shared_ptr_t *shared_self =
       ten_shared_ptr_create(self, ten_extension_info_destroy);

--- a/core/src/ten_runtime/extension_group/extension_group_info/extension_group_info.c
+++ b/core/src/ten_runtime/extension_group/extension_group_info/extension_group_info.c
@@ -173,7 +173,7 @@ ten_shared_ptr_t *get_extension_group_info_in_extension_groups_info(
   ten_string_set_formatted(&self->extension_group_instance_name, "%s",
                            extension_group_instance_name);
 
-  ten_loc_set(&self->loc, app_uri, graph_id, NULL, NULL);
+  ten_loc_set(&self->loc, app_uri, graph_id, NULL);
 
   // Add the extension group addon name if we know it now.
   if (strlen(extension_group_addon_name)) {

--- a/core/src/ten_runtime/msg/cmd_base/cmd/start_graph/cmd.c
+++ b/core/src/ten_runtime/msg/cmd_base/cmd/start_graph/cmd.c
@@ -392,7 +392,7 @@ static void ten_raw_cmd_start_graph_add_missing_extension_group_node(
 
     ten_loc_set(&extension_group_info->loc,
                 ten_string_get_raw_str(&extension_info->loc.app_uri), NULL,
-                NULL, NULL);
+                NULL);
 
     ten_shared_ptr_t *shared_group = ten_shared_ptr_create(
         extension_group_info, ten_extension_group_info_destroy);

--- a/core/src/ten_runtime/msg/msg.c
+++ b/core/src/ten_runtime/msg/msg.c
@@ -115,7 +115,7 @@ static bool ten_raw_msg_clear_and_set_dest(ten_msg_t *self, const char *uri,
 
   ten_list_clear(&self->dest_loc);
   ten_list_push_ptr_back(&self->dest_loc,
-                         ten_loc_create(uri, graph_id, "", extension_name),
+                         ten_loc_create(uri, graph_id, extension_name),
                          (ten_ptr_listnode_destroy_func_t)ten_loc_destroy);
 
   return true;
@@ -127,7 +127,7 @@ void ten_raw_msg_add_dest(ten_msg_t *self, const char *uri,
   TEN_ASSERT(ten_raw_msg_check_integrity(self), "Should not happen.");
 
   ten_list_push_ptr_back(&self->dest_loc,
-                         ten_loc_create(uri, graph_id, "", extension_name),
+                         ten_loc_create(uri, graph_id, extension_name),
                          (ten_ptr_listnode_destroy_func_t)ten_loc_destroy);
 }
 
@@ -227,21 +227,17 @@ const char *ten_msg_get_first_dest_uri(ten_shared_ptr_t *self) {
 
 static void ten_raw_msg_set_src(ten_msg_t *self, const char *uri,
                                 const char *graph_id,
-                                const char *extension_group_name,
                                 const char *extension_name) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_raw_msg_check_integrity(self), "Should not happen.");
-  ten_loc_set(&self->src_loc, uri, graph_id, extension_group_name,
-              extension_name);
+  ten_loc_set(&self->src_loc, uri, graph_id, extension_name);
 }
 
 void ten_msg_set_src(ten_shared_ptr_t *self, const char *uri,
-                     const char *graph_id, const char *extension_group_name,
-                     const char *extension_name) {
+                     const char *graph_id, const char *extension_name) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
-  ten_raw_msg_set_src(ten_msg_get_raw_msg(self), uri, graph_id,
-                      extension_group_name, extension_name);
+  ten_raw_msg_set_src(ten_msg_get_raw_msg(self), uri, graph_id, extension_name);
 }
 
 void ten_msg_set_src_to_app(ten_shared_ptr_t *self, ten_app_t *app) {
@@ -250,7 +246,7 @@ void ten_msg_set_src_to_app(ten_shared_ptr_t *self, ten_app_t *app) {
   TEN_ASSERT(app, "Should not happen.");
   TEN_ASSERT(ten_app_check_integrity(app, false), "Should not happen.");
 
-  ten_msg_set_src(self, ten_app_get_uri(app), NULL, NULL, NULL);
+  ten_msg_set_src(self, ten_app_get_uri(app), NULL, NULL);
 }
 
 void ten_msg_set_src_to_engine(ten_shared_ptr_t *self, ten_engine_t *engine) {
@@ -260,7 +256,7 @@ void ten_msg_set_src_to_engine(ten_shared_ptr_t *self, ten_engine_t *engine) {
   TEN_ASSERT(ten_engine_check_integrity(engine, false), "Should not happen.");
 
   ten_msg_set_src(self, ten_app_get_uri(engine->app),
-                  ten_engine_get_id(engine, true), NULL, NULL);
+                  ten_engine_get_id(engine, true), NULL);
 }
 
 void ten_msg_set_src_to_extension(ten_shared_ptr_t *self,
@@ -291,26 +287,7 @@ void ten_msg_set_src_to_extension(ten_shared_ptr_t *self,
 
   ten_msg_set_src(self, ten_app_get_uri(engine->app),
                   ten_engine_get_id(engine, false),
-                  ten_extension_group_get_name(extension_group, true),
                   ten_extension_get_name(extension, true));
-}
-
-void ten_msg_set_src_to_extension_group(
-    ten_shared_ptr_t *self, ten_extension_group_t *extension_group) {
-  TEN_ASSERT(self, "Should not happen.");
-  TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
-  TEN_ASSERT(extension_group, "Should not happen.");
-  TEN_ASSERT(ten_extension_group_check_integrity(extension_group, true),
-             "Should not happen.");
-
-  ten_engine_t *engine =
-      extension_group->extension_thread->extension_context->engine;
-  TEN_ASSERT(engine, "Should not happen.");
-  TEN_ASSERT(ten_engine_check_integrity(engine, false), "Should not happen.");
-
-  ten_msg_set_src(self, ten_app_get_uri(engine->app),
-                  ten_engine_get_id(engine, false),
-                  ten_extension_group_get_name(extension_group, true), NULL);
 }
 
 bool ten_msg_src_uri_is_empty(ten_shared_ptr_t *self) {

--- a/core/src/ten_runtime/test/extension_tester.c
+++ b/core/src/ten_runtime/test/extension_tester.c
@@ -30,8 +30,6 @@
 #include "ten_runtime/ten_env/internal/metadata.h"
 #include "ten_runtime/ten_env/internal/on_xxx_done.h"
 #include "ten_runtime/ten_env_proxy/ten_env_proxy.h"
-#include "ten_utils/container/list.h"
-#include "ten_utils/container/list_str.h"
 #include "ten_utils/io/runloop.h"
 #include "ten_utils/lib/error.h"
 #include "ten_utils/lib/event.h"
@@ -281,7 +279,7 @@ static void test_app_ten_env_send_start_graph_cmd(ten_env_t *ten_env,
   // `cmd_result` of the `start_graph` command can ultimately be returned to
   // this `app` and processed by the `out path`, enabling the invocation of the
   // result handler specified below.
-  ten_msg_set_src(cmd, ten_app_get_uri(app), NULL, NULL, NULL);
+  ten_msg_set_src(cmd, ten_app_get_uri(app), NULL, NULL);
 
   bool rc =
       ten_msg_clear_and_set_dest(cmd, ten_app_get_uri(app), NULL, NULL, NULL);

--- a/tests/ten_runtime/smoke/start_graph/start_graph_with_msg_conversion.cc
+++ b/tests/ten_runtime/smoke/start_graph/start_graph_with_msg_conversion.cc
@@ -17,9 +17,9 @@ class test_normal_extension_1 : public ten::extension_t {
 
   void on_start(ten::ten_env_t &ten_env) override {
     ten_env.send_cmd(ten::cmd_t::create("A"),
-                     [this](ten::ten_env_t &ten_env,
-                            std::unique_ptr<ten::cmd_result_t> cmd_result,
-                            ten::error_t *err) { ten_env.on_start_done(); });
+                     [](ten::ten_env_t &ten_env,
+                        std::unique_ptr<ten::cmd_result_t> cmd_result,
+                        ten::error_t *err) { ten_env.on_start_done(); });
   }
 };
 


### PR DESCRIPTION
This change simplifies the ten_loc_t structure by removing the extension_group_name field
and updating all related functions and calls accordingly.
The extension group name is no longer required in the context
of location handling, streamlining the codebase.