### PR TITLE
refactor: streamline subgraph flattening logic and remove deprecated colon notation handling

### DIFF
--- a/core/src/ten_rust/tests/test_case/graph/subgraph.rs
+++ b/core/src/ten_rust/tests/test_case/graph/subgraph.rs
@@ -54,7 +54,7 @@ mod tests {
                     dest: vec![connection::GraphDestination {
                         loc: connection::GraphLoc {
                             app: None,
-                            extension: Some("subgraph_1:ext_d".to_string()),
+                            extension: Some("subgraph_1_ext_d".to_string()),
                             subgraph: None,
                         },
                         msg_conversion: None,
@@ -161,7 +161,7 @@ mod tests {
         let connections = flattened.connections.as_ref().unwrap();
         assert_eq!(connections.len(), 2); // Original + internal subgraph connection
 
-        // Check that colon notation is converted to underscore
+        // Check that the connection destination is correct
         let main_connection = connections
             .iter()
             .find(|conn| conn.loc.extension.as_deref() == Some("ext_a"))


### PR DESCRIPTION
- Removed the `handle_colon_notation` function and its usage in the flattening process.
- Introduced new helper functions to update `exposed_messages` and
 `exposed_properties` after flattening.
- Consolidated flattening logic into `flatten_graph_core` for better maintainability and clarity.
- Updated tests to reflect changes in extension naming conventions.