### PR TITLE
feat: implement standalone test extension support in the extension module

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -137,7 +137,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/out/linux/x64/tests/standalone/ten_runtime_smoke_test",
       "args": [
-        "--gtest_filter=ExtensionTest.WrongEngineThenCorrectInMigration"
+        "--gtest_filter=StandaloneTest.OnCmd"
       ],
       "cwd": "${workspaceFolder}/out/linux/x64/tests/standalone/",
       "env": {

--- a/core/include_internal/ten_runtime/app/app.h
+++ b/core/include_internal/ten_runtime/app/app.h
@@ -17,6 +17,7 @@
 #include "include_internal/ten_runtime/schema_store/store.h"
 #include "ten_runtime/app/app.h"
 #include "ten_runtime/ten_env/ten_env.h"
+#include "ten_runtime/test/extension_tester.h"
 #include "ten_utils/container/list.h"
 #include "ten_utils/io/runloop.h"
 #include "ten_utils/lib/mutex.h"
@@ -148,6 +149,7 @@ typedef struct ten_app_t {
   bool preload_all_addons;
 
   bool is_standalone_test_app;
+  TEN_EXTENSION_TESTER_TEST_MODE standalone_test_mode;
   ten_string_t standalone_tested_target_name;
 
   void *user_data;

--- a/core/include_internal/ten_runtime/common/constant_str.h
+++ b/core/include_internal/ten_runtime/common/constant_str.h
@@ -164,7 +164,6 @@
 #define TEN_STR_APP "app"
 #define TEN_STR_NAME "name"
 #define TEN_STR_TEN "ten"
-#define TEN_STR_STAR "*"
 #define TEN_STR_ADDON_BASE_DIR_FIND_FROM_APP_BASE_DIR "=*=find_from_app=*="
 
 // Services.

--- a/core/include_internal/ten_runtime/extension/extension.h
+++ b/core/include_internal/ten_runtime/extension/extension.h
@@ -225,6 +225,8 @@ struct ten_extension_t {
   // output messages.
   ten_hashtable_t msg_not_connected_count_map;
 
+  bool is_standalone_test_extension;
+
   void *user_data;
 };
 

--- a/core/include_internal/ten_runtime/extension/test.h
+++ b/core/include_internal/ten_runtime/extension/test.h
@@ -11,5 +11,8 @@
 #include "include_internal/ten_runtime/common/loc.h"
 #include "ten_runtime/extension/extension.h"
 
-TEN_RUNTIME_PRIVATE_API void ten_adjust_dest_loc_for_standalone_test_scenario(
-    ten_loc_t *dest_loc, ten_extension_t *from_extension);
+TEN_RUNTIME_PRIVATE_API void ten_adjust_msg_dest_for_standalone_test_scenario(
+    ten_shared_ptr_t *msg, ten_extension_t *from_extension);
+
+TEN_RUNTIME_PRIVATE_API void ten_add_msg_dest_for_standalone_test_scenario(
+    ten_shared_ptr_t *msg, ten_extension_t *from_extension);

--- a/core/include_internal/ten_runtime/extension/test.h
+++ b/core/include_internal/ten_runtime/extension/test.h
@@ -14,5 +14,5 @@
 TEN_RUNTIME_PRIVATE_API void ten_adjust_msg_dest_for_standalone_test_scenario(
     ten_shared_ptr_t *msg, ten_extension_t *from_extension);
 
-TEN_RUNTIME_PRIVATE_API void ten_add_msg_dest_for_standalone_test_scenario(
+TEN_RUNTIME_PRIVATE_API bool ten_add_msg_dest_for_standalone_test_scenario(
     ten_shared_ptr_t *msg, ten_extension_t *from_extension);

--- a/core/include_internal/ten_runtime/extension/test.h
+++ b/core/include_internal/ten_runtime/extension/test.h
@@ -1,0 +1,15 @@
+//
+// Copyright © 2025 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+#pragma once
+
+#include "ten_runtime/ten_config.h"
+
+#include "include_internal/ten_runtime/common/loc.h"
+#include "ten_runtime/extension/extension.h"
+
+TEN_RUNTIME_PRIVATE_API void ten_adjust_dest_loc_for_standalone_test_scenario(
+    ten_loc_t *dest_loc, ten_extension_t *from_extension);

--- a/core/include_internal/ten_runtime/test/env_tester.h
+++ b/core/include_internal/ten_runtime/test/env_tester.h
@@ -11,7 +11,6 @@
 #include <stdbool.h>
 
 #include "include_internal/ten_runtime/binding/common.h"
-#include "ten_runtime/msg/msg.h"
 #include "ten_utils/lib/signature.h"
 
 #define TEN_ENV_TESTER_SIGNATURE 0x66C619FBA7DC8BD9U

--- a/core/src/ten_runtime/app/app.c
+++ b/core/src/ten_runtime/app/app.c
@@ -162,6 +162,7 @@ ten_app_t *ten_app_create(ten_app_on_configure_func_t on_configure,
   self->preload_all_addons = false;
 
   self->is_standalone_test_app = false;
+  self->standalone_test_mode = TEN_EXTENSION_TESTER_TEST_MODE_INVALID;
   TEN_STRING_INIT(self->standalone_tested_target_name);
 
   self->user_data = NULL;

--- a/core/src/ten_runtime/extension/extension.c
+++ b/core/src/ten_runtime/extension/extension.c
@@ -12,7 +12,6 @@
 #include <time.h>
 
 #include "include_internal/ten_runtime/addon/addon_host.h"
-#include "include_internal/ten_runtime/app/app.h"
 #include "include_internal/ten_runtime/common/constant_str.h"
 #include "include_internal/ten_runtime/common/loc.h"
 #include "include_internal/ten_runtime/engine/engine.h"
@@ -309,13 +308,7 @@ static void ten_extension_determine_out_msg_dest_from_msg(
 
     ten_msg_clear_and_set_dest_to_loc(curr_msg, dest_loc);
 
-    ten_loc_t *dest_loc_in_curr_msg = ten_msg_get_first_dest_loc(curr_msg);
-    TEN_ASSERT(dest_loc_in_curr_msg, "Should not happen.");
-    TEN_ASSERT(ten_loc_check_integrity(dest_loc_in_curr_msg),
-               "Should not happen.");
-
-    ten_adjust_dest_loc_for_standalone_test_scenario(dest_loc_in_curr_msg,
-                                                     self);
+    ten_adjust_msg_dest_for_standalone_test_scenario(curr_msg, self);
 
     ten_list_push_smart_ptr_back(result_msgs, curr_msg);
 
@@ -379,13 +372,7 @@ static bool ten_extension_determine_out_msg_dest_from_graph(
         ten_msg_clear_and_set_dest_from_extension_info(curr_msg,
                                                        dest_extension_info);
 
-        ten_loc_t *dest_loc_in_curr_msg = ten_msg_get_first_dest_loc(curr_msg);
-        TEN_ASSERT(dest_loc_in_curr_msg, "Should not happen.");
-        TEN_ASSERT(ten_loc_check_integrity(dest_loc_in_curr_msg),
-                   "Should not happen.");
-
-        ten_adjust_dest_loc_for_standalone_test_scenario(dest_loc_in_curr_msg,
-                                                         self);
+        ten_adjust_msg_dest_for_standalone_test_scenario(curr_msg, self);
 
         ten_list_push_smart_ptr_back(result_msgs, curr_msg);
 
@@ -400,30 +387,7 @@ static bool ten_extension_determine_out_msg_dest_from_graph(
 
   // Graph doesn't specify how to route the messages.
 
-  ten_engine_t *engine = self->extension_context->engine;
-  TEN_ASSERT(engine, "Invalid argument.");
-  TEN_ASSERT(ten_engine_check_integrity(engine, false),
-             "Invalid use of engine %p.", engine);
-
-  ten_app_t *app = engine->app;
-  TEN_ASSERT(app, "Invalid argument.");
-  TEN_ASSERT(ten_app_check_integrity(app, false), "Invalid use of app %p.",
-             app);
-
-  if (app->is_standalone_test_app) {
-    const char *target_extension_name = NULL;
-
-    if (self->is_standalone_test_extension) {
-      // =-=-=
-      target_extension_name =
-          ten_string_get_raw_str(&app->standalone_tested_target_name);
-    } else {
-      target_extension_name = TEN_STR_TEN_TEST_EXTENSION;
-    }
-
-    ten_msg_add_dest(msg, ten_app_get_uri(app),
-                     ten_engine_get_id(engine, false), target_extension_name);
-  }
+  ten_add_msg_dest_for_standalone_test_scenario(msg, self);
 
   if (ten_msg_get_dest_cnt(msg) == 0) {
     TEN_MSG_TYPE msg_type = ten_msg_get_type(msg);

--- a/core/src/ten_runtime/extension/extension.c
+++ b/core/src/ten_runtime/extension/extension.c
@@ -387,24 +387,22 @@ static bool ten_extension_determine_out_msg_dest_from_graph(
 
   // Graph doesn't specify how to route the messages.
 
-  ten_add_msg_dest_for_standalone_test_scenario(msg, self);
-
-  if (ten_msg_get_dest_cnt(msg) == 0) {
-    TEN_MSG_TYPE msg_type = ten_msg_get_type(msg);
-    const char *msg_name = ten_msg_get_name(msg);
-
-    // In any case, the user needs to be informed about the error where the
-    // graph does not have a specified destination for the message.
-    TEN_ASSERT(err, "Should not happen.");
-    ten_error_set(
-        err, TEN_ERROR_CODE_MSG_NOT_CONNECTED,
-        "Failed to find destination of a '%s' message '%s' from graph.",
-        ten_msg_type_to_string(msg_type), msg_name);
-
-    return false;
-  } else {
+  if (ten_add_msg_dest_for_standalone_test_scenario(msg, self)) {
+    ten_list_push_smart_ptr_back(result_msgs, msg);
     return true;
   }
+
+  TEN_MSG_TYPE msg_type = ten_msg_get_type(msg);
+  const char *msg_name = ten_msg_get_name(msg);
+
+  // In any case, the user needs to be informed about the error where the
+  // graph does not have a specified destination for the message.
+  TEN_ASSERT(err, "Should not happen.");
+  ten_error_set(err, TEN_ERROR_CODE_MSG_NOT_CONNECTED,
+                "Failed to find destination of a '%s' message '%s' from graph.",
+                ten_msg_type_to_string(msg_type), msg_name);
+
+  return false;
 }
 
 typedef enum TEN_EXTENSION_DETERMINE_OUT_MSGS_RESULT {

--- a/core/src/ten_runtime/extension/msg_dest_info/msg_dest_info.c
+++ b/core/src/ten_runtime/extension/msg_dest_info/msg_dest_info.c
@@ -105,10 +105,5 @@ bool ten_msg_dest_info_qualified(ten_msg_dest_info_t *self,
     return true;
   }
 
-  // "*" is a special rule that matches all names.
-  if (ten_string_is_equal_c_str(&self->name, TEN_STR_STAR)) {
-    return true;
-  }
-
   return false;
 }

--- a/core/src/ten_runtime/extension/test.c
+++ b/core/src/ten_runtime/extension/test.c
@@ -1,0 +1,48 @@
+//
+// Copyright © 2025 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+#include "include_internal/ten_runtime/app/app.h"
+#include "include_internal/ten_runtime/common/constant_str.h"
+#include "include_internal/ten_runtime/common/loc.h"
+#include "include_internal/ten_runtime/engine/engine.h"
+#include "include_internal/ten_runtime/extension/extension.h"
+#include "include_internal/ten_runtime/extension_context/extension_context.h"
+
+void ten_adjust_dest_loc_for_standalone_test_scenario(
+    ten_loc_t *dest_loc, ten_extension_t *from_extension) {
+  TEN_ASSERT(dest_loc, "Invalid argument.");
+  TEN_ASSERT(ten_loc_check_integrity(dest_loc), "Invalid argument.");
+
+  TEN_ASSERT(from_extension, "Invalid argument.");
+  TEN_ASSERT(ten_extension_check_integrity(from_extension, true),
+             "Invalid argument.");
+
+  ten_engine_t *engine = from_extension->extension_context->engine;
+  TEN_ASSERT(engine, "Invalid argument.");
+  TEN_ASSERT(ten_engine_check_integrity(engine, false),
+             "Invalid use of engine %p.", engine);
+
+  ten_app_t *app = engine->app;
+  TEN_ASSERT(app, "Invalid argument.");
+  TEN_ASSERT(ten_app_check_integrity(app, false), "Invalid use of app %p.",
+             app);
+
+  if (app->is_standalone_test_app) {
+    bool is_test_extension = from_extension->is_standalone_test_extension;
+    const char *target_extension_name = NULL;
+
+    if (is_test_extension) {
+      // =-=-=
+      target_extension_name =
+          ten_string_get_raw_str(&app->standalone_tested_target_name);
+    } else {
+      target_extension_name = TEN_STR_TEN_TEST_EXTENSION;
+    }
+
+    ten_loc_set(dest_loc, ten_app_get_uri(app),
+                ten_engine_get_id(engine, false), target_extension_name);
+  }
+}

--- a/core/src/ten_runtime/extension/test.c
+++ b/core/src/ten_runtime/extension/test.c
@@ -52,7 +52,7 @@ void ten_adjust_msg_dest_for_standalone_test_scenario(
   }
 }
 
-void ten_add_msg_dest_for_standalone_test_scenario(
+bool ten_add_msg_dest_for_standalone_test_scenario(
     ten_shared_ptr_t *msg, ten_extension_t *from_extension) {
   TEN_ASSERT(msg, "Invalid argument.");
   TEN_ASSERT(ten_msg_check_integrity(msg), "Invalid argument.");
@@ -84,5 +84,9 @@ void ten_add_msg_dest_for_standalone_test_scenario(
 
     ten_msg_add_dest(msg, ten_app_get_uri(app),
                      ten_engine_get_id(engine, false), target_extension_name);
+
+    return true;
   }
+
+  return false;
 }

--- a/core/src/ten_runtime/msg/msg.c
+++ b/core/src/ten_runtime/msg/msg.c
@@ -500,7 +500,11 @@ void ten_msg_clear_and_set_dest_from_extension_info(
   TEN_ASSERT(ten_extension_info_check_integrity(extension_info, false),
              "Invalid use of extension_info %p.", extension_info);
 
-  ten_msg_clear_and_set_dest_to_loc(self, &extension_info->loc);
+  ten_loc_t *dest_loc = &extension_info->loc;
+  TEN_ASSERT(dest_loc, "Should not happen.");
+  TEN_ASSERT(ten_loc_check_integrity(dest_loc), "Should not happen.");
+
+  ten_msg_clear_and_set_dest_to_loc(self, dest_loc);
 }
 
 ten_list_t *ten_msg_get_dest(ten_shared_ptr_t *self) {

--- a/core/src/ten_runtime/test/extension_tester.c
+++ b/core/src/ten_runtime/test/extension_tester.c
@@ -469,7 +469,9 @@ static void test_app_ten_env_send_graph_info(ten_env_t *ten_env,
   ten_extension_tester_test_graph_info_t *test_graph_info = user_data;
   TEN_ASSERT(test_graph_info, "Should not happen.");
 
+  // Mark this app as a standalone test app.
   app->is_standalone_test_app = true;
+  app->standalone_test_mode = test_graph_info->test_mode;
   ten_string_set_formatted(
       &app->standalone_tested_target_name, "%s",
       ten_string_get_raw_str(&test_graph_info->test_target.single.addon_name));

--- a/core/src/ten_runtime/test/extension_tester.c
+++ b/core/src/ten_runtime/test/extension_tester.c
@@ -355,82 +355,19 @@ static ten_shared_ptr_t *create_start_graph_cmd(
     ten_string_t graph_json_str;
     ten_string_init_formatted(&graph_json_str,
                               "{\
-             \"nodes\": [{\
-                \"type\": \"extension\",\
-                \"name\": \"ten:test_extension\",\
-                \"addon\": \"ten:test_extension\",\
-                \"extension_group\": \"test_extension_group_1\"\
-             },{\
-                \"type\": \"extension\",\
-                \"name\": \"%s\",\
-                \"addon\": \"%s\",\
-                \"extension_group\": \"test_extension_group_2\",\
-                \"property\": %s\
-             }],\
-             \"connections\": [{\
-               \"extension_group\": \"test_extension_group_1\",\
-               \"extension\": \"ten:test_extension\",\
-               \"cmd\": [{\
-                 \"name\": \"*\",\
-                 \"dest\": [{\
-                    \"extension_group\": \"test_extension_group_2\",\
-                    \"extension\": \"%s\"\
-                 }]\
-               }],\
-               \"data\": [{\
-                 \"name\": \"*\",\
-                 \"dest\": [{\
-                    \"extension_group\": \"test_extension_group_2\",\
-                    \"extension\": \"%s\"\
-                 }]\
-               }],\
-               \"video_frame\": [{\
-                 \"name\": \"*\",\
-                 \"dest\": [{\
-                    \"extension_group\": \"test_extension_group_2\",\
-                    \"extension\": \"%s\"\
-                 }]\
-               }],\
-               \"audio_frame\": [{\
-                 \"name\": \"*\",\
-                 \"dest\": [{\
-                    \"extension_group\": \"test_extension_group_2\",\
-                    \"extension\": \"%s\"\
-                 }]\
-               }]\
-             },{\
-               \"extension_group\": \"test_extension_group_2\",\
-               \"extension\": \"%s\",\
-               \"cmd\": [{\
-                 \"name\": \"*\",\
-                 \"dest\": [{\
-                    \"extension_group\": \"test_extension_group_1\",\
-                    \"extension\": \"ten:test_extension\"\
-                 }]\
-               }],\
-               \"data\": [{\
-                 \"name\": \"*\",\
-                 \"dest\": [{\
-                    \"extension_group\": \"test_extension_group_1\",\
-                    \"extension\": \"ten:test_extension\"\
-                 }]\
-               }],\
-               \"video_frame\": [{\
-                 \"name\": \"*\",\
-                 \"dest\": [{\
-                    \"extension_group\": \"test_extension_group_1\",\
-                    \"extension\": \"ten:test_extension\"\
-                 }]\
-               }],\
-               \"audio_frame\": [{\
-                 \"name\": \"*\",\
-                 \"dest\": [{\
-                    \"extension_group\": \"test_extension_group_1\",\
-                    \"extension\": \"ten:test_extension\"\
-                 }]\
-               }]\
-             }]\
-         }",
+      \"nodes\": [{\
+         \"type\": \"extension\",\
+         \"name\": \"ten:test_extension\",\
+         \"addon\": \"ten:test_extension\",\
+         \"extension_group\": \"test_extension_group_1\"\
+      },{\
+         \"type\": \"extension\",\
+         \"name\": \"%s\",\
+         \"addon\": \"%s\",\
+         \"extension_group\": \"test_extension_group_2\",\
+         \"property\": %s\
+      }]\
+    }",
                               addon_name, addon_name, property_json_str,
                               addon_name, addon_name, addon_name, addon_name,
                               addon_name);

--- a/core/src/ten_runtime/test/test_extension.c
+++ b/core/src/ten_runtime/test/test_extension.c
@@ -403,6 +403,9 @@ static void test_extension_addon_create_instance(ten_addon_t *addon,
       test_extension_on_cmd, test_extension_on_data,
       test_extension_on_audio_frame, test_extension_on_video_frame, NULL);
 
+  // Mark this extension as a standalone test extension.
+  extension->is_standalone_test_extension = true;
+
   ten_env_on_create_instance_done(ten_env, extension, context, NULL);
 }
 


### PR DESCRIPTION
- Added a new boolean field `is_standalone_test_extension` to the `ten_extension_t` structure to
identify standalone test extensions.
- Updated the `ten_extension_create` function to initialize this field.
- Enhanced message destination determination logic to handle standalone test scenarios.
- Modified the test extension creation to mark it as a standalone test extension.