### PR TITLE
feat: introduce hash table support in msg_dest_info structures and add is_empty check

### DIFF
--- a/core/include/ten_utils/container/hash_table.h
+++ b/core/include/ten_utils/container/hash_table.h
@@ -95,6 +95,8 @@ TEN_UTILS_API void ten_hashtable_destroy(ten_hashtable_t *self);
 
 TEN_UTILS_API uint32_t ten_hashtable_items_cnt(ten_hashtable_t *self);
 
+TEN_UTILS_API bool ten_hashtable_is_empty(ten_hashtable_t *self);
+
 TEN_UTILS_API void ten_hashtable_init(ten_hashtable_t *self,
                                       ptrdiff_t hh_offset);
 

--- a/core/include_internal/ten_runtime/extension/msg_dest_info/all_msg_type_dest_info.h
+++ b/core/include_internal/ten_runtime/extension/msg_dest_info/all_msg_type_dest_info.h
@@ -8,15 +8,16 @@
 
 #include "ten_runtime/ten_config.h"
 
-#include "ten_utils/container/list.h"
+#include "ten_utils/container/hash_table.h"
 
 typedef struct ten_extension_t ten_extension_t;
 
+// key: string, value: ten_msg_dest_info_t
 typedef struct ten_all_msg_type_dest_info_t {
-  ten_list_t cmd;          // ptr of ten_msg_dest_info_t
-  ten_list_t data;         // ptr of ten_msg_dest_info_t
-  ten_list_t video_frame;  // ptr of ten_msg_dest_info_t
-  ten_list_t audio_frame;  // ptr of ten_msg_dest_info_t
+  ten_hashtable_t cmd;
+  ten_hashtable_t data;
+  ten_hashtable_t audio_frame;
+  ten_hashtable_t video_frame;
 } ten_all_msg_type_dest_info_t;
 
 TEN_RUNTIME_PRIVATE_API void ten_all_msg_type_dest_info_init(

--- a/core/include_internal/ten_runtime/extension/msg_dest_info/msg_dest_info.h
+++ b/core/include_internal/ten_runtime/extension/msg_dest_info/msg_dest_info.h
@@ -8,10 +8,10 @@
 
 #include "ten_runtime/ten_config.h"
 
+#include "ten_utils/container/hash_handle.h"
 #include "ten_utils/container/list.h"
 #include "ten_utils/lib/error.h"
 #include "ten_utils/lib/signature.h"
-#include "ten_utils/lib/smart_ptr.h"
 #include "ten_utils/lib/string.h"
 
 #define TEN_MSG_DEST_STATIC_INFO_SIGNATURE 0x43B5CAAF1BB9BC41U
@@ -19,6 +19,9 @@
 
 typedef struct ten_msg_dest_info_t {
   ten_signature_t signature;
+
+  ten_hashhandle_t hh_in_all_msg_type_dest_info;
+
   ten_string_t name;  // The name of a message or an interface.
   ten_list_t dest;    // ten_weak_ptr_t of ten_extension_info_t
 } ten_msg_dest_info_t;

--- a/core/src/ten_runtime/extension/extension.c
+++ b/core/src/ten_runtime/extension/extension.c
@@ -217,7 +217,7 @@ void ten_extension_destroy(ten_extension_t *self) {
 }
 
 static ten_msg_dest_info_t *ten_extension_get_msg_dests_from_graph_internal(
-    ten_list_t *dest_info_list, ten_shared_ptr_t *msg) {
+    ten_hashtable_t *dest_info_list, ten_shared_ptr_t *msg) {
   TEN_ASSERT(dest_info_list, "Should not happen.");
   TEN_ASSERT(msg, "Should not happen.");
 
@@ -225,11 +225,11 @@ static ten_msg_dest_info_t *ten_extension_get_msg_dests_from_graph_internal(
   TEN_ASSERT(msg_name, "Should not happen.");
   TEN_ASSERT(strlen(msg_name) > 0, "Should not happen.");
 
-  // TODO(Wei): Use hash table to speed up the findings.
-  ten_listnode_t *msg_dest_info_node = ten_list_find_ptr_custom(
-      dest_info_list, msg_name, ten_msg_dest_info_qualified);
-  if (msg_dest_info_node) {
-    ten_msg_dest_info_t *msg_dest = ten_ptr_listnode_get(msg_dest_info_node);
+  ten_hashhandle_t *msg_dest_info_hh =
+      ten_hashtable_find_string(dest_info_list, msg_name);
+  if (msg_dest_info_hh) {
+    ten_msg_dest_info_t *msg_dest = CONTAINER_OF_FROM_FIELD(
+        msg_dest_info_hh, ten_msg_dest_info_t, hh_in_all_msg_type_dest_info);
     TEN_ASSERT(msg_dest, "Should not happen.");
     TEN_ASSERT(ten_msg_dest_info_check_integrity(msg_dest),
                "Should not happen.");
@@ -254,12 +254,12 @@ static ten_msg_dest_info_t *ten_extension_get_msg_dests_from_graph(
     case TEN_MSG_TYPE_DATA:
       return ten_extension_get_msg_dests_from_graph_internal(
           &self->extension_info->msg_dest_info.data, msg);
-    case TEN_MSG_TYPE_VIDEO_FRAME:
-      return ten_extension_get_msg_dests_from_graph_internal(
-          &self->extension_info->msg_dest_info.video_frame, msg);
     case TEN_MSG_TYPE_AUDIO_FRAME:
       return ten_extension_get_msg_dests_from_graph_internal(
           &self->extension_info->msg_dest_info.audio_frame, msg);
+    case TEN_MSG_TYPE_VIDEO_FRAME:
+      return ten_extension_get_msg_dests_from_graph_internal(
+          &self->extension_info->msg_dest_info.video_frame, msg);
     default:
       TEN_ASSERT(0, "Should not happen.");
       return NULL;

--- a/core/src/ten_runtime/extension/extension_info/json.c
+++ b/core/src/ten_runtime/extension/extension_info/json.c
@@ -17,12 +17,18 @@
 #include "ten_utils/lib/string.h"
 #include "ten_utils/macro/check.h"
 
-static bool pack_msg_dest(ten_extension_info_t *self, ten_list_t *msg_dests,
-                          ten_json_t *msg_json, ten_error_t *err) {
+static bool pack_msg_dest(ten_extension_info_t *self,
+                          ten_hashtable_t *msg_dests, ten_json_t *msg_json,
+                          ten_error_t *err) {
   TEN_ASSERT(msg_json, "Should not happen.");
 
-  ten_list_foreach (msg_dests, iter) {
-    ten_msg_dest_info_t *msg_dest = ten_ptr_listnode_get(iter.node);
+  ten_hashtable_foreach(msg_dests, iter) {
+    ten_hashhandle_t *hh = iter.node;
+    ten_msg_dest_info_t *msg_dest =
+        CONTAINER_OF_FROM_OFFSET(hh, msg_dests->hh_offset);
+    TEN_ASSERT(msg_dest, "Should not happen.");
+    TEN_ASSERT(ten_msg_dest_info_check_integrity(msg_dest),
+               "Should not happen.");
 
     ten_json_t msg_dest_json = TEN_JSON_INIT_VAL(msg_json->ctx, false);
     ten_json_init_object(&msg_dest_json);
@@ -98,10 +104,10 @@ int ten_extension_info_connections_to_json(ten_extension_info_t *self,
              "Should not happen.");
   TEN_ASSERT(json, "Invalid argument.");
 
-  if (ten_list_is_empty(&self->msg_dest_info.cmd) &&
-      ten_list_is_empty(&self->msg_dest_info.data) &&
-      ten_list_is_empty(&self->msg_dest_info.video_frame) &&
-      ten_list_is_empty(&self->msg_dest_info.audio_frame) &&
+  if (ten_hashtable_is_empty(&self->msg_dest_info.cmd) &&
+      ten_hashtable_is_empty(&self->msg_dest_info.data) &&
+      ten_hashtable_is_empty(&self->msg_dest_info.audio_frame) &&
+      ten_hashtable_is_empty(&self->msg_dest_info.video_frame) &&
       ten_list_is_empty(&self->msg_conversion_contexts)) {
     return 0;
   }
@@ -130,7 +136,7 @@ int ten_extension_info_connections_to_json(ten_extension_info_t *self,
   ten_json_object_set_string(json, TEN_STR_EXTENSION,
                              ten_string_get_raw_str(&self->loc.extension_name));
 
-  if (!ten_list_is_empty(&self->msg_dest_info.cmd)) {
+  if (!ten_hashtable_is_empty(&self->msg_dest_info.cmd)) {
     ten_json_t cmd_dest_json = TEN_JSON_INIT_VAL(json->ctx, false);
     ten_json_object_peek_or_create_array(json, TEN_STR_CMD, &cmd_dest_json);
 
@@ -141,7 +147,7 @@ int ten_extension_info_connections_to_json(ten_extension_info_t *self,
     }
   }
 
-  if (!ten_list_is_empty(&self->msg_dest_info.data)) {
+  if (!ten_hashtable_is_empty(&self->msg_dest_info.data)) {
     ten_json_t data_dest_json = TEN_JSON_INIT_VAL(json->ctx, false);
     ten_json_object_peek_or_create_array(json, TEN_STR_DATA, &data_dest_json);
 
@@ -152,7 +158,7 @@ int ten_extension_info_connections_to_json(ten_extension_info_t *self,
     }
   }
 
-  if (!ten_list_is_empty(&self->msg_dest_info.video_frame)) {
+  if (!ten_hashtable_is_empty(&self->msg_dest_info.video_frame)) {
     ten_json_t video_frame_dest_json = TEN_JSON_INIT_VAL(json->ctx, false);
     ten_json_object_peek_or_create_array(json, TEN_STR_VIDEO_FRAME,
                                          &video_frame_dest_json);
@@ -164,7 +170,7 @@ int ten_extension_info_connections_to_json(ten_extension_info_t *self,
     }
   }
 
-  if (!ten_list_is_empty(&self->msg_dest_info.audio_frame)) {
+  if (!ten_hashtable_is_empty(&self->msg_dest_info.audio_frame)) {
     ten_json_t audio_frame_dest_json = TEN_JSON_INIT_VAL(json->ctx, false);
     ten_json_object_peek_or_create_array(json, TEN_STR_AUDIO_FRAME,
                                          &audio_frame_dest_json);

--- a/core/src/ten_runtime/extension/extension_info/value.c
+++ b/core/src/ten_runtime/extension/extension_info/value.c
@@ -15,6 +15,7 @@
 #include "ten_runtime/common/error_code.h"
 #include "ten_utils/lib/error.h"
 #include "ten_utils/macro/check.h"
+#include "ten_utils/macro/mark.h"
 #include "ten_utils/value/value.h"
 #include "ten_utils/value/value_merge.h"
 #include "ten_utils/value/value_object.h"
@@ -33,7 +34,7 @@
 // ------------------------
 static bool parse_msg_dest_value(ten_value_t *value,
                                  ten_list_t *extensions_info,
-                                 ten_list_t *static_dests,
+                                 ten_hashtable_t *static_dests,
                                  ten_extension_info_t *src_extension_info,
                                  ten_error_t *err) {
   TEN_ASSERT(value && ten_value_is_array(value) && extensions_info,
@@ -54,8 +55,9 @@ static bool parse_msg_dest_value(ten_value_t *value,
       return false;
     }
 
-    ten_list_push_ptr_back(static_dests, msg_dest,
-                           (void (*)(void *))ten_msg_dest_info_destroy);
+    ten_hashtable_add_string(
+        static_dests, &msg_dest->hh_in_all_msg_type_dest_info,
+        ten_string_get_raw_str(&msg_dest->name), ten_msg_dest_info_destroy);
   }
 
   return true;
@@ -246,7 +248,7 @@ ten_shared_ptr_t *ten_extension_info_parse_connection_dest_part_from_value(
 }
 
 ten_value_t *ten_extension_info_node_to_value(ten_extension_info_t *self,
-                                              ten_error_t *err) {
+                                              TEN_UNUSED ten_error_t *err) {
   TEN_ASSERT(self, "Invalid argument.");
   // TEN_NOLINTNEXTLINE(thread-check)
   // thread-check: The graph-related information of the extension remains
@@ -330,7 +332,8 @@ ten_value_t *ten_extension_info_node_to_value(ten_extension_info_t *self,
 }
 
 static ten_value_t *pack_msg_dest(ten_extension_info_t *self,
-                                  ten_list_t *msg_dests, ten_error_t *err) {
+                                  ten_hashtable_t *msg_dests,
+                                  ten_error_t *err) {
   TEN_ASSERT(self, "Invalid argument.");
   // TEN_NOLINTNEXTLINE(thread-check)
   // thread-check: The graph-related information of the extension remains
@@ -341,8 +344,13 @@ static ten_value_t *pack_msg_dest(ten_extension_info_t *self,
 
   ten_list_t dest_list = TEN_LIST_INIT_VAL;
 
-  ten_list_foreach (msg_dests, iter) {
-    ten_msg_dest_info_t *msg_dest = ten_ptr_listnode_get(iter.node);
+  ten_hashtable_foreach(msg_dests, iter) {
+    ten_hashhandle_t *hh = iter.node;
+    ten_msg_dest_info_t *msg_dest =
+        CONTAINER_OF_FROM_OFFSET(hh, msg_dests->hh_offset);
+    TEN_ASSERT(msg_dest, "Should not happen.");
+    TEN_ASSERT(ten_msg_dest_info_check_integrity(msg_dest),
+               "Should not happen.");
 
     ten_value_t *msg_dest_value =
         ten_msg_dest_info_to_value(msg_dest, self, err);
@@ -372,10 +380,10 @@ ten_value_t *ten_extension_info_connection_to_value(ten_extension_info_t *self,
   TEN_ASSERT(ten_extension_info_check_integrity(self, false),
              "Should not happen.");
 
-  if (ten_list_is_empty(&self->msg_dest_info.cmd) &&
-      ten_list_is_empty(&self->msg_dest_info.data) &&
-      ten_list_is_empty(&self->msg_dest_info.video_frame) &&
-      ten_list_is_empty(&self->msg_dest_info.audio_frame) &&
+  if (ten_hashtable_is_empty(&self->msg_dest_info.cmd) &&
+      ten_hashtable_is_empty(&self->msg_dest_info.data) &&
+      ten_hashtable_is_empty(&self->msg_dest_info.video_frame) &&
+      ten_hashtable_is_empty(&self->msg_dest_info.audio_frame) &&
       ten_list_is_empty(&self->msg_conversion_contexts)) {
     return NULL;
   }
@@ -434,7 +442,7 @@ ten_value_t *ten_extension_info_connection_to_value(ten_extension_info_t *self,
       (ten_ptr_listnode_destroy_func_t)ten_value_kv_destroy);
 
   // Parse 'cmd'
-  if (!ten_list_is_empty(&self->msg_dest_info.cmd)) {
+  if (!ten_hashtable_is_empty(&self->msg_dest_info.cmd)) {
     ten_value_t *cmd_dest_value =
         pack_msg_dest(self, &self->msg_dest_info.cmd, err);
     if (!cmd_dest_value) {
@@ -447,7 +455,7 @@ ten_value_t *ten_extension_info_connection_to_value(ten_extension_info_t *self,
   }
 
   // Parse 'data'
-  if (!ten_list_is_empty(&self->msg_dest_info.data)) {
+  if (!ten_hashtable_is_empty(&self->msg_dest_info.data)) {
     ten_value_t *data_dest_value =
         pack_msg_dest(self, &self->msg_dest_info.data, err);
     if (!data_dest_value) {
@@ -460,7 +468,7 @@ ten_value_t *ten_extension_info_connection_to_value(ten_extension_info_t *self,
   }
 
   // Parse 'video_frame'
-  if (!ten_list_is_empty(&self->msg_dest_info.video_frame)) {
+  if (!ten_hashtable_is_empty(&self->msg_dest_info.video_frame)) {
     ten_value_t *video_frame_dest_value =
         pack_msg_dest(self, &self->msg_dest_info.video_frame, err);
     if (!video_frame_dest_value) {
@@ -474,7 +482,7 @@ ten_value_t *ten_extension_info_connection_to_value(ten_extension_info_t *self,
   }
 
   // Parse 'audio_frame'
-  if (!ten_list_is_empty(&self->msg_dest_info.audio_frame)) {
+  if (!ten_hashtable_is_empty(&self->msg_dest_info.audio_frame)) {
     ten_value_t *audio_frame_dest_value =
         pack_msg_dest(self, &self->msg_dest_info.audio_frame, err);
     if (!audio_frame_dest_value) {

--- a/core/src/ten_runtime/extension/msg_dest_info/all_msg_type_dest_info.c
+++ b/core/src/ten_runtime/extension/msg_dest_info/all_msg_type_dest_info.c
@@ -6,22 +6,29 @@
 //
 #include "include_internal/ten_runtime/extension/msg_dest_info/all_msg_type_dest_info.h"
 
+#include "include_internal/ten_runtime/extension/msg_dest_info/msg_dest_info.h"
 #include "ten_utils/macro/check.h"
 
 void ten_all_msg_type_dest_info_init(ten_all_msg_type_dest_info_t *self) {
   TEN_ASSERT(self, "Should not happen.");
 
-  ten_list_init(&self->cmd);
-  ten_list_init(&self->video_frame);
-  ten_list_init(&self->audio_frame);
-  ten_list_init(&self->data);
+  ten_hashtable_init(
+      &self->cmd, offsetof(ten_msg_dest_info_t, hh_in_all_msg_type_dest_info));
+  ten_hashtable_init(
+      &self->data, offsetof(ten_msg_dest_info_t, hh_in_all_msg_type_dest_info));
+  ten_hashtable_init(
+      &self->audio_frame,
+      offsetof(ten_msg_dest_info_t, hh_in_all_msg_type_dest_info));
+  ten_hashtable_init(
+      &self->video_frame,
+      offsetof(ten_msg_dest_info_t, hh_in_all_msg_type_dest_info));
 }
 
 void ten_all_msg_type_dest_info_deinit(ten_all_msg_type_dest_info_t *self) {
   TEN_ASSERT(self, "Should not happen.");
 
-  ten_list_clear(&self->cmd);
-  ten_list_clear(&self->video_frame);
-  ten_list_clear(&self->audio_frame);
-  ten_list_clear(&self->data);
+  ten_hashtable_deinit(&self->cmd);
+  ten_hashtable_deinit(&self->data);
+  ten_hashtable_deinit(&self->audio_frame);
+  ten_hashtable_deinit(&self->video_frame);
 }

--- a/core/src/ten_runtime/extension/msg_dest_info/msg_dest_info.c
+++ b/core/src/ten_runtime/extension/msg_dest_info/msg_dest_info.c
@@ -8,7 +8,6 @@
 
 #include <stdlib.h>
 
-#include "include_internal/ten_runtime/common/constant_str.h"
 #include "include_internal/ten_runtime/extension/extension_info/extension_info.h"
 #include "include_internal/ten_runtime/extension/extension_info/json.h"
 #include "ten_utils/container/list_node_smart_ptr.h"

--- a/core/src/ten_runtime/extension/msg_dest_info/msg_dest_info.c
+++ b/core/src/ten_runtime/extension/msg_dest_info/msg_dest_info.c
@@ -36,6 +36,7 @@ ten_msg_dest_info_t *ten_msg_dest_info_create(const char *msg_name) {
 
   ten_signature_set(&self->signature,
                     (ten_signature_t)TEN_MSG_DEST_STATIC_INFO_SIGNATURE);
+
   ten_list_init(&self->dest);
 
   ten_string_init_formatted(&self->name, "%s", msg_name);

--- a/core/src/ten_runtime/msg/cmd_base/cmd/close_app/cmd.c
+++ b/core/src/ten_runtime/msg/cmd_base/cmd/close_app/cmd.c
@@ -46,8 +46,10 @@ ten_shared_ptr_t *ten_cmd_close_app_create(void) {
 bool ten_raw_cmd_close_app_loop_all_fields(
     ten_msg_t *self, ten_raw_msg_process_one_field_func_t cb, void *user_data,
     ten_error_t *err) {
-  TEN_ASSERT(self && ten_raw_cmd_check_integrity((ten_cmd_t *)self) && cb,
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_raw_cmd_check_integrity((ten_cmd_t *)self),
              "Should not happen.");
+  TEN_ASSERT(cb, "Should not happen.");
 
   for (size_t i = 0; i < ten_cmd_close_app_fields_info_size; ++i) {
     ten_msg_process_field_func_t process_field =

--- a/core/src/ten_runtime/msg/cmd_base/cmd/cmd.c
+++ b/core/src/ten_runtime/msg/cmd_base/cmd/cmd.c
@@ -97,8 +97,10 @@ void ten_raw_cmd_copy_field(ten_msg_t *self, ten_msg_t *src,
 bool ten_raw_cmd_process_field(ten_msg_t *self,
                                ten_raw_msg_process_one_field_func_t cb,
                                void *user_data, ten_error_t *err) {
-  TEN_ASSERT(self && ten_raw_cmd_check_integrity((ten_cmd_t *)self) && cb,
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_raw_cmd_check_integrity((ten_cmd_t *)self),
              "Should not happen.");
+  TEN_ASSERT(cb, "Should not happen.");
 
   for (size_t i = 0; i < ten_cmd_fields_info_size; ++i) {
     ten_msg_process_field_func_t process_field =

--- a/core/src/ten_runtime/msg/cmd_base/cmd/custom/cmd.c
+++ b/core/src/ten_runtime/msg/cmd_base/cmd/custom/cmd.c
@@ -183,8 +183,10 @@ bool ten_raw_cmd_custom_set_ten_property(ten_msg_t *self, ten_list_t *paths,
 bool ten_raw_cmd_custom_loop_all_fields(ten_msg_t *self,
                                         ten_raw_msg_process_one_field_func_t cb,
                                         void *user_data, ten_error_t *err) {
-  TEN_ASSERT(self && ten_raw_cmd_check_integrity((ten_cmd_t *)self) && cb,
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_raw_cmd_check_integrity((ten_cmd_t *)self),
              "Should not happen.");
+  TEN_ASSERT(cb, "Should not happen.");
 
   for (size_t i = 0; i < ten_cmd_custom_fields_info_size; ++i) {
     ten_msg_process_field_func_t process_field =

--- a/core/src/ten_runtime/msg/cmd_base/cmd/start_graph/cmd.c
+++ b/core/src/ten_runtime/msg/cmd_base/cmd/start_graph/cmd.c
@@ -335,10 +335,12 @@ static void ten_cmd_start_graph_collect_all_connectable_apps(
     ten_shared_ptr_t *self, ten_app_t *app,
     ten_extension_info_t *extension_info, ten_list_t *next,
     bool from_src_point_of_view) {
-  TEN_ASSERT(self && ten_cmd_base_check_integrity(self) &&
-                 ten_msg_get_type(self) == TEN_MSG_TYPE_CMD_START_GRAPH &&
-                 app && next,
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_cmd_base_check_integrity(self), "Should not happen.");
+  TEN_ASSERT(ten_msg_get_type(self) == TEN_MSG_TYPE_CMD_START_GRAPH,
              "Should not happen.");
+  TEN_ASSERT(app, "Should not happen.");
+  TEN_ASSERT(next, "Should not happen.");
 
   ten_hashtable_foreach(&extension_info->msg_dest_info.cmd, iter) {
     ten_hashhandle_t *hh = iter.node;
@@ -396,10 +398,12 @@ static void ten_cmd_start_graph_collect_all_connectable_apps(
 // Get the list of the immediate remote apps of the local app.
 void ten_cmd_start_graph_collect_all_immediate_connectable_apps(
     ten_shared_ptr_t *self, ten_app_t *app, ten_list_t *next) {
-  TEN_ASSERT(self && ten_cmd_base_check_integrity(self) &&
-                 ten_msg_get_type(self) == TEN_MSG_TYPE_CMD_START_GRAPH &&
-                 app && next,
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_cmd_base_check_integrity(self), "Should not happen.");
+  TEN_ASSERT(ten_msg_get_type(self) == TEN_MSG_TYPE_CMD_START_GRAPH,
              "Should not happen.");
+  TEN_ASSERT(app, "Should not happen.");
+  TEN_ASSERT(next, "Should not happen.");
 
   ten_list_foreach (ten_cmd_start_graph_get_extensions_info(self), iter) {
     ten_extension_info_t *extension_info =
@@ -576,10 +580,13 @@ ten_list_t
 ten_cmd_start_graph_get_extension_addon_and_instance_name_pairs_of_specified_extension_group(
     ten_shared_ptr_t *self, const char *app_uri, const char *graph_id,
     const char *extension_group_name) {
-  TEN_ASSERT(self && ten_cmd_base_check_integrity(self) &&
-                 ten_msg_get_type(self) == TEN_MSG_TYPE_CMD_START_GRAPH &&
-                 app_uri && graph_id && extension_group_name,
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_cmd_base_check_integrity(self), "Should not happen.");
+  TEN_ASSERT(ten_msg_get_type(self) == TEN_MSG_TYPE_CMD_START_GRAPH,
              "Should not happen.");
+  TEN_ASSERT(app_uri && graph_id && extension_group_name, "Should not happen.");
+  TEN_ASSERT(graph_id && extension_group_name, "Should not happen.");
+  TEN_ASSERT(extension_group_name, "Should not happen.");
 
   ten_list_t result = TEN_LIST_INIT_VAL;
 
@@ -633,9 +640,10 @@ ten_list_t ten_cmd_start_graph_get_requested_extension_names(
   ten_list_foreach (requested_extensions_info, iter) {
     ten_extension_info_t *requested_extension_info =
         ten_shared_ptr_get_data(ten_smart_ptr_listnode_get(iter.node));
-    TEN_ASSERT(requested_extension_info && ten_extension_info_check_integrity(
-                                               requested_extension_info, true),
-               "Should not happen.");
+    TEN_ASSERT(requested_extension_info, "Should not happen.");
+    TEN_ASSERT(
+        ten_extension_info_check_integrity(requested_extension_info, true),
+        "Should not happen.");
 
     ten_string_t *requested_extension_name =
         &requested_extension_info->loc.extension_name;
@@ -651,8 +659,10 @@ ten_list_t ten_cmd_start_graph_get_requested_extension_names(
 bool ten_raw_cmd_start_graph_loop_all_fields(
     ten_msg_t *self, ten_raw_msg_process_one_field_func_t cb, void *user_data,
     ten_error_t *err) {
-  TEN_ASSERT(self && ten_raw_cmd_check_integrity((ten_cmd_t *)self) && cb,
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_raw_cmd_check_integrity((ten_cmd_t *)self),
              "Should not happen.");
+  TEN_ASSERT(cb, "Should not happen.");
 
   for (size_t i = 0; i < ten_cmd_start_graph_fields_info_size; ++i) {
     ten_msg_process_field_func_t process_field =

--- a/core/src/ten_runtime/msg/cmd_base/cmd/start_graph/cmd.c
+++ b/core/src/ten_runtime/msg/cmd_base/cmd/start_graph/cmd.c
@@ -340,35 +340,55 @@ static void ten_cmd_start_graph_collect_all_connectable_apps(
                  app && next,
              "Should not happen.");
 
-  ten_list_foreach (&extension_info->msg_dest_info.cmd, iter_cmd) {
-    ten_msg_dest_info_t *cmd_dest = ten_ptr_listnode_get(iter_cmd.node);
+  ten_hashtable_foreach(&extension_info->msg_dest_info.cmd, iter) {
+    ten_hashhandle_t *hh = iter.node;
+    ten_msg_dest_info_t *msg_dest = CONTAINER_OF_FROM_OFFSET(
+        hh, extension_info->msg_dest_info.cmd.hh_offset);
+    TEN_ASSERT(msg_dest, "Should not happen.");
+    TEN_ASSERT(ten_msg_dest_info_check_integrity(msg_dest),
+               "Should not happen.");
+
     ten_cmd_start_graph_collect_connectable_apps(self, app, extension_info,
-                                                 &cmd_dest->dest, next,
+                                                 &msg_dest->dest, next,
                                                  from_src_point_of_view);
   }
 
-  ten_list_foreach (&extension_info->msg_dest_info.video_frame,
-                    iter_video_frame) {
-    ten_msg_dest_info_t *video_frame_dest =
-        ten_ptr_listnode_get(iter_video_frame.node);
+  ten_hashtable_foreach(&extension_info->msg_dest_info.video_frame, iter) {
+    ten_hashhandle_t *hh = iter.node;
+    ten_msg_dest_info_t *msg_dest = CONTAINER_OF_FROM_OFFSET(
+        hh, extension_info->msg_dest_info.video_frame.hh_offset);
+    TEN_ASSERT(msg_dest, "Should not happen.");
+    TEN_ASSERT(ten_msg_dest_info_check_integrity(msg_dest),
+               "Should not happen.");
+
     ten_cmd_start_graph_collect_connectable_apps(self, app, extension_info,
-                                                 &video_frame_dest->dest, next,
+                                                 &msg_dest->dest, next,
                                                  from_src_point_of_view);
   }
 
-  ten_list_foreach (&extension_info->msg_dest_info.audio_frame,
-                    iter_audio_frame) {
-    ten_msg_dest_info_t *audio_frame_dest =
-        ten_ptr_listnode_get(iter_audio_frame.node);
+  ten_hashtable_foreach(&extension_info->msg_dest_info.audio_frame, iter) {
+    ten_hashhandle_t *hh = iter.node;
+    ten_msg_dest_info_t *msg_dest = CONTAINER_OF_FROM_OFFSET(
+        hh, extension_info->msg_dest_info.audio_frame.hh_offset);
+    TEN_ASSERT(msg_dest, "Should not happen.");
+    TEN_ASSERT(ten_msg_dest_info_check_integrity(msg_dest),
+               "Should not happen.");
+
     ten_cmd_start_graph_collect_connectable_apps(self, app, extension_info,
-                                                 &audio_frame_dest->dest, next,
+                                                 &msg_dest->dest, next,
                                                  from_src_point_of_view);
   }
 
-  ten_list_foreach (&extension_info->msg_dest_info.data, iter_data) {
-    ten_msg_dest_info_t *data_dest = ten_ptr_listnode_get(iter_data.node);
+  ten_hashtable_foreach(&extension_info->msg_dest_info.data, iter) {
+    ten_hashhandle_t *hh = iter.node;
+    ten_msg_dest_info_t *msg_dest = CONTAINER_OF_FROM_OFFSET(
+        hh, extension_info->msg_dest_info.data.hh_offset);
+    TEN_ASSERT(msg_dest, "Should not happen.");
+    TEN_ASSERT(ten_msg_dest_info_check_integrity(msg_dest),
+               "Should not happen.");
+
     ten_cmd_start_graph_collect_connectable_apps(self, app, extension_info,
-                                                 &data_dest->dest, next,
+                                                 &msg_dest->dest, next,
                                                  from_src_point_of_view);
   }
 }

--- a/core/src/ten_runtime/msg/cmd_base/cmd/timeout/cmd.c
+++ b/core/src/ten_runtime/msg/cmd_base/cmd/timeout/cmd.c
@@ -88,8 +88,10 @@ void ten_cmd_timeout_set_timer_id(ten_shared_ptr_t *self, uint32_t timer_id) {
 bool ten_raw_cmd_timeout_loop_all_fields(
     ten_msg_t *self, ten_raw_msg_process_one_field_func_t cb, void *user_data,
     ten_error_t *err) {
-  TEN_ASSERT(self && ten_raw_cmd_check_integrity((ten_cmd_t *)self) && cb,
+  TEN_ASSERT(self, "Should not happen.");
+  TEN_ASSERT(ten_raw_cmd_check_integrity((ten_cmd_t *)self),
              "Should not happen.");
+  TEN_ASSERT(cb, "Should not happen.");
 
   for (size_t i = 0; i < ten_cmd_timeout_fields_info_size; ++i) {
     ten_msg_process_field_func_t process_field =

--- a/core/src/ten_utils/container/hash_bucket.c
+++ b/core/src/ten_utils/container/hash_bucket.c
@@ -15,7 +15,8 @@
 // otherwise, there will be a circular dependency issue.
 
 void ten_hashbucket_add(ten_hashbucket_t *self, ten_hashhandle_t *hh) {
-  TEN_ASSERT(self && hh, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(hh, "Invalid argument.");
 
   self->items_cnt++;
 
@@ -36,7 +37,8 @@ void ten_hashbucket_add(ten_hashbucket_t *self, ten_hashhandle_t *hh) {
 
 // Remove a item from a given bucket.
 void ten_hashbucket_del(ten_hashbucket_t *self, ten_hashhandle_t *hh) {
-  TEN_ASSERT(self && hh, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(hh, "Invalid argument.");
 
   self->items_cnt--;
 
@@ -54,7 +56,8 @@ void ten_hashbucket_del(ten_hashbucket_t *self, ten_hashhandle_t *hh) {
 
 ten_hashhandle_t *ten_hashbucket_find(ten_hashbucket_t *self, uint32_t hashval,
                                       const void *key, size_t keylen) {
-  TEN_ASSERT(self && key, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(key, "Invalid argument.");
 
   ten_hashhandle_t *out = NULL;
   if (self->head != NULL) {

--- a/core/src/ten_utils/container/hash_table.c
+++ b/core/src/ten_utils/container/hash_table.c
@@ -404,6 +404,11 @@ uint32_t ten_hashtable_items_cnt(ten_hashtable_t *self) {
   return self->items_cnt;
 }
 
+bool ten_hashtable_is_empty(ten_hashtable_t *self) {
+  TEN_ASSERT(self, "Invalid argument.");
+  return self->items_cnt == 0;
+}
+
 ten_hashhandle_t *ten_hashtable_find_by_key(ten_hashtable_t *self,
                                             const void *key, uint32_t keylen) {
   TEN_ASSERT(self && key, "Invalid argument.");

--- a/core/src/ten_utils/container/hash_table.c
+++ b/core/src/ten_utils/container/hash_table.c
@@ -213,7 +213,8 @@ void ten_hashtable_clear(ten_hashtable_t *self) {
 }
 
 void ten_hashtable_concat(ten_hashtable_t *self, ten_hashtable_t *target) {
-  TEN_ASSERT(self && target, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(target, "Invalid argument.");
 
   ten_hashtable_foreach(target, iter) {
     ten_hashhandle_t *hh = iter.node;
@@ -315,7 +316,8 @@ void ten_hashtable_expand_bkts(ten_hashtable_t *self) {
 
 static void ten_hashtable_add_to_app_list(ten_hashtable_t *self,
                                           ten_hashhandle_t *hh) {
-  TEN_ASSERT(self && hh, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(hh, "Invalid argument.");
 
   hh->next = NULL;
   if (self->tail) {
@@ -332,7 +334,8 @@ static void ten_hashtable_add_to_app_list(ten_hashtable_t *self,
 static void ten_hashtable_add_by_hash_val(ten_hashtable_t *self,
                                           ten_hashhandle_t *hh,
                                           uint32_t hashval) {
-  TEN_ASSERT(self && hh, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(hh, "Invalid argument.");
 
   self->items_cnt++;
   const uint32_t bkt_idx = ten_hash_get_bucket_idx(hashval, self->bkts_cnt);
@@ -344,7 +347,9 @@ static void ten_hashtable_add_by_hash_val(ten_hashtable_t *self,
 
 void ten_hashtable_add_by_key(ten_hashtable_t *self, ten_hashhandle_t *hh,
                               const void *key, uint32_t keylen, void *destroy) {
-  TEN_ASSERT(self && hh && key, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(hh, "Invalid argument.");
+  TEN_ASSERT(key, "Invalid argument.");
 
   ten_hashhandle_init(hh, self, key, keylen, destroy);
   ten_hashtable_add_by_hash_val(self, hh, hh->hashval);
@@ -355,7 +360,9 @@ static void ten_hashtable_replace_by_hash_val(ten_hashtable_t *self,
                                               ten_hashhandle_t *hh,
                                               uint32_t hashval, void *key,
                                               uint32_t keylen) {
-  TEN_ASSERT(self && hh && key, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(hh, "Invalid argument.");
+  TEN_ASSERT(key, "Invalid argument.");
 
   ten_hashhandle_t *replaced = ten_hashtable_find(self, hashval, key, keylen);
   if (replaced) {
@@ -366,7 +373,9 @@ static void ten_hashtable_replace_by_hash_val(ten_hashtable_t *self,
 
 void ten_hashtable_replace_by_key(ten_hashtable_t *self, ten_hashhandle_t *hh,
                                   void *key, uint32_t keylen, void *destroy) {
-  TEN_ASSERT(self && hh && key, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(hh, "Invalid argument.");
+  TEN_ASSERT(key, "Invalid argument.");
 
   ten_hashhandle_init(hh, self, key, keylen, destroy);
   ten_hashtable_replace_by_hash_val(self, hh, hh->hashval, key, keylen);
@@ -374,7 +383,9 @@ void ten_hashtable_replace_by_key(ten_hashtable_t *self, ten_hashhandle_t *hh,
 }
 
 void ten_hashtable_del(ten_hashtable_t *self, ten_hashhandle_t *hh) {
-  TEN_ASSERT(self && hh && self == hh->tbl, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(hh, "Invalid argument.");
+  TEN_ASSERT(self == hh->tbl, "Invalid argument.");
 
   const uint32_t bkt_idx = ten_hash_get_bucket_idx(hh->hashval, self->bkts_cnt);
   ten_hashbucket_del(&(self->bkts[bkt_idx]), hh);
@@ -411,14 +422,18 @@ bool ten_hashtable_is_empty(ten_hashtable_t *self) {
 
 ten_hashhandle_t *ten_hashtable_find_by_key(ten_hashtable_t *self,
                                             const void *key, uint32_t keylen) {
-  TEN_ASSERT(self && key, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(key, "Invalid argument.");
+
   uint32_t hashval = ten_hash_function(key, keylen);
   return ten_hashtable_find(self, hashval, key, keylen);
 }
 
 ten_hashhandle_t *ten_hashtable_find(ten_hashtable_t *self, uint32_t hashval,
                                      const void *key, uint32_t keylen) {
-  TEN_ASSERT(self && key, "Invalid argument.");
+  TEN_ASSERT(self, "Invalid argument.");
+  TEN_ASSERT(key, "Invalid argument.");
+
   const uint32_t bkt_idx = ten_hash_get_bucket_idx(hashval, self->bkts_cnt);
   return ten_hashbucket_find(&(self->bkts[bkt_idx]), hashval, key, keylen);
 }


### PR DESCRIPTION
- Replaced list structures with hash tables for cmd, data, audio_frame, and video_frame in
ten_all_msg_type_dest_info_t.
- Added ten_hashtable_is_empty function to check if a hash table is empty.
- Updated related functions to utilize hash table operations for improved performance and
efficiency.