### PR TITLE
feat: add functions to free C strings and parse JSON into Graph structure

### DIFF
--- a/core/include_internal/ten_rust/ten_rust.h
+++ b/core/include_internal/ten_rust/ten_rust.h
@@ -18,7 +18,52 @@ typedef struct MetricHandle MetricHandle;
 typedef struct ServiceHub ServiceHub;
 typedef struct ten_app_t ten_app_t;
 
+/**
+ * @brief Frees a C string that was allocated by Rust.
+ *
+ * This function takes ownership of a raw pointer and frees it. The caller must
+ * ensure that the pointer was originally allocated by Rust and that it is not
+ * used after being freed. Passing a null pointer is safe, as the function will
+ * simply return in that case.
+ *
+ * @param ptr Pointer to the C string to be freed. Can be NULL.
+ */
 TEN_RUST_PRIVATE_API void ten_rust_free_cstring(const char *ptr);
+
+/**
+ * @brief Parses a JSON string into a Graph and returns it as a JSON string.
+ *
+ * This function takes a C string containing JSON, validates and processes it,
+ * then serializes it back to JSON.
+ *
+ * @param json_str A null-terminated C string containing the JSON representation
+ *                 of a graph. Must not be NULL.
+ *
+ * @return On success: A pointer to a newly allocated C string containing the
+ *         processed graph JSON. On failure: NULL pointer.
+ *
+ * @note The caller must ensure that:
+ *       - json_str is a valid null-terminated C string
+ *       - The returned pointer (if not null) is freed using
+ *         ten_rust_free_cstring()
+ *       - The input string contains valid UTF-8 encoded JSON
+ *
+ * @note Memory Management: The returned string is allocated by Rust and must be
+ *       freed by calling ten_rust_free_cstring() when no longer needed.
+ *
+ * @example
+ * ```c
+ * const char* input_json = "{\"nodes\": []}";
+ * const char* result = ten_rust_graph_from_str(input_json);
+ * if (result != NULL) {
+ *     printf("Processed graph: %s\n", result);
+ *     ten_rust_free_cstring(result);
+ * } else {
+ *     printf("Failed to process graph\n");
+ * }
+ * ```
+ */
+TEN_RUST_PRIVATE_API const char *ten_rust_graph_from_str(const char *json_str);
 
 TEN_RUST_PRIVATE_API Cipher *ten_cipher_create(const char *algorithm,
                                                const char *params);

--- a/core/src/ten_rust/src/bindings.rs
+++ b/core/src/ten_rust/src/bindings.rs
@@ -4,7 +4,10 @@
 // Licensed under the Apache License, Version 2.0, with certain conditions.
 // Refer to the "LICENSE" file in the root directory for more information.
 //
-use std::ffi::{c_char, CString};
+use std::ffi::{c_char, CStr, CString};
+use std::str::FromStr;
+
+use crate::graph::Graph;
 
 /// Frees a C string that was allocated by Rust.
 ///
@@ -23,5 +26,67 @@ pub extern "C" fn ten_rust_free_cstring(ptr: *const c_char) {
         // Cast away const-ness to take ownership back and let it drop.
         let ptr = ptr as *mut c_char;
         let _ = CString::from_raw(ptr);
+    }
+}
+
+/// Parses a JSON string into a Graph and returns it as a JSON string.
+///
+/// This function wraps the Graph::from_str() functionality for C code.
+/// It takes a C string containing JSON, parses it into a Graph structure,
+/// validates and processes it, then serializes it back to JSON.
+///
+/// # Parameters
+/// - `json_str`: A null-terminated C string containing the JSON representation
+///   of a graph
+///
+/// # Returns
+/// - On success: A pointer to a newly allocated C string containing the
+///   processed graph JSON
+/// - On failure: A null pointer
+///
+/// # Safety
+///
+/// The caller must ensure that:
+/// - `json_str` is a valid null-terminated C string
+/// - The returned pointer (if not null) is freed using
+///   `ten_rust_free_cstring()`
+/// - The input string contains valid UTF-8 encoded JSON
+///
+/// # Memory Management
+///
+/// The returned string is allocated by Rust and must be freed by calling
+/// `ten_rust_free_cstring()` when no longer needed.
+#[no_mangle]
+pub unsafe extern "C" fn ten_rust_graph_from_str(
+    json_str: *const c_char,
+) -> *const c_char {
+    if json_str.is_null() {
+        return std::ptr::null();
+    }
+
+    // Convert C string to Rust string
+    let c_str = CStr::from_ptr(json_str);
+
+    let rust_str = match c_str.to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null(), // Invalid UTF-8
+    };
+
+    // Parse the JSON string into a Graph
+    let graph = match Graph::from_str(rust_str) {
+        Ok(g) => g,
+        Err(_) => return std::ptr::null(), // Parsing failed
+    };
+
+    // Serialize the graph back to JSON
+    let json_output = match serde_json::to_string(&graph) {
+        Ok(json) => json,
+        Err(_) => return std::ptr::null(), // Serialization failed
+    };
+
+    // Convert to C string
+    match CString::new(json_output) {
+        Ok(c_string) => c_string.into_raw(),
+        Err(_) => std::ptr::null(), // Contains null bytes
     }
 }

