### PR TITLE
fix(designer fe): logviewer backstage widget

### DIFF
--- a/core/src/ten_manager/designer_frontend/bun.lock
+++ b/core/src/ten_manager/designer_frontend/bun.lock
@@ -40,7 +40,7 @@
         "i18next": "^24.2.3",
         "i18next-browser-languagedetector": "^8.1.0",
         "i18next-http-backend": "^3.0.2",
-        "lucide-react": "^0.473.0",
+        "lucide-react": "^0.511.0",
         "monaco-editor": "^0.52.2",
         "motion": "^12.10.0",
         "next-themes": "^0.4.6",
@@ -789,7 +789,7 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
-    "lucide-react": ["lucide-react@0.473.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-KW6u5AKeIjkvrxXZ6WuCu9zHE/gEYSXCay+Gre2ZoInD0Je/e3RBtP4OHpJVJ40nDklSvjVKjgH7VU8/e2dzRw=="],
+    "lucide-react": ["lucide-react@0.511.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 

--- a/core/src/ten_manager/designer_frontend/package.json
+++ b/core/src/ten_manager/designer_frontend/package.json
@@ -47,7 +47,7 @@
     "i18next": "^24.2.3",
     "i18next-browser-languagedetector": "^8.1.0",
     "i18next-http-backend": "^3.0.2",
-    "lucide-react": "^0.473.0",
+    "lucide-react": "^0.511.0",
     "monaco-editor": "^0.52.2",
     "motion": "^12.10.0",
     "next-themes": "^0.4.6",

--- a/core/src/ten_manager/designer_frontend/public/locales/en-US/common.json
+++ b/core/src/ten_manager/designer_frontend/public/locales/en-US/common.json
@@ -148,7 +148,8 @@
       "filteredByAddon": "Filter logs by Addon",
       "noAddons": "No Avaliable Addons",
       "noMatchedAddons": "No matched addons",
-      "noLogs": "No logs to display."
+      "noLogs": "No logs to display.",
+      "cleanLogs": "Clean Logs"
     },
     "default": {
       "defaultLabelForAppRun": "Default label for app run",

--- a/core/src/ten_manager/designer_frontend/public/locales/en-US/common.json
+++ b/core/src/ten_manager/designer_frontend/public/locales/en-US/common.json
@@ -146,7 +146,7 @@
       "title": "Log Viewer",
       "appInstall": "App Install",
       "filteredByAddon": "Filter logs by Addon",
-      "noAddons": "No Avaliable Addons",
+      "noAddons": "No Available Addons",
       "noMatchedAddons": "No matched addons",
       "noLogs": "No logs to display.",
       "cleanLogs": "Clean Logs"

--- a/core/src/ten_manager/designer_frontend/public/locales/ja-JP/common.json
+++ b/core/src/ten_manager/designer_frontend/public/locales/ja-JP/common.json
@@ -148,7 +148,8 @@
       "filteredByAddon": "アドオンでログをフィルター",
       "noAddons": "利用可能なアドオンがありません",
       "noMatchedAddons": "一致するアドオンがありません",
-      "noLogs": "表示するログがありません"
+      "noLogs": "表示するログがありません",
+      "cleanLogs": "ログをクリア"
     },
     "default": {
       "defaultLabelForAppRun": "アプリ実行のデフォルトラベル",

--- a/core/src/ten_manager/designer_frontend/public/locales/zh-CN/common.json
+++ b/core/src/ten_manager/designer_frontend/public/locales/zh-CN/common.json
@@ -148,7 +148,8 @@
       "filteredByAddon": "按插件筛选日志",
       "noAddons": "无可用插件",
       "noMatchedAddons": "无匹配插件",
-      "noLogs": "暂无日志"
+      "noLogs": "暂无日志",
+      "cleanLogs": "清除日志"
     },
     "default": {
       "defaultLabelForAppRun": "默认应用运行标签",

--- a/core/src/ten_manager/designer_frontend/public/locales/zh-TW/common.json
+++ b/core/src/ten_manager/designer_frontend/public/locales/zh-TW/common.json
@@ -148,7 +148,8 @@
       "filteredByAddon": "依附加元件篩選日誌",
       "noAddons": "無可用附加元件",
       "noMatchedAddons": "無符合的附加元件",
-      "noLogs": "無日誌顯示"
+      "noLogs": "無日誌顯示",
+      "cleanLogs": "清空日誌"
     },
     "default": {
       "defaultLabelForAppRun": "預設應用程式運行標籤",

--- a/core/src/ten_manager/designer_frontend/src/components/Popup/Default/App.tsx
+++ b/core/src/ten_manager/designer_frontend/src/components/Popup/Default/App.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
-import { PlayIcon } from "lucide-react";
+import { PlayIcon, BrushCleaningIcon } from "lucide-react";
 
 import {
   Select,
@@ -138,10 +138,12 @@ export const AppRunPopupContent = (props: { widget: IDefaultWidget }) => {
   const handleRun = () => {
     removeWidget(widget.widget_id);
 
+    const newAppStartWidgetId = "app-start-" + Date.now();
+
     appendWidget({
       container_id: CONTAINER_DEFAULT_ID,
       group_id: GROUP_LOG_VIEWER_ID,
-      widget_id: "app-start-" + Date.now(),
+      widget_id: newAppStartWidgetId,
 
       category: EWidgetCategory.LogViewer,
       display_type: EWidgetDisplayType.Popup,
@@ -164,20 +166,18 @@ export const AppRunPopupContent = (props: { widget: IDefaultWidget }) => {
       },
       actions: {
         onClose: () => {
-          removeBackstageWidget(widget.widget_id);
-          removeLogViewerHistory(widget.widget_id);
+          removeBackstageWidget(newAppStartWidgetId);
         },
-        // custom_actions: [
-        //   {
-        //     id: "app-start-widget-closed",
-        //     label: "app-start-widget-closed",
-        //     Icon: OctagonXIcon,
-        //     onClick: () => {
-        //       console.log("app-start-widget-closed");
-        //       console.log(baseDir, selectedScript);
-        //     },
-        //   },
-        // ],
+        custom_actions: [
+          {
+            id: "app-start-log-clean",
+            label: t("popup.logViewer.cleanLogs"),
+            Icon: BrushCleaningIcon,
+            onClick: () => {
+              removeLogViewerHistory(newAppStartWidgetId);
+            },
+          },
+        ],
       },
     });
   };

--- a/core/src/ten_manager/designer_frontend/src/components/Widget/AppsWidget.tsx
+++ b/core/src/ten_manager/designer_frontend/src/components/Widget/AppsWidget.tsx
@@ -15,6 +15,7 @@ import {
   HardDriveDownloadIcon,
   PlayIcon,
   FolderIcon,
+  BrushCleaningIcon,
 } from "lucide-react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -266,8 +267,17 @@ export const AppsManagerWidget = (props: { className?: string }) => {
       actions: {
         onClose: () => {
           removeBackstageWidget(widgetId);
-          removeLogViewerHistory(widgetId);
         },
+        custom_actions: [
+          {
+            id: "app-start-log-clean",
+            label: t("popup.logViewer.cleanLogs"),
+            Icon: BrushCleaningIcon,
+            onClick: () => {
+              removeLogViewerHistory(widgetId);
+            },
+          },
+        ],
       },
     });
   };

