### PR TITLE
refactor: update graph retrieval logic to utilize DesignerGraphInfo structure

### DIFF
--- a/core/src/ten_manager/src/designer/graphs/get.rs
+++ b/core/src/ten_manager/src/designer/graphs/get.rs
@@ -10,6 +10,7 @@ use actix_web::{web, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
 
 use crate::designer::graphs::nodes::get::DesignerGraphNode;
+use crate::designer::graphs::DesignerGraphInfo;
 use crate::designer::{
     graphs::{
         DesignerGraph, DesignerGraphExposedMessage,
@@ -18,17 +19,86 @@ use crate::designer::{
     response::{ApiResponse, Status},
     DesignerState,
 };
+use ten_rust::graph::{
+    connection::GraphConnection, graph_info::GraphInfo, node::GraphNode,
+    GraphExposedMessage, GraphExposedProperty,
+};
 
 #[derive(Serialize, Deserialize)]
 pub struct GetGraphsRequestPayload {}
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct GetGraphsResponseData {
-    pub uuid: String,
-    pub name: Option<String>,
-    pub auto_start: Option<bool>,
-    pub base_dir: Option<String>,
-    pub graph: DesignerGraph,
+/// Converts a collection of nodes, connections, exposed_messages, and
+/// exposed_properties into a DesignerGraph structure.
+fn create_designer_graph(
+    nodes: &[GraphNode],
+    connections: &Option<Vec<GraphConnection>>,
+    exposed_messages: &Option<Vec<GraphExposedMessage>>,
+    exposed_properties: &Option<Vec<GraphExposedProperty>>,
+) -> DesignerGraph {
+    DesignerGraph {
+        nodes: nodes
+            .iter()
+            .filter_map(|node| DesignerGraphNode::try_from(node.clone()).ok())
+            .collect(),
+        connections: connections
+            .as_ref()
+            .map(|conns| conns.iter().map(|conn| conn.clone().into()).collect())
+            .unwrap_or_default(),
+        exposed_messages: exposed_messages
+            .as_ref()
+            .map(|msgs| {
+                msgs.iter()
+                    .map(|msg| DesignerGraphExposedMessage {
+                        msg_type: msg.msg_type.clone(),
+                        name: msg.name.clone(),
+                        extension: msg.extension.clone(),
+                        subgraph: msg.subgraph.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        exposed_properties: exposed_properties
+            .as_ref()
+            .map(|props| {
+                props
+                    .iter()
+                    .map(|prop| DesignerGraphExposedProperty {
+                        extension: prop.extension.clone(),
+                        subgraph: prop.subgraph.clone(),
+                        name: prop.name.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
+}
+
+/// Extracts a DesignerGraph from GraphInfo, preferring pre_flatten data if
+/// available, otherwise falling back to the main graph data.
+fn extract_designer_graph_from_graph_info(
+    graph_info: &GraphInfo,
+) -> DesignerGraph {
+    graph_info
+        .graph
+        .graph
+        .pre_flatten
+        .as_ref()
+        .map(|pre_flatten| {
+            create_designer_graph(
+                &pre_flatten.nodes,
+                &pre_flatten.connections,
+                &pre_flatten.exposed_messages,
+                &pre_flatten.exposed_properties,
+            )
+        })
+        .unwrap_or_else(|| {
+            create_designer_graph(
+                &graph_info.graph.graph.nodes,
+                &graph_info.graph.graph.connections,
+                &graph_info.graph.graph.exposed_messages,
+                &graph_info.graph.graph.exposed_properties,
+            )
+        })
 }
 
 pub async fn get_graphs_endpoint(
@@ -37,120 +107,14 @@ pub async fn get_graphs_endpoint(
 ) -> Result<impl Responder, actix_web::Error> {
     let graphs_cache = state.graphs_cache.read().await;
 
-    let graphs: Vec<GetGraphsResponseData> = graphs_cache
+    let graphs: Vec<DesignerGraphInfo> = graphs_cache
         .iter()
-        .map(|(uuid, graph_info)| GetGraphsResponseData {
-            uuid: uuid.to_string(),
+        .map(|(uuid, graph_info)| DesignerGraphInfo {
+            graph_id: *uuid,
             name: graph_info.name.clone(),
             auto_start: graph_info.auto_start,
             base_dir: graph_info.app_base_dir.clone(),
-            graph: graph_info
-                .graph
-                .graph
-                .pre_flatten
-                .as_ref()
-                .map(|pre_flatten| DesignerGraph {
-                    nodes: pre_flatten
-                        .nodes
-                        .iter()
-                        .filter_map(|node| {
-                            DesignerGraphNode::try_from(node.clone()).ok()
-                        })
-                        .collect(),
-                    connections: pre_flatten
-                        .connections
-                        .as_ref()
-                        .map(|conns| {
-                            conns
-                                .iter()
-                                .map(|conn| conn.clone().into())
-                                .collect()
-                        })
-                        .unwrap_or_default(),
-                    exposed_messages: pre_flatten
-                        .exposed_messages
-                        .as_ref()
-                        .map(|msgs| {
-                            msgs.iter()
-                                .map(|msg| DesignerGraphExposedMessage {
-                                    msg_type: msg.msg_type.clone(),
-                                    name: msg.name.clone(),
-                                    extension: msg.extension.clone(),
-                                    subgraph: msg.subgraph.clone(),
-                                })
-                                .collect()
-                        })
-                        .unwrap_or_default(),
-                    exposed_properties: pre_flatten
-                        .exposed_properties
-                        .as_ref()
-                        .map(|props| {
-                            props
-                                .iter()
-                                .map(|prop| DesignerGraphExposedProperty {
-                                    extension: prop.extension.clone(),
-                                    subgraph: prop.subgraph.clone(),
-                                    name: prop.name.clone(),
-                                })
-                                .collect()
-                        })
-                        .unwrap_or_default(),
-                })
-                .unwrap_or_else(|| DesignerGraph {
-                    nodes: graph_info
-                        .graph
-                        .graph
-                        .nodes
-                        .iter()
-                        .filter_map(|node| {
-                            DesignerGraphNode::try_from(node.clone()).ok()
-                        })
-                        .collect(),
-                    connections: graph_info
-                        .graph
-                        .graph
-                        .connections
-                        .as_ref()
-                        .map(|conns| {
-                            conns
-                                .iter()
-                                .map(|conn| conn.clone().into())
-                                .collect()
-                        })
-                        .unwrap_or_default(),
-                    exposed_messages: graph_info
-                        .graph
-                        .graph
-                        .exposed_messages
-                        .as_ref()
-                        .map(|msgs| {
-                            msgs.iter()
-                                .map(|msg| DesignerGraphExposedMessage {
-                                    msg_type: msg.msg_type.clone(),
-                                    name: msg.name.clone(),
-                                    extension: msg.extension.clone(),
-                                    subgraph: msg.subgraph.clone(),
-                                })
-                                .collect()
-                        })
-                        .unwrap_or_default(),
-                    exposed_properties: graph_info
-                        .graph
-                        .graph
-                        .exposed_properties
-                        .as_ref()
-                        .map(|props| {
-                            props
-                                .iter()
-                                .map(|prop| DesignerGraphExposedProperty {
-                                    extension: prop.extension.clone(),
-                                    subgraph: prop.subgraph.clone(),
-                                    name: prop.name.clone(),
-                                })
-                                .collect()
-                        })
-                        .unwrap_or_default(),
-                }),
+            graph: extract_designer_graph_from_graph_info(graph_info),
         })
         .collect();
 

--- a/core/src/ten_manager/src/designer/graphs/mod.rs
+++ b/core/src/ten_manager/src/designer/graphs/mod.rs
@@ -21,7 +21,7 @@ use crate::designer::graphs::{
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DesignerGraphInfo {
-    pub uuid: Uuid,
+    pub graph_id: Uuid,
 
     pub name: Option<String>,
     pub auto_start: Option<bool>,

--- a/core/src/ten_manager/tests/test_case/designer/get_graphs.rs
+++ b/core/src/ten_manager/tests/test_case/designer/get_graphs.rs
@@ -15,10 +15,8 @@ use ten_manager::{
                 get_graph_connections_endpoint, DesignerGraphConnection,
                 GetGraphConnectionsRequestPayload,
             },
-            get::{
-                get_graphs_endpoint, GetGraphsRequestPayload,
-                GetGraphsResponseData,
-            },
+            get::{get_graphs_endpoint, GetGraphsRequestPayload},
+            DesignerGraphInfo,
         },
         response::ApiResponse,
         storage::in_memory::TmanStorageInMemory,
@@ -111,7 +109,7 @@ async fn test_cmd_designer_graphs_app_property_not_exist() {
 
     let body = test::read_body(resp).await;
     let body_str = std::str::from_utf8(&body).unwrap();
-    let json: ApiResponse<Vec<GetGraphsResponseData>> =
+    let json: ApiResponse<Vec<DesignerGraphInfo>> =
         serde_json::from_str(body_str).unwrap();
 
     let pretty_json = serde_json::to_string_pretty(&json).unwrap();

--- a/core/src/ten_manager/tests/test_case/designer/graphs/get.rs
+++ b/core/src/ten_manager/tests/test_case/designer/graphs/get.rs
@@ -9,15 +9,14 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use actix_web::{test, web, App};
+    use uuid::Uuid;
+
     use ten_manager::{
         constants::TEST_DIR,
         designer::{
             graphs::{
-                get::{
-                    get_graphs_endpoint, GetGraphsRequestPayload,
-                    GetGraphsResponseData,
-                },
-                DesignerGraph,
+                get::{get_graphs_endpoint, GetGraphsRequestPayload},
+                DesignerGraph, DesignerGraphInfo,
             },
             response::ApiResponse,
             storage::in_memory::TmanStorageInMemory,
@@ -79,7 +78,7 @@ mod tests {
         let body = test::read_body(resp).await;
         let body_str = std::str::from_utf8(&body).unwrap();
 
-        let graphs: ApiResponse<Vec<GetGraphsResponseData>> =
+        let graphs: ApiResponse<Vec<DesignerGraphInfo>> =
             serde_json::from_str(body_str).unwrap();
 
         let empty_graph = DesignerGraph {
@@ -90,22 +89,25 @@ mod tests {
         };
 
         let expected_graphs = vec![
-            GetGraphsResponseData {
-                uuid: "default".to_string(),
+            DesignerGraphInfo {
+                graph_id: Uuid::parse_str("default")
+                    .unwrap_or_else(|_| Uuid::new_v4()),
                 name: Some("default".to_string()),
                 auto_start: Some(true),
                 base_dir: Some(TEST_DIR.to_string()),
                 graph: empty_graph.clone(),
             },
-            GetGraphsResponseData {
-                uuid: "default_with_app_uri".to_string(),
+            DesignerGraphInfo {
+                graph_id: Uuid::parse_str("default_with_app_uri")
+                    .unwrap_or_else(|_| Uuid::new_v4()),
                 name: Some("default_with_app_uri".to_string()),
                 auto_start: Some(true),
                 base_dir: Some(TEST_DIR.to_string()),
                 graph: empty_graph.clone(),
             },
-            GetGraphsResponseData {
-                uuid: "addon_not_found".to_string(),
+            DesignerGraphInfo {
+                graph_id: Uuid::parse_str("addon_not_found")
+                    .unwrap_or_else(|_| Uuid::new_v4()),
                 name: Some("addon_not_found".to_string()),
                 auto_start: Some(false),
                 base_dir: Some(TEST_DIR.to_string()),
@@ -127,7 +129,7 @@ mod tests {
             assert_eq!(actual.base_dir, expected.base_dir);
         }
 
-        let json: ApiResponse<Vec<GetGraphsResponseData>> =
+        let json: ApiResponse<Vec<DesignerGraphInfo>> =
             serde_json::from_str(body_str).unwrap();
         let pretty_json = serde_json::to_string_pretty(&json).unwrap();
         println!("Response body: {pretty_json}");


### PR DESCRIPTION
- Replaced GetGraphsResponseData with DesignerGraphInfo in the get_graphs_endpoint.
- Introduced create_designer_graph and extract_designer_graph_from_graph_info functions to
streamline graph creation from GraphInfo.
- Updated related tests to reflect changes in response structure.