--- a/core/src/ten_rust/src/lib.rs
+++ b/core/src/ten_rust/src/lib.rs
@@ -6,7 +6,7 @@
 //
 pub mod _0_8_compatible;
 pub mod base_dir_pkg_info;
-mod bindings;
+pub mod bindings;
 pub mod constants;
 pub mod crypto;
 pub mod env;

--- a/core/src/ten_rust/tests/test_case/bindings.rs
+++ b/core/src/ten_rust/tests/test_case/bindings.rs
@@ -1,0 +1,93 @@
+//
+// Copyright © 2025 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+#[cfg(test)]
+mod tests {
+    use std::ffi::{CStr, CString};
+    use ten_rust::bindings::{ten_rust_free_cstring, ten_rust_graph_from_str};
+
+    #[test]
+    fn test_ten_rust_graph_from_str_valid_json() {
+        let input_json = r#"{
+            "nodes": [
+                {
+                    "type": "extension",
+                    "name": "test_extension",
+                    "addon": "test_addon"
+                }
+            ]
+        }"#;
+
+        let c_input = CString::new(input_json).unwrap();
+        let result_ptr = unsafe { ten_rust_graph_from_str(c_input.as_ptr()) };
+
+        assert!(!result_ptr.is_null());
+
+        // Convert the result back to a Rust string to verify it's valid JSON
+        let result_cstr = unsafe { CStr::from_ptr(result_ptr) };
+        let result_str = result_cstr.to_str().unwrap();
+
+        // Parse the result to ensure it's valid JSON
+        let parsed: serde_json::Value =
+            serde_json::from_str(result_str).unwrap();
+        assert!(parsed.is_object());
+        assert!(parsed["nodes"].is_array());
+
+        // Free the allocated string
+        ten_rust_free_cstring(result_ptr);
+    }
+
+    #[test]
+    fn test_ten_rust_graph_from_str_invalid_json() {
+        let input_json = "invalid json";
+
+        let c_input = CString::new(input_json).unwrap();
+        let result_ptr = unsafe { ten_rust_graph_from_str(c_input.as_ptr()) };
+
+        // Should return null for invalid JSON
+        assert!(result_ptr.is_null());
+    }
+
+    #[test]
+    fn test_ten_rust_graph_from_str_null_input() {
+        let result_ptr = unsafe { ten_rust_graph_from_str(std::ptr::null()) };
+
+        // Should return null for null input
+        assert!(result_ptr.is_null());
+    }
+
+    #[test]
+    fn test_ten_rust_free_cstring_null_input() {
+        // Should not crash with null input
+        ten_rust_free_cstring(std::ptr::null());
+    }
+
+    #[test]
+    fn test_ten_rust_graph_from_str_empty_graph() {
+        let input_json = r#"{
+            "nodes": []
+        }"#;
+
+        let c_input = CString::new(input_json).unwrap();
+        let result_ptr = unsafe { ten_rust_graph_from_str(c_input.as_ptr()) };
+
+        assert!(!result_ptr.is_null());
+
+        // Convert the result back to a Rust string
+        let result_cstr = unsafe { CStr::from_ptr(result_ptr) };
+        let result_str = result_cstr.to_str().unwrap();
+
+        // Parse the result to ensure it's valid JSON
+        let parsed: serde_json::Value =
+            serde_json::from_str(result_str).unwrap();
+        assert!(parsed.is_object());
+        assert!(parsed["nodes"].is_array());
+        assert_eq!(parsed["nodes"].as_array().unwrap().len(), 0);
+
+        // Free the allocated string
+        ten_rust_free_cstring(result_ptr);
+    }
+}

--- a/core/src/ten_rust/tests/test_case/mod.rs
+++ b/core/src/ten_rust/tests/test_case/mod.rs
@@ -4,6 +4,7 @@
 // Licensed under the Apache License, Version 2.0, with certain conditions.
 // Refer to the "LICENSE" file in the root directory for more information.
 //
+mod bindings;
 mod crypto_test;
 mod graph;
 mod graph_check;


### PR DESCRIPTION
- Introduced `ten_rust_free_cstring` to safely free C strings allocated by Rust.
- Added `ten_rust_graph_from_str` to parse a JSON string into a Graph and
return it as a JSON string.
- Updated bindings and tests to accommodate new functionality.