### PR TITLE
feat: enforce mutual exclusion between source_uri and graph fields in…

### DIFF
--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -518,6 +518,7 @@ jobs:
           MALLOC_CHECK_: 3
           TEN_ENABLE_MEMORY_TRACKING: "true"
           TEN_ENABLE_BACKTRACE_DUMP: "true"
+          GODEBUG: asyncpreemptoff=1
         run: |
           curl -fsSL https://ollama.com/install.sh | sh
 

--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -518,7 +518,7 @@ jobs:
           MALLOC_CHECK_: 3
           TEN_ENABLE_MEMORY_TRACKING: "true"
           TEN_ENABLE_BACKTRACE_DUMP: "true"
-          GODEBUG: asyncpreemptoff=1
+          GOTRACEBACK: crash
         run: |
           curl -fsSL https://ollama.com/install.sh | sh
 

--- a/.github/workflows/mac_arm64.yml
+++ b/.github/workflows/mac_arm64.yml
@@ -395,6 +395,7 @@ jobs:
           MALLOC_CHECK_: 3
           TEN_ENABLE_MEMORY_TRACKING: "true"
           TEN_ENABLE_BACKTRACE_DUMP: "true"
+          GODEBUG: asyncpreemptoff=1
         run: |
           if [ ${{ matrix.build_type }} == "debug" ]; then
             export PATH="/opt/homebrew/opt/llvm/bin:$PATH"

--- a/.github/workflows/mac_arm64.yml
+++ b/.github/workflows/mac_arm64.yml
@@ -395,7 +395,7 @@ jobs:
           MALLOC_CHECK_: 3
           TEN_ENABLE_MEMORY_TRACKING: "true"
           TEN_ENABLE_BACKTRACE_DUMP: "true"
-          GODEBUG: asyncpreemptoff=1
+          GOTRACEBACK: crash
         run: |
           if [ ${{ matrix.build_type }} == "debug" ]; then
             export PATH="/opt/homebrew/opt/llvm/bin:$PATH"

--- a/.github/workflows/mac_x64.yml
+++ b/.github/workflows/mac_x64.yml
@@ -386,6 +386,7 @@ jobs:
           MALLOC_CHECK_: 3
           TEN_ENABLE_MEMORY_TRACKING: "true"
           TEN_ENABLE_BACKTRACE_DUMP: "true"
+          GODEBUG: asyncpreemptoff=1
         run: |
           if [ ${{ matrix.build_type }} == "debug" ]; then
             export PATH="/usr/local/opt/llvm/bin:$PATH"

--- a/.github/workflows/mac_x64.yml
+++ b/.github/workflows/mac_x64.yml
@@ -386,7 +386,7 @@ jobs:
           MALLOC_CHECK_: 3
           TEN_ENABLE_MEMORY_TRACKING: "true"
           TEN_ENABLE_BACKTRACE_DUMP: "true"
-          GODEBUG: asyncpreemptoff=1
+          GOTRACEBACK: crash
         run: |
           if [ ${{ matrix.build_type }} == "debug" ]; then
             export PATH="/usr/local/opt/llvm/bin:$PATH"

