### PR TITLE
feat: implement custom source location handling in msg_t class

### DIFF
--- a/core/include/ten_runtime/binding/cpp/detail/test/env_tester.h
+++ b/core/include/ten_runtime/binding/cpp/detail/test/env_tester.h
@@ -178,6 +178,16 @@ class ten_env_tester_t {
         err != nullptr ? err->get_c_error() : nullptr);
   }
 
+  bool set_msg_source(msg_t &msg, const loc_t &loc, error_t *err = nullptr) {
+    TEN_ASSERT(c_ten_env_tester, "Should not happen.");
+    return ten_env_tester_set_msg_source(
+        c_ten_env_tester, msg.get_underlying_msg(),
+        loc.app_uri.has_value() ? loc.app_uri->c_str() : nullptr,
+        loc.graph_id.has_value() ? loc.graph_id->c_str() : nullptr,
+        loc.extension_name.has_value() ? loc.extension_name->c_str() : nullptr,
+        err != nullptr ? err->get_c_error() : nullptr);
+  }
+
  private:
   friend extension_tester_t;
   friend class ten_env_tester_proxy_t;

--- a/core/include/ten_runtime/test/env_tester.h
+++ b/core/include/ten_runtime/test/env_tester.h
@@ -8,6 +8,7 @@
 
 #include "ten_runtime/ten_config.h"
 
+#include "ten_runtime/msg/msg.h"
 #include "ten_runtime/ten_env/internal/send.h"
 #include "ten_utils/lib/error.h"
 #include "ten_utils/lib/smart_ptr.h"
@@ -65,3 +66,7 @@ TEN_RUNTIME_API bool ten_env_tester_log(ten_env_tester_t *self,
                                         const char *func_name,
                                         const char *file_name, size_t line_no,
                                         const char *msg, ten_error_t *error);
+
+TEN_RUNTIME_API bool ten_env_tester_set_msg_source(
+    ten_env_tester_t *self, ten_shared_ptr_t *msg, const char *app_uri,
+    const char *graph_id, const char *extension_name, ten_error_t *err);

