### PR TITLE
refactor: improve argument validation in TEN_ASSERT statements across multiple files

### DIFF
--- a/core/src/ten_runtime/extension/extension.c
+++ b/core/src/ten_runtime/extension/extension.c
@@ -557,13 +557,13 @@ bool ten_extension_dispatch_msg(ten_extension_t *self, ten_shared_ptr_t *msg,
 
     ten_list_foreach (&result_msgs, iter) {
       ten_shared_ptr_t *result_msg = ten_smart_ptr_listnode_get(iter.node);
-      TEN_ASSERT(result_msg && ten_msg_check_integrity(result_msg),
-                 "Invalid argument.");
+      TEN_ASSERT(result_msg, "Invalid argument.");
+      TEN_ASSERT(ten_msg_check_integrity(result_msg), "Invalid argument.");
 
       ten_path_t *path = (ten_path_t *)ten_path_table_add_out_path(
           self->path_table, result_msg);
-      TEN_ASSERT(path && ten_path_check_integrity(path, true),
-                 "Should not happen.");
+      TEN_ASSERT(path, "Should not happen.");
+      TEN_ASSERT(ten_path_check_integrity(path, true), "Should not happen.");
 
       ten_list_push_ptr_back(&result_out_paths, path, NULL);
     }
@@ -581,8 +581,8 @@ bool ten_extension_dispatch_msg(ten_extension_t *self, ten_shared_ptr_t *msg,
 
   ten_list_foreach (&result_msgs, iter) {
     ten_shared_ptr_t *result_msg = ten_smart_ptr_listnode_get(iter.node);
-    TEN_ASSERT(result_msg && ten_msg_check_integrity(result_msg),
-               "Invalid argument.");
+    TEN_ASSERT(result_msg, "Invalid argument.");
+    TEN_ASSERT(ten_msg_check_integrity(result_msg), "Invalid argument.");
 
     ten_extension_thread_dispatch_msg(self->extension_thread, result_msg);
   }

--- a/core/src/ten_runtime/extension/internal/close.c
+++ b/core/src/ten_runtime/extension/internal/close.c
@@ -58,8 +58,8 @@ void ten_extension_flush_remaining_paths(ten_extension_t *extension) {
     // Generate an error result for each remaining out path.
     ten_list_foreach (out_paths, iter) {
       ten_path_t *path = (ten_path_t *)ten_ptr_listnode_get(iter.node);
-      TEN_ASSERT(path && ten_path_check_integrity(path, true),
-                 "Should not happen.");
+      TEN_ASSERT(path, "Should not happen.");
+      TEN_ASSERT(ten_path_check_integrity(path, true), "Should not happen.");
 
       ten_shared_ptr_t *cmd_result =
           ten_cmd_result_create(TEN_STATUS_CODE_ERROR);

--- a/core/src/ten_runtime/extension/internal/path_timer.c
+++ b/core/src/ten_runtime/extension/internal/path_timer.c
@@ -43,8 +43,8 @@ static void ten_extension_in_path_timer_on_triggered(ten_timer_t *self,
   size_t removed_count = 0;
   ten_list_foreach (in_paths, iter) {
     ten_path_t *path = (ten_path_t *)ten_ptr_listnode_get(iter.node);
-    TEN_ASSERT(path && ten_path_check_integrity(path, true),
-               "Should not happen.");
+    TEN_ASSERT(path, "Should not happen.");
+    TEN_ASSERT(ten_path_check_integrity(path, true), "Should not happen.");
 
     if (current_time_us >= path->expired_time_us) {
       ten_list_remove_node(in_paths, iter.node);
@@ -79,8 +79,8 @@ static void ten_extension_out_path_timer_on_triggered(ten_timer_t *self,
   ten_list_t timeout_cmd_result_list = TEN_LIST_INIT_VAL;
   ten_list_foreach (out_paths, iter) {
     ten_path_t *path = (ten_path_t *)ten_ptr_listnode_get(iter.node);
-    TEN_ASSERT(path && ten_path_check_integrity(path, true),
-               "Should not happen.");
+    TEN_ASSERT(path, "Should not happen.");
+    TEN_ASSERT(ten_path_check_integrity(path, true), "Should not happen.");
 
     if (current_time_us >= path->expired_time_us) {
       ten_shared_ptr_t *cmd_result =

--- a/core/src/ten_runtime/path/path_table.c
+++ b/core/src/ten_runtime/path/path_table.c
@@ -136,8 +136,8 @@ static ten_listnode_t *ten_path_table_find_path_from_cmd_id(
 
   ten_list_foreach (list, paths_iter) {
     ten_path_t *path = (ten_path_t *)ten_ptr_listnode_get(paths_iter.node);
-    TEN_ASSERT(path && ten_path_check_integrity(path, true),
-               "Should not happen.");
+    TEN_ASSERT(path, "Should not happen.");
+    TEN_ASSERT(ten_path_check_integrity(path, true), "Should not happen.");
 
     // TEN_LOGD("path(%s) cmd_id: %s, cmd_id: %s",
     //          type == TEN_PATH_IN ? "in" : "out",

--- a/core/src/ten_runtime/test/env_tester.c
+++ b/core/src/ten_runtime/test/env_tester.c
@@ -49,7 +49,8 @@ bool ten_env_tester_check_integrity(ten_env_tester_t *self, bool check_thread) {
 }
 
 ten_env_tester_t *ten_env_tester_create(ten_extension_tester_t *tester) {
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_env_tester_t *self = TEN_MALLOC(sizeof(ten_env_tester_t));
@@ -315,7 +316,8 @@ static void ten_env_tester_notify_log_ctx_destroy(
 static void ten_extension_tester_execute_error_handler_task(void *self,
                                                             void *arg) {
   ten_extension_tester_t *tester = self;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_env_tester_send_msg_ctx_t *ctx = arg;
@@ -329,7 +331,8 @@ static void ten_extension_tester_execute_error_handler_task(void *self,
 static void ten_extension_tester_execute_cmd_result_handler_task(void *self,
                                                                  void *arg) {
   ten_extension_tester_t *tester = self;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_env_tester_send_cmd_callback_ctx_t *ctx = arg;
@@ -351,7 +354,8 @@ static void ten_extension_tester_execute_cmd_result_handler_task(void *self,
 static void ten_extension_tester_execute_return_result_handler_task(void *self,
                                                                     void *arg) {
   ten_extension_tester_t *tester = self;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_env_tester_return_result_ctx_t *return_result_info = arg;

--- a/core/src/ten_runtime/test/extension_tester.c
+++ b/core/src/ten_runtime/test/extension_tester.c
@@ -261,11 +261,11 @@ static void ten_extension_tester_destroy_test_target(
 
 void ten_extension_tester_destroy(ten_extension_tester_t *self) {
   TEN_ASSERT(self, "Invalid argument.");
-  TEN_ASSERT(
-      // TEN_NOLINTNEXTLINE(thread-check)
-      // thread-check: In TEN world, the destroy operations need to be performed
-      // in any threads.
-      ten_extension_tester_check_integrity(self, false), "Invalid argument.");
+  // TEN_NOLINTNEXTLINE(thread-check)
+  // thread-check: In TEN world, the destroy operations need to be performed in
+  // any threads.
+  TEN_ASSERT(ten_extension_tester_check_integrity(self, false),
+             "Invalid argument.");
 
   // The `ten_env_proxy` of `test_app` should be released in the tester task
   // triggered by the `deinit` of `test_app`.

--- a/core/src/ten_runtime/test/test_extension.c
+++ b/core/src/ten_runtime/test/test_extension.c
@@ -39,7 +39,8 @@ static ten_extension_tester_t *test_extension_get_extension_tester_ptr(
 
 static void test_extension_on_configure(ten_extension_t *self,
                                         ten_env_t *ten_env) {
-  TEN_ASSERT(self && ten_env, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env, "Invalid argument.");
 
 #if defined(_DEBUG)
   ten_random_sleep_range_ms(0, 1000);
@@ -63,7 +64,8 @@ static void test_extension_on_configure(ten_extension_t *self,
 static void ten_extension_tester_on_test_extension_init_task(
     void *self_, TEN_UNUSED void *arg) {
   ten_extension_tester_t *tester = self_;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_extension_tester_on_test_extension_init(tester);
@@ -72,7 +74,8 @@ static void ten_extension_tester_on_test_extension_init_task(
 static void ten_extension_tester_on_test_extension_start_task(
     void *self_, TEN_UNUSED void *arg) {
   ten_extension_tester_t *tester = self_;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_extension_tester_on_test_extension_start(tester);
@@ -81,14 +84,16 @@ static void ten_extension_tester_on_test_extension_start_task(
 static void ten_extension_tester_on_test_extension_stop_task(
     void *self_, TEN_UNUSED void *arg) {
   ten_extension_tester_t *tester = self_;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_extension_tester_on_test_extension_stop(tester);
 }
 
 static void test_extension_on_init(ten_extension_t *self, ten_env_t *ten_env) {
-  TEN_ASSERT(self && ten_env, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env, "Invalid argument.");
 
 #if defined(_DEBUG)
   ten_random_sleep_range_ms(0, 1000);
@@ -111,7 +116,8 @@ static void test_extension_on_init(ten_extension_t *self, ten_env_t *ten_env) {
 }
 
 static void test_extension_on_start(ten_extension_t *self, ten_env_t *ten_env) {
-  TEN_ASSERT(self && ten_env, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env, "Invalid argument.");
 
 #if defined(_DEBUG)
   ten_random_sleep_range_ms(0, 1000);
@@ -134,7 +140,8 @@ static void test_extension_on_start(ten_extension_t *self, ten_env_t *ten_env) {
 }
 
 static void test_extension_on_stop(ten_extension_t *self, ten_env_t *ten_env) {
-  TEN_ASSERT(self && ten_env, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env, "Invalid argument.");
 
 #if defined(_DEBUG)
   ten_random_sleep_range_ms(0, 1000);
@@ -195,7 +202,8 @@ void ten_builtin_test_extension_ten_env_notify_on_deinit_done(
 static void ten_extension_tester_on_test_extension_cmd_task(void *self_,
                                                             void *arg) {
   ten_extension_tester_t *tester = self_;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_shared_ptr_t *cmd = arg;
@@ -210,7 +218,8 @@ static void ten_extension_tester_on_test_extension_cmd_task(void *self_,
 
 static void test_extension_on_cmd(ten_extension_t *self, ten_env_t *ten_env,
                                   ten_shared_ptr_t *cmd) {
-  TEN_ASSERT(self && ten_env, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env, "Invalid argument.");
 
   ten_extension_tester_t *tester = self->user_data;
   TEN_ASSERT(tester, "Should not happen.");
@@ -230,7 +239,8 @@ static void test_extension_on_cmd(ten_extension_t *self, ten_env_t *ten_env,
 static void ten_extension_tester_on_test_extension_data_task(void *self_,
                                                              void *arg) {
   ten_extension_tester_t *tester = self_;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_shared_ptr_t *data = arg;
@@ -245,7 +255,8 @@ static void ten_extension_tester_on_test_extension_data_task(void *self_,
 
 static void test_extension_on_data(ten_extension_t *self, ten_env_t *ten_env,
                                    ten_shared_ptr_t *data) {
-  TEN_ASSERT(self && ten_env, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env, "Invalid argument.");
 
   ten_extension_tester_t *tester = self->user_data;
   TEN_ASSERT(tester, "Should not happen.");
@@ -265,7 +276,8 @@ static void test_extension_on_data(ten_extension_t *self, ten_env_t *ten_env,
 static void ten_extension_tester_on_test_extension_audio_frame_task(void *self_,
                                                                     void *arg) {
   ten_extension_tester_t *tester = self_;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_shared_ptr_t *audio_frame = arg;
@@ -281,7 +293,8 @@ static void ten_extension_tester_on_test_extension_audio_frame_task(void *self_,
 static void test_extension_on_audio_frame(ten_extension_t *self,
                                           ten_env_t *ten_env,
                                           ten_shared_ptr_t *audio_frame) {
-  TEN_ASSERT(self && ten_env, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env, "Invalid argument.");
 
   ten_extension_tester_t *tester = self->user_data;
   TEN_ASSERT(tester, "Should not happen.");
@@ -303,7 +316,8 @@ static void test_extension_on_audio_frame(ten_extension_t *self,
 static void ten_extension_tester_on_test_extension_video_frame_task(void *self_,
                                                                     void *arg) {
   ten_extension_tester_t *tester = self_;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_shared_ptr_t *video_frame = arg;
@@ -319,7 +333,8 @@ static void ten_extension_tester_on_test_extension_video_frame_task(void *self_,
 static void test_extension_on_video_frame(ten_extension_t *self,
                                           ten_env_t *ten_env,
                                           ten_shared_ptr_t *video_frame) {
-  TEN_ASSERT(self && ten_env, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env, "Invalid argument.");
 
   ten_extension_tester_t *tester = self->user_data;
   TEN_ASSERT(tester, "Should not happen.");
@@ -341,7 +356,8 @@ static void test_extension_on_video_frame(ten_extension_t *self,
 static void ten_extension_tester_on_test_extension_deinit_task(
     void *self_, TEN_UNUSED void *arg) {
   ten_extension_tester_t *tester = self_;
-  TEN_ASSERT(tester && ten_extension_tester_check_integrity(tester, true),
+  TEN_ASSERT(tester, "Invalid argument.");
+  TEN_ASSERT(ten_extension_tester_check_integrity(tester, true),
              "Invalid argument.");
 
   ten_extension_tester_on_test_extension_deinit(tester);
@@ -349,7 +365,8 @@ static void ten_extension_tester_on_test_extension_deinit_task(
 
 static void test_extension_on_deinit(ten_extension_t *self,
                                      ten_env_t *ten_env) {
-  TEN_ASSERT(self && ten_env, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(ten_env, "Invalid argument.");
 
 #if defined(_DEBUG)
   ten_random_sleep_range_ms(0, 1000);


### PR DESCRIPTION
- Updated TEN_ASSERT statements to separate null checks and integrity checks for better clarity and
maintainability.
- Ensured consistent error messaging for invalid arguments in various functions related to path
handling and extension testing.