--- a/core/src/ten_rust/src/graph/graph_info.rs
+++ b/core/src/ten_rust/src/graph/graph_info.rs
@@ -38,6 +38,45 @@ pub struct GraphInfo {
 
 impl GraphInfo {
     pub fn validate_and_complete(&mut self) -> Result<()> {
+        // Validate mutual exclusion between source_uri and graph fields
+        if self.source_uri.is_some() {
+            // When source_uri is present, the graph fields should be empty or
+            // None
+            if !self.graph.nodes.is_empty() {
+                return Err(anyhow!(
+                    "When 'source_uri' is specified, 'nodes' field must not \
+                     be present"
+                ));
+            }
+
+            if let Some(connections) = &self.graph.connections {
+                if !connections.is_empty() {
+                    return Err(anyhow!(
+                        "When 'source_uri' is specified, 'connections' field \
+                         must not be present"
+                    ));
+                }
+            }
+
+            if let Some(exposed_messages) = &self.graph.exposed_messages {
+                if !exposed_messages.is_empty() {
+                    return Err(anyhow!(
+                        "When 'source_uri' is specified, 'exposed_messages' \
+                         field must not be present"
+                    ));
+                }
+            }
+
+            if let Some(exposed_properties) = &self.graph.exposed_properties {
+                if !exposed_properties.is_empty() {
+                    return Err(anyhow!(
+                        "When 'source_uri' is specified, 'exposed_properties' \
+                         field must not be present"
+                    ));
+                }
+            }
+        }
+
         // If source_uri is specified, load graph from the URI.
         if let Some(uri) = self.source_uri.clone() {
             self.load_graph_from_uri(&uri)?;

--- a/core/src/ten_rust/src/graph/graph_info.rs
+++ b/core/src/ten_rust/src/graph/graph_info.rs
@@ -78,8 +78,10 @@ impl GraphInfo {
         }
 
         // If source_uri is specified, load graph from the URI.
-        if let Some(uri) = self.source_uri.clone() {
-            self.load_graph_from_uri(&uri)?;
+        let source_uri = self.source_uri.clone();
+        let app_base_dir = self.app_base_dir.clone();
+        if let Some(uri) = source_uri {
+            self.load_graph_from_uri(&uri, app_base_dir.as_deref())?;
         }
 
         self.graph.validate_and_complete()
@@ -94,7 +96,11 @@ impl GraphInfo {
     ///
     /// This function replaces the current graph with the one loaded from the
     /// URI.
-    fn load_graph_from_uri(&mut self, uri: &str) -> Result<()> {
+    fn load_graph_from_uri(
+        &mut self,
+        uri: &str,
+        base_dir: Option<&str>,
+    ) -> Result<()> {
         // Check if the URI is a URL (starts with http:// or https://)
         if uri.starts_with("http://") || uri.starts_with("https://") {
             // TODO: Implement HTTP request to fetch the graph file
@@ -108,13 +114,12 @@ impl GraphInfo {
         // Handle relative and absolute paths.
         let path = if Path::new(uri).is_absolute() {
             PathBuf::from(uri)
-        } else if let Some(app_base_dir) = &self.app_base_dir {
+        } else if let Some(base_dir) = base_dir {
             // If app_base_dir is available, use it as the base for relative
             // paths.
-            Path::new(app_base_dir).join(uri)
+            Path::new(base_dir).join(uri)
         } else {
-            // If app_base_dir is not available, just use the URI as is.
-            PathBuf::from(uri)
+            panic!("base_dir is not available");
         };
 
         // Read the graph file.

--- a/core/src/ten_rust/src/graph/subgraph.rs
+++ b/core/src/ten_rust/src/graph/subgraph.rs
@@ -513,7 +513,7 @@ impl Graph {
         subgraph_mappings: &mut HashMap<String, Graph>,
     ) -> Result<()>
     where
-        F: Fn(&str) -> Result<Graph>,
+        F: Fn(&str, Option<&str>) -> Result<Graph>,
     {
         // First, recursively flatten any nested subgraphs within this subgraph.
         // This ensures depth-first processing.
@@ -565,7 +565,7 @@ impl Graph {
         subgraph_mappings: &mut HashMap<String, Graph>,
     ) -> Result<()>
     where
-        F: Fn(&str) -> Result<Graph>,
+        F: Fn(&str, Option<&str>) -> Result<Graph>,
     {
         let source_uri =
             subgraph_node.source_uri.as_ref().ok_or_else(|| {
@@ -575,7 +575,7 @@ impl Graph {
                 )
             })?;
 
-        let subgraph = subgraph_loader(source_uri)?;
+        let subgraph = subgraph_loader(source_uri, None)?;
 
         Self::process_loaded_subgraph(
             subgraph_node,
@@ -625,7 +625,7 @@ impl Graph {
         subgraph_mappings: &mut HashMap<String, Graph>,
     ) -> Result<()>
     where
-        F: Fn(&str) -> Result<Graph>,
+        F: Fn(&str, Option<&str>) -> Result<Graph>,
     {
         // Process all nodes in the graph
         for node in &graph.nodes {
@@ -825,7 +825,7 @@ impl Graph {
         preserve_exposed_info: bool,
     ) -> Result<Graph>
     where
-        F: Fn(&str) -> Result<Graph>,
+        F: Fn(&str, Option<&str>) -> Result<Graph>,
     {
         // Check if this graph contains any subgraphs
         let has_subgraphs = graph
@@ -885,7 +885,7 @@ impl Graph {
     /// exposed info. This is the main public API for flattening graphs.
     pub fn flatten_graph<F>(&self, subgraph_loader: &F) -> Result<Graph>
     where
-        F: Fn(&str) -> Result<Graph>,
+        F: Fn(&str, Option<&str>) -> Result<Graph>,
     {
         Self::flatten(self, subgraph_loader, false)
     }

--- a/core/src/ten_rust/src/json_schema/data/property.schema.json
+++ b/core/src/ten_rust/src/json_schema/data/property.schema.json
@@ -856,7 +856,45 @@
                   ]
                 }
               }
-            }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "source_uri"
+                ],
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "nodes"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "connections"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "exposed_messages"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "exposed_properties"
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "required": [
+                    "source_uri"
+                  ]
+                }
+              }
+            ]
           }
         }
       }

--- a/core/src/ten_rust/tests/test_case/json_schema/mod.rs
+++ b/core/src/ten_rust/tests/test_case/json_schema/mod.rs
@@ -1524,4 +1524,203 @@ mod tests {
             ten_validate_property_json_string(property_json_with_subgraph);
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_validate_source_uri_mutual_exclusion_with_nodes() {
+        // Test that source_uri and nodes are mutually exclusive
+        let property = r#"
+        {
+          "ten": {
+            "predefined_graphs": [
+              {
+                "name": "default",
+                "source_uri": "test_graph.json",
+                "nodes": [
+                  {
+                    "type": "extension",
+                    "name": "test_ext",
+                    "addon": "test_addon",
+                    "extension_group": "test_group"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        "#;
+
+        let result = ten_validate_property_json_string(property);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("oneOf"));
+    }
+
+    #[test]
+    fn test_validate_source_uri_mutual_exclusion_with_connections() {
+        // Test that source_uri and connections are mutually exclusive
+        let property = r#"
+        {
+          "ten": {
+            "predefined_graphs": [
+              {
+                "name": "default",
+                "source_uri": "test_graph.json",
+                "connections": [
+                  {
+                    "extension": "test_ext",
+                    "cmd": [
+                      {
+                        "name": "test_cmd",
+                        "dest": [
+                          {
+                            "extension": "test_ext"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        "#;
+
+        let result = ten_validate_property_json_string(property);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("oneOf"));
+    }
+
+    #[test]
+    fn test_validate_source_uri_mutual_exclusion_with_exposed_messages() {
+        // Test that source_uri and exposed_messages are mutually exclusive
+        let property = r#"
+        {
+          "ten": {
+            "predefined_graphs": [
+              {
+                "name": "default",
+                "source_uri": "test_graph.json",
+                "exposed_messages": [
+                  {
+                    "type": "cmd_in",
+                    "name": "test_msg",
+                    "extension": "test_ext"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        "#;
+
+        let result = ten_validate_property_json_string(property);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("oneOf"));
+    }
+
+    #[test]
+    fn test_validate_source_uri_mutual_exclusion_with_exposed_properties() {
+        // Test that source_uri and exposed_properties are mutually exclusive
+        let property = r#"
+        {
+          "ten": {
+            "predefined_graphs": [
+              {
+                "name": "default",
+                "source_uri": "test_graph.json",
+                "exposed_properties": [
+                  {
+                    "name": "test_prop",
+                    "extension": "test_ext"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        "#;
+
+        let result = ten_validate_property_json_string(property);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("oneOf"));
+    }
+
+    #[test]
+    fn test_validate_source_uri_without_conflicting_fields_succeeds() {
+        // Test that source_uri alone is valid
+        let property = r#"
+        {
+          "ten": {
+            "predefined_graphs": [
+              {
+                "name": "default",
+                "source_uri": "test_graph.json"
+              }
+            ]
+          }
+        }
+        "#;
+
+        let result = ten_validate_property_json_string(property);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_graph_without_source_uri_succeeds() {
+        // Test that a graph without source_uri but with other fields is valid
+        let property = r#"
+        {
+          "ten": {
+            "predefined_graphs": [
+              {
+                "name": "default",
+                "nodes": [
+                  {
+                    "type": "extension",
+                    "name": "test_ext",
+                    "addon": "test_addon",
+                    "extension_group": "test_group"
+                  }
+                ],
+                "connections": [
+                  {
+                    "extension": "test_ext",
+                    "cmd": [
+                      {
+                        "name": "test_cmd",
+                        "dest": [
+                          {
+                            "extension": "test_ext"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "exposed_messages": [
+                  {
+                    "type": "cmd_in",
+                    "name": "test_msg",
+                    "extension": "test_ext"
+                  }
+                ],
+                "exposed_properties": [
+                  {
+                    "name": "test_prop",
+                    "extension": "test_ext"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        "#;
+
+        let result = ten_validate_property_json_string(property);
+        assert!(result.is_ok());
+    }
 }

--- a/tests/ten_runtime/integration/go/access_property_go/access_property_go_app/property.json
+++ b/tests/ten_runtime/integration/go/access_property_go/access_property_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/call_api_after_deinited_go/call_api_after_deinited_go_app/property.json
+++ b/tests/ten_runtime/integration/go/call_api_after_deinited_go/call_api_after_deinited_go_app/property.json
@@ -1,7 +1,7 @@
 {
   "ten": {
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/call_api_during_deiniting_go/call_api_during_deiniting_go_app/property.json
+++ b/tests/ten_runtime/integration/go/call_api_during_deiniting_go/call_api_during_deiniting_go_app/property.json
@@ -1,7 +1,7 @@
 {
   "ten": {
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/close_app_cmd_go/close_app_cmd_go_app/property.json
+++ b/tests/ten_runtime/integration/go/close_app_cmd_go/close_app_cmd_go_app/property.json
@@ -1,7 +1,7 @@
 {
   "ten": {
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/close_app_go/close_app_go_app/property.json
+++ b/tests/ten_runtime/integration/go/close_app_go/close_app_go_app/property.json
@@ -3,7 +3,7 @@
     "uri": "msgpack://127.0.0.1:8007/",
     "long_running_mode": true,
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/exit_signal_go/exit_signal_go_app/property.json
+++ b/tests/ten_runtime/integration/go/exit_signal_go/exit_signal_go_app/property.json
@@ -1,5 +1,8 @@
 {
   "ten": {
+    "log": {
+      "level": 1
+    },
     "predefined_graphs": [
       {
         "name": "default",

--- a/tests/ten_runtime/integration/go/expired_ten_go/expired_ten_go_app/property.json
+++ b/tests/ten_runtime/integration/go/expired_ten_go/expired_ten_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/failed_to_create_extension_go/failed_to_create_extension_go_app/property.json
+++ b/tests/ten_runtime/integration/go/failed_to_create_extension_go/failed_to_create_extension_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/frequently_cgo_call_go/frequently_cgo_call_go_app/property.json
+++ b/tests/ten_runtime/integration/go/frequently_cgo_call_go/frequently_cgo_call_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/handle_error_go/handle_error_go_app/property.json
+++ b/tests/ten_runtime/integration/go/handle_error_go/handle_error_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/local_dependency_1_go/local_dependency_1_go_app/property.json
+++ b/tests/ten_runtime/integration/go/local_dependency_1_go/local_dependency_1_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/local_dependency_2_go/local_dependency_2_go_app/property.json
+++ b/tests/ten_runtime/integration/go/local_dependency_2_go/local_dependency_2_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/msg_clone_go/msg_clone_go_app/property.json
+++ b/tests/ten_runtime/integration/go/msg_clone_go/msg_clone_go_app/property.json
@@ -1,7 +1,7 @@
 {
   "ten": {
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/multi_dest_go/multi_dest_go_app/property.json
+++ b/tests/ten_runtime/integration/go/multi_dest_go/multi_dest_go_app/property.json
@@ -1,7 +1,7 @@
 {
   "ten": {
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/no_dest_go/no_dest_go_app/property.json
+++ b/tests/ten_runtime/integration/go/no_dest_go/no_dest_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/prepare_to_stop_go/prepare_to_stop_go_app/property.json
+++ b/tests/ten_runtime/integration/go/prepare_to_stop_go/prepare_to_stop_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/return_result_go/return_result_go_app/property.json
+++ b/tests/ten_runtime/integration/go/return_result_go/return_result_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/return_value_go/return_value_go_app/property.json
+++ b/tests/ten_runtime/integration/go/return_value_go/return_value_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/send_data_go/send_data_go_app/property.json
+++ b/tests/ten_runtime/integration/go/send_data_go/send_data_go_app/property.json
@@ -1,7 +1,7 @@
 {
   "ten": {
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/start_app_sync_go/start_app_sync_go_app/property.json
+++ b/tests/ten_runtime/integration/go/start_app_sync_go/start_app_sync_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/start_graph_go/start_graph_go_app/property.json
+++ b/tests/ten_runtime/integration/go/start_graph_go/start_graph_go_app/property.json
@@ -1,7 +1,7 @@
 {
   "ten": {
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/start_predefined_graph_go/start_predefined_graph_go_app/property.json
+++ b/tests/ten_runtime/integration/go/start_predefined_graph_go/start_predefined_graph_go_app/property.json
@@ -1,7 +1,7 @@
 {
   "ten": {
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {

--- a/tests/ten_runtime/integration/go/three_extension_cmd_go/three_extension_cmd_go_app/property.json
+++ b/tests/ten_runtime/integration/go/three_extension_cmd_go/three_extension_cmd_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     }
   }
 }

--- a/tests/ten_runtime/integration/go/transfer_pointer_go/transfer_pointer_go_app/property.json
+++ b/tests/ten_runtime/integration/go/transfer_pointer_go/transfer_pointer_go_app/property.json
@@ -2,7 +2,7 @@
   "ten": {
     "uri": "msgpack://127.0.0.1:8007/",
     "log": {
-      "level": 2
+      "level": 1
     },
     "predefined_graphs": [
       {


### PR DESCRIPTION
… GraphInfo

Added validation logic to ensure that when 'source_uri' is specified, the 'nodes', 'connections', 'exposed_messages',
and 'exposed_properties' fields must not be present. Updated JSON schema to reflect these constraints and added
 corresponding unit tests to verify the behavior.