--- a/core/include_internal/ten_runtime/msg/msg.h
+++ b/core/include_internal/ten_runtime/msg/msg.h
@@ -51,6 +51,9 @@ typedef struct ten_msg_t {
   // that have not specified a name.
   ten_value_t name;  // string
 
+  bool has_custom_src_loc;
+  ten_loc_t custom_src_loc;
+
   ten_loc_t src_loc;
   ten_list_t dest_loc;
 
@@ -72,6 +75,15 @@ TEN_RUNTIME_PRIVATE_API void ten_raw_msg_deinit(ten_msg_t *self);
 
 TEN_RUNTIME_PRIVATE_API void ten_raw_msg_copy_field(
     ten_msg_t *self, ten_msg_t *src, ten_list_t *excluded_field_ids);
+
+TEN_RUNTIME_PRIVATE_API void ten_raw_msg_set_custom_src(
+    ten_msg_t *self, const char *app_uri, const char *graph_id,
+    const char *extension_name);
+
+TEN_RUNTIME_PRIVATE_API void ten_msg_set_custom_src(ten_shared_ptr_t *self,
+                                                    const char *app_uri,
+                                                    const char *graph_id,
+                                                    const char *extension_name);
 
 TEN_RUNTIME_PRIVATE_API void ten_raw_msg_set_src_to_loc(ten_msg_t *self,
                                                         ten_loc_t *loc);

--- a/core/include_internal/ten_runtime/test/env_tester.h
+++ b/core/include_internal/ten_runtime/test/env_tester.h
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 
 #include "include_internal/ten_runtime/binding/common.h"
+#include "ten_runtime/msg/msg.h"
 #include "ten_utils/lib/signature.h"
 
 #define TEN_ENV_TESTER_SIGNATURE 0x66C619FBA7DC8BD9U

--- a/core/src/ten_runtime/msg/field/src.c
+++ b/core/src/ten_runtime/msg/field/src.c
@@ -10,12 +10,19 @@
 #include "include_internal/ten_runtime/common/loc.h"
 #include "include_internal/ten_runtime/msg/msg.h"
 #include "ten_utils/macro/check.h"
+#include "ten_utils/macro/mark.h"
 #include "ten_utils/value/value.h"
 
 void ten_raw_msg_src_copy(ten_msg_t *self, ten_msg_t *src,
-                          ten_list_t *excluded_field_ids) {
+                          TEN_UNUSED ten_list_t *excluded_field_ids) {
   TEN_ASSERT(src && ten_raw_msg_check_integrity(src), "Should not happen.");
+
   ten_loc_set_from_loc(&self->src_loc, &src->src_loc);
+
+  self->has_custom_src_loc = src->has_custom_src_loc;
+  if (src->has_custom_src_loc) {
+    ten_loc_set_from_loc(&self->custom_src_loc, &src->custom_src_loc);
+  }
 }
 
 bool ten_raw_msg_src_process(ten_msg_t *self,

--- a/core/src/ten_runtime/msg/msg.c
+++ b/core/src/ten_runtime/msg/msg.c
@@ -64,6 +64,9 @@ void ten_raw_msg_init(ten_msg_t *self, TEN_MSG_TYPE type) {
   self->type = type;
   ten_value_init_string(&self->name);
 
+  self->has_custom_src_loc = false;
+  ten_loc_init_empty(&self->custom_src_loc);
+
   ten_loc_init_empty(&self->src_loc);
   ten_list_init(&self->dest_loc);
 
@@ -83,6 +86,8 @@ void ten_raw_msg_deinit(ten_msg_t *self) {
   ten_signature_set(&self->signature, 0);
   ten_value_deinit(&self->name);
 
+  ten_loc_deinit(&self->custom_src_loc);
+
   ten_loc_deinit(&self->src_loc);
   ten_list_clear(&self->dest_loc);
 
@@ -91,27 +96,50 @@ void ten_raw_msg_deinit(ten_msg_t *self) {
   ten_value_deinit(&self->properties);
 }
 
+void ten_raw_msg_set_custom_src(ten_msg_t *self, const char *app_uri,
+                                const char *graph_id,
+                                const char *extension_name) {
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_raw_msg_check_integrity(self), "Should not happen.");
+
+  ten_loc_set(&self->custom_src_loc, app_uri, graph_id, extension_name);
+  self->has_custom_src_loc = true;
+}
+
+void ten_msg_set_custom_src(ten_shared_ptr_t *self, const char *app_uri,
+                            const char *graph_id, const char *extension_name) {
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
+  ten_raw_msg_set_custom_src(ten_msg_get_raw_msg(self), app_uri, graph_id,
+                             extension_name);
+}
+
 void ten_raw_msg_set_src_to_loc(ten_msg_t *self, ten_loc_t *loc) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_raw_msg_check_integrity(self), "Should not happen.");
+
   ten_loc_set_from_loc(&self->src_loc, loc);
 }
 
 void ten_msg_set_src_to_loc(ten_shared_ptr_t *self, ten_loc_t *loc) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
   ten_raw_msg_set_src_to_loc(ten_shared_ptr_get_data(self), loc);
 }
 
 static void ten_raw_msg_clear_dest(ten_msg_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_raw_msg_check_integrity(self), "Should not happen.");
+
   ten_list_clear(&self->dest_loc);
 }
 
 void ten_msg_clear_dest(ten_shared_ptr_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
   ten_raw_msg_clear_dest(ten_msg_get_raw_msg(self));
 }
 
@@ -182,6 +210,7 @@ void ten_msg_clear_and_set_dest_from_msg_src(ten_shared_ptr_t *self,
 static bool ten_raw_msg_src_is_empty(ten_msg_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_raw_msg_check_integrity(self), "Should not happen.");
+
   return ten_loc_is_empty(&self->src_loc);
 }
 