--- a/core/src/ten_manager/designer_frontend/src/components/Widget/ExtensionWidget/ExtensionDetails.tsx
+++ b/core/src/ten_manager/designer_frontend/src/components/Widget/ExtensionWidget/ExtensionDetails.tsx
@@ -5,7 +5,12 @@
 // Refer to the "LICENSE" file in the root directory for more information.
 //
 import * as React from "react";
-import { BlocksIcon, HardDriveDownloadIcon, CheckIcon } from "lucide-react";
+import {
+  BlocksIcon,
+  HardDriveDownloadIcon,
+  CheckIcon,
+  BrushCleaningIcon,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/Button";
@@ -230,8 +235,17 @@ export const ExtensionDetails = (props: {
       actions: {
         onClose: () => {
           removeBackstageWidget(widgetId);
-          removeLogViewerHistory(widgetId);
         },
+        custom_actions: [
+          {
+            id: "app-start-log-clean",
+            label: t("popup.logViewer.cleanLogs"),
+            Icon: BrushCleaningIcon,
+            onClick: () => {
+              removeLogViewerHistory(widgetId);
+            },
+          },
+        ],
       },
     });
   };

--- a/core/src/ten_manager/designer_frontend/src/components/Widget/ExtensionWidget/ExtensionList.tsx
+++ b/core/src/ten_manager/designer_frontend/src/components/Widget/ExtensionWidget/ExtensionList.tsx
@@ -5,7 +5,7 @@
 // Refer to the "LICENSE" file in the root directory for more information.
 //
 import * as React from "react";
-import { BlocksIcon, CheckIcon } from "lucide-react";
+import { BlocksIcon, CheckIcon, BrushCleaningIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { FixedSizeList as VirtualList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -179,8 +179,17 @@ export const ExtensionBaseItem = React.forwardRef<
         actions: {
           onClose: () => {
             removeBackstageWidget(widgetId);
-            removeLogViewerHistory(widgetId);
           },
+          custom_actions: [
+            {
+              id: "app-start-log-clean",
+              label: t("popup.logViewer.cleanLogs"),
+              Icon: BrushCleaningIcon,
+              onClick: () => {
+                removeLogViewerHistory(widgetId);
+              },
+            },
+          ],
         },
       });
     };

--- a/core/src/ten_manager/designer_frontend/src/flow/FlowCanvas.tsx
+++ b/core/src/ten_manager/designer_frontend/src/flow/FlowCanvas.tsx
@@ -21,6 +21,7 @@ import {
   type EdgeChange,
 } from "@xyflow/react";
 import { useTranslation } from "react-i18next";
+import { BrushCleaningIcon } from "lucide-react";
 
 import CustomNode from "@/flow/CustomNode";
 import CustomEdge from "@/flow/CustomEdge";
@@ -165,8 +166,17 @@ const FlowCanvas = forwardRef<FlowCanvasRef, FlowCanvasProps>(
         actions: {
           onClose: () => {
             removeBackstageWidget(widgetId);
-            removeLogViewerHistory(widgetId);
           },
+          custom_actions: [
+            {
+              id: "app-start-log-clean",
+              label: t("popup.logViewer.cleanLogs"),
+              Icon: BrushCleaningIcon,
+              onClick: () => {
+                removeLogViewerHistory(widgetId);
+              },
+            },
+          ],
         },
       });
     };


### PR DESCRIPTION
resolves #892 

- update `lucide-react` (more icons)
- remove corresponding frontstage&backstage widgets by widgetId (close ws connection)
- after closing widgets, logs would not be automatically cleaned (move to `clean logs` button)
- add `clean logs` action