### PR TITLE
feat(designer fe): persistent storage with schema

### DIFF
--- a/core/src/ten_manager/designer_frontend/src/api/endpoints/storage.ts
+++ b/core/src/ten_manager/designer_frontend/src/api/endpoints/storage.ts
@@ -90,11 +90,29 @@ export const ENDPOINT_STORAGE = {
       method: ENDPOINT_METHOD.POST,
       requestSchema: z.object({
         key: z.string(),
-        value: z.any(),
+        value: z.unknown(),
       }),
       responseSchema: genResSchema<{ success: boolean }>(
         z.object({
           success: z.boolean(),
+        })
+      ),
+    },
+  },
+  persistentSchema: {
+    [ENDPOINT_METHOD.POST]: {
+      url: `${API_DESIGNER_V1}/storage/persistent/schema`,
+      method: ENDPOINT_METHOD.POST,
+      requestSchema: z.object({
+        schema: z.any(), // Schema can be any valid JSON schema
+      }),
+      responseSchema: genResSchema<{
+        success: boolean;
+        cleaned_fields?: string[];
+      }>(
+        z.object({
+          success: z.boolean(),
+          cleaned_fields: z.array(z.string()).optional(),
         })
       ),
     },

--- a/core/src/ten_manager/designer_frontend/src/api/services/storage.ts
+++ b/core/src/ten_manager/designer_frontend/src/api/services/storage.ts
@@ -4,15 +4,18 @@
 // Licensed under the Apache License, Version 2.0, with certain conditions.
 // Refer to the "LICENSE" file in the root directory for more information.
 //
+import * as React from "react";
 import z from "zod";
 
 import {
   makeAPIRequest,
   useCancelableSWR,
   prepareReqUrl,
+  getQueryHookCache,
 } from "@/api/services/utils";
 import { ENDPOINT_PREFERENCES, ENDPOINT_STORAGE } from "@/api/endpoints";
 import { ENDPOINT_METHOD } from "@/api/endpoints/constant";
+import { PERSISTENT_SCHEMA, PERSISTENT_DEFAULTS } from "@/constants/persistent";
 
 export const usePreferencesLogViewerLines = () => {
   const template =
@@ -42,11 +45,12 @@ export const updatePreferencesLogViewerLines = async (size: number) => {
 };
 
 export const getStorageValueByKey = async (
-  key: string,
+  queryKey?: string,
   options?: {
     storageType?: "in-memory" | "persistent";
   }
 ) => {
+  const key = queryKey || "properties"; // Default key if not provided
   const template =
     options?.storageType === "persistent"
       ? ENDPOINT_STORAGE.persistentGet[ENDPOINT_METHOD.POST]
@@ -59,12 +63,14 @@ export const getStorageValueByKey = async (
 };
 
 export const setStorageValueByKey = async (
-  key: string,
-  value: unknown,
+  setKey?: string,
+  setVal?: unknown,
   options?: {
     storageType?: "in-memory" | "persistent";
   }
 ) => {
+  const key = setKey || "properties"; // Default key if not provided
+  const value = setVal || PERSISTENT_DEFAULTS; // Default value if not provided
   const template =
     options?.storageType === "persistent"
       ? ENDPOINT_STORAGE.persistentSet[ENDPOINT_METHOD.POST]
@@ -74,4 +80,70 @@ export const setStorageValueByKey = async (
   });
   const res = await req;
   return template.responseSchema.parse(res).data.success;
+};
+
+export const setPersistentStorageSchema = async (
+  schema: z.infer<z.ZodTypeAny>
+) => {
+  const template = ENDPOINT_STORAGE.persistentSchema[ENDPOINT_METHOD.POST];
+  const req = makeAPIRequest(template, {
+    body: { schema },
+  });
+  const res = await req;
+  return template.responseSchema.parse(res).data;
+};
+
+export const initPersistentStorageSchema = async () => {
+  const res = await setPersistentStorageSchema(PERSISTENT_SCHEMA);
+  return res;
+};
+
+export const useStorage = <T>(type?: "in-memory" | "persistent") => {
+  const template =
+    type === "persistent"
+      ? ENDPOINT_STORAGE.persistentGet[ENDPOINT_METHOD.POST]
+      : ENDPOINT_STORAGE.inMemoryGet[ENDPOINT_METHOD.POST];
+  const url = prepareReqUrl(template) + type;
+  const queryHookCache = getQueryHookCache();
+
+  const [data, setData] = React.useState<T | null>(() => {
+    const [cachedData, cachedDataIsExpired] = queryHookCache.get<T>(url);
+    if (!cachedData || cachedDataIsExpired) {
+      return null;
+    }
+    return cachedData;
+  });
+  const [error, setError] = React.useState<Error | null>(null);
+  const [isLoading, setIsLoading] = React.useState<boolean>(false);
+
+  const fetchData = React.useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const req = makeAPIRequest(template, {
+        body: {
+          key: "properties",
+        },
+      });
+      const res = await req;
+      const parsedData = template.responseSchema.parse(res).data as T;
+      setData(parsedData);
+      queryHookCache.set(url, parsedData);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url]);
+
+  React.useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    data,
+    error,
+    isLoading,
+    mutate: fetchData,
+  };
 };

--- a/core/src/ten_manager/designer_frontend/src/constants/persistent.ts
+++ b/core/src/ten_manager/designer_frontend/src/constants/persistent.ts
@@ -1,0 +1,26 @@
+//
+// Copyright © 2025 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+
+// Refer to https://json-schema.org/learn/getting-started-step-by-step
+export const PERSISTENT_SCHEMA = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "https://example.com/persistent.schema.json",
+  title: "Persistent Schema",
+  description: "A schema for persistent storage",
+  type: "object",
+  properties: {
+    version: {
+      type: "string",
+      description: "Schema version",
+    },
+  },
+  required: ["version"],
+};
+
+export const PERSISTENT_DEFAULTS = {
+  version: "0.0.1",
+};


### PR DESCRIPTION
- Support the `persistent/schema` API.
- Create `core/src/ten_manager/designer_frontend/src/constants/persistent.ts` to store the JSON schema and default values.
- Initialize the remote persistent schema:
  - Query `properties` on the first visit.
  - Reset the schema if `properties.version` does not match `version` in `core/src/ten_manager/designer_frontend/src/constants/persistent.ts`.