@@ -227,6 +256,7 @@ ten_loc_t *ten_raw_msg_get_first_dest_loc(ten_msg_t *self) {
 
 bool ten_msg_check_integrity(ten_shared_ptr_t *self) {
   TEN_ASSERT(self, "Should not happen.");
+
   ten_msg_t *raw_msg = ten_shared_ptr_get_data(self);
   if (ten_raw_msg_check_integrity(raw_msg) == false) {
     return false;
@@ -237,12 +267,14 @@ bool ten_msg_check_integrity(ten_shared_ptr_t *self) {
 bool ten_msg_src_is_empty(ten_shared_ptr_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
   return ten_raw_msg_src_is_empty(ten_msg_get_raw_msg(self));
 }
 
 const char *ten_msg_get_first_dest_uri(ten_shared_ptr_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
   return ten_raw_msg_get_first_dest_uri(ten_msg_get_raw_msg(self));
 }
 
@@ -251,6 +283,7 @@ static void ten_raw_msg_set_src(ten_msg_t *self, const char *uri,
                                 const char *extension_name) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_raw_msg_check_integrity(self), "Should not happen.");
+
   ten_loc_set(&self->src_loc, uri, graph_id, extension_name);
 }
 
@@ -258,6 +291,7 @@ void ten_msg_set_src(ten_shared_ptr_t *self, const char *uri,
                      const char *graph_id, const char *extension_name) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
   ten_raw_msg_set_src(ten_msg_get_raw_msg(self), uri, graph_id, extension_name);
 }
 
@@ -478,18 +512,21 @@ void ten_msg_clear_and_set_dest_from_extension_info(
 ten_list_t *ten_msg_get_dest(ten_shared_ptr_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
   return &ten_msg_get_raw_msg(self)->dest_loc;
 }
 
 size_t ten_raw_msg_get_dest_cnt(ten_msg_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_raw_msg_check_integrity(self), "Should not happen.");
+
   return ten_list_size(&self->dest_loc);
 }
 
 size_t ten_msg_get_dest_cnt(ten_shared_ptr_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
   return ten_raw_msg_get_dest_cnt(ten_shared_ptr_get_data(self));
 }
 
@@ -506,18 +543,21 @@ const char *ten_msg_get_src_app_uri(ten_shared_ptr_t *self) {
 const char *ten_msg_get_src_graph_id(ten_shared_ptr_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
   return ten_string_get_raw_str(&ten_msg_get_raw_msg(self)->src_loc.graph_id);
 }
 
 ten_loc_t *ten_raw_msg_get_src_loc(ten_msg_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_raw_msg_check_integrity(self), "Should not happen.");
+
   return &self->src_loc;
 }
 
 ten_loc_t *ten_msg_get_src_loc(ten_shared_ptr_t *self) {
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
+
   return ten_raw_msg_get_src_loc(ten_shared_ptr_get_data(self));
 }
 
@@ -527,7 +567,15 @@ void ten_msg_get_source(ten_shared_ptr_t *self, const char **app_uri,
   TEN_ASSERT(self, "Should not happen.");
   TEN_ASSERT(ten_msg_check_integrity(self), "Should not happen.");
 
-  ten_loc_t *loc = ten_msg_get_src_loc(self);
+  ten_msg_t *raw_msg = ten_msg_get_raw_msg(self);
+  TEN_ASSERT(raw_msg, "Should not happen.");
+  ten_loc_t *loc = NULL;
+
+  if (raw_msg->has_custom_src_loc) {
+    loc = &raw_msg->custom_src_loc;
+  } else {
+    loc = &raw_msg->src_loc;
+  }
   TEN_ASSERT(loc, "Should not happen.");
 
   if (app_uri) {

--- a/core/src/ten_runtime/test/env_tester.c
+++ b/core/src/ten_runtime/test/env_tester.c
@@ -16,6 +16,7 @@
 #include "include_internal/ten_runtime/test/extension_tester.h"
 #include "ten_runtime/app/app.h"
 #include "ten_runtime/common/error_code.h"
+#include "ten_runtime/common/loc.h"
 #include "ten_runtime/extension/extension.h"
 #include "ten_runtime/msg/cmd/close_app/cmd.h"
 #include "ten_runtime/msg/cmd_result/cmd_result.h"
@@ -826,7 +827,7 @@ bool ten_env_tester_send_video_frame(
 }
 
 static void test_app_ten_env_send_close_app_cmd(ten_env_t *ten_env,
-                                                void *user_data) {
+                                                TEN_UNUSED void *user_data) {
   TEN_ASSERT(ten_env, "Should not happen.");
   TEN_ASSERT(ten_env_check_integrity(ten_env, true), "Should not happen.");
 
@@ -904,7 +905,8 @@ bool ten_env_tester_log(ten_env_tester_t *self, TEN_LOG_LEVEL level,
   return rc;
 }
 
-bool ten_env_tester_on_init_done(ten_env_tester_t *self, ten_error_t *err) {
+bool ten_env_tester_on_init_done(ten_env_tester_t *self,
+                                 TEN_UNUSED ten_error_t *err) {
   TEN_ASSERT(self && ten_env_tester_check_integrity(self, true),
              "Invalid argument.");
 
@@ -913,7 +915,8 @@ bool ten_env_tester_on_init_done(ten_env_tester_t *self, ten_error_t *err) {
   return true;
 }
 
-bool ten_env_tester_on_start_done(ten_env_tester_t *self, ten_error_t *err) {
+bool ten_env_tester_on_start_done(ten_env_tester_t *self,
+                                  TEN_UNUSED ten_error_t *err) {
   TEN_ASSERT(self && ten_env_tester_check_integrity(self, true),
              "Invalid argument.");
 
@@ -922,7 +925,8 @@ bool ten_env_tester_on_start_done(ten_env_tester_t *self, ten_error_t *err) {
   return true;
 }
 
-bool ten_env_tester_on_stop_done(ten_env_tester_t *self, ten_error_t *err) {
+bool ten_env_tester_on_stop_done(ten_env_tester_t *self,
+                                 TEN_UNUSED ten_error_t *err) {
   TEN_ASSERT(self && ten_env_tester_check_integrity(self, true),
              "Invalid argument.");
 
@@ -931,7 +935,8 @@ bool ten_env_tester_on_stop_done(ten_env_tester_t *self, ten_error_t *err) {
   return true;
 }
 
-bool ten_env_tester_on_deinit_done(ten_env_tester_t *self, ten_error_t *err) {
+bool ten_env_tester_on_deinit_done(ten_env_tester_t *self,
+                                   TEN_UNUSED ten_error_t *err) {
   TEN_ASSERT(self && ten_env_tester_check_integrity(self, true),
              "Invalid argument.");
 
@@ -948,4 +953,32 @@ void ten_env_tester_set_destroy_handler_in_target_lang(
              "Invalid use of ten_env_tester %p.", self);
 
   self->destroy_handler = destroy_handler;
+}
+
+static bool ten_env_tester_set_raw_msg_source(
+    ten_env_tester_t *self, ten_msg_t *msg, const char *app_uri,
+    const char *graph_id, const char *extension_name, ten_error_t *err) {
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env_tester_check_integrity(self, true),
+             "Invalid use of ten_env_tester %p.", self);
+
+  TEN_ASSERT(msg, "Invalid argument.");
+  TEN_ASSERT(ten_raw_msg_check_integrity(msg), "Invalid argument.");
+
+  if (!ten_loc_str_check_correct(app_uri, graph_id, extension_name, err)) {
+    return false;
+  }
+
+  ten_raw_msg_set_custom_src(msg, app_uri, graph_id, extension_name);
+
+  return true;
+}
+
+bool ten_env_tester_set_msg_source(ten_env_tester_t *self,
+                                   ten_shared_ptr_t *msg, const char *app_uri,
+                                   const char *graph_id,
+                                   const char *extension_name,
+                                   ten_error_t *err) {
+  return ten_env_tester_set_raw_msg_source(
+      self, ten_msg_get_raw_msg(msg), app_uri, graph_id, extension_name, err);
 }

--- a/tests/ten_runtime/smoke/standalone_test/msg_custom_src.cc
+++ b/tests/ten_runtime/smoke/standalone_test/msg_custom_src.cc
@@ -1,0 +1,91 @@
+//
+// Copyright © 2025 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+#include "gtest/gtest.h"
+#include "include_internal/ten_runtime/binding/cpp/ten.h"
+#include "ten_runtime/binding/cpp/detail/extension.h"
+#include "ten_runtime/common/status_code.h"
+#include "ten_utils/lang/cpp/lib/value.h"
+#include "tests/ten_runtime/smoke/util/binding/cpp/check.h"
+
+namespace {
+
+// This part is the extension codes written by the developer, maintained in its
+// final release form, and will not change due to testing requirements.
+
+class test_extension : public ten::extension_t {
+ public:
+  explicit test_extension(const char *name) : ten::extension_t(name) {}
+
+  void on_cmd(ten::ten_env_t &ten_env,
+              std::unique_ptr<ten::cmd_t> cmd) override {
+    if (cmd->get_name() == "hello_world") {
+      auto src_loc = cmd->get_source();
+      EXPECT_EQ(*src_loc.app_uri, "test_app");
+      EXPECT_EQ(*src_loc.graph_id, "test_graph");
+      EXPECT_EQ(*src_loc.extension_name, "test_extension");
+      TEN_LOGI("src_loc.app_uri: %s", src_loc.app_uri->c_str());
+      TEN_LOGI("src_loc.graph_id: %s", src_loc.graph_id->c_str());
+      TEN_LOGI("src_loc.extension_name: %s", src_loc.extension_name->c_str());
+
+      auto cmd_result = ten::cmd_result_t::create(TEN_STATUS_CODE_OK, *cmd);
+      cmd_result->set_property("detail", "hello world, too");
+      bool rc = ten_env.return_result(std::move(cmd_result));
+      EXPECT_EQ(rc, true);
+    } else {
+      auto cmd_result = ten::cmd_result_t::create(TEN_STATUS_CODE_ERROR, *cmd);
+      bool rc = ten_env.return_result(std::move(cmd_result));
+      EXPECT_EQ(rc, true);
+    }
+  }
+};
+
+TEN_CPP_REGISTER_ADDON_AS_EXTENSION(
+    standalone_test_msg_custom_src__test_extension, test_extension);
+
+}  // namespace
+
+namespace {
+
+class extension_tester : public ten::extension_tester_t {
+ public:
+  void on_start(ten::ten_env_tester_t &ten_env) override {
+    // Send the first command to the extension.
+    auto new_cmd = ten::cmd_t::create("hello_world");
+
+    bool rc = ten_env.set_msg_source(*new_cmd,
+                                     {nullptr, "test_graph", "test_extension"});
+    EXPECT_EQ(rc, false);
+
+    rc = ten_env.set_msg_source(*new_cmd,
+                                {"test_app", "test_graph", "test_extension"});
+    EXPECT_EQ(rc, true);
+
+    ten_env.send_cmd(
+        std::move(new_cmd),
+        [](ten::ten_env_tester_t &ten_env,
+           std::unique_ptr<ten::cmd_result_t> result, ten::error_t *err) {
+          if (result->get_status_code() == TEN_STATUS_CODE_OK) {
+            ten_env.stop_test();
+          }
+        });
+
+    ten_env.on_start_done();
+  }
+};
+
+}  // namespace
+
+TEST(StandaloneTest, MsgCurtomSrc) {  // NOLINT
+  auto *tester = new extension_tester();
+  tester->set_test_mode_single(
+      "standalone_test_msg_custom_src__test_extension");
+
+  bool rc = tester->run();
+  TEN_ASSERT(rc, "Should not happen.");
+
+  delete tester;
+}


### PR DESCRIPTION
- Added support for custom source location in the msg_t structure with new fields and methods.
- Introduced `set_msg_source` method in ten_env_tester_t to set custom source location for messages.
- Updated related functions to handle the new custom source location logic.
- Enhanced message initialization and copying to include custom source location attributes.