### PR TITLE
feat: add JSON ADC credentials for Google ASR and streamline logs; fix Bytedance ASR config lint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -119,7 +119,8 @@
     "**/third_party/*/**": true
   },
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.defaultFormatter": "ms-python.python"
   },
-  "cmake.sourceDirectory": "D:/dev/TEN-Agent/third_party/mbedtls"
+  "cmake.sourceDirectory": "D:/dev/TEN-Agent/third_party/mbedtls",
+  "python.formatting.provider": "black"
 }

--- a/ai_agents/agents/integration_tests/asr_guarder/tests/bin/start
+++ b/ai_agents/agents/integration_tests/asr_guarder/tests/bin/start
@@ -4,6 +4,6 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
-export PYTHONPATH=.:ten_packages/system/ten_runtime_python/lib:ten_packages/system/ten_runtime_python/interface:ten_packages/system/ten_ai_base/interface:ten_packages/extension/azure_asr_python:$PYTHONPATH
+export PYTHONPATH=.:ten_packages/system/ten_runtime_python/lib:ten_packages/system/ten_runtime_python/interface:ten_packages/system/ten_ai_base/interface:ten_packages/extension:$PYTHONPATH
 
 pytest -s tests/ "$@"

--- a/ai_agents/agents/ten_packages/extension/bytedance_asr/config.py
+++ b/ai_agents/agents/ten_packages/extension/bytedance_asr/config.py
@@ -60,11 +60,16 @@ class BytedanceASRConfig(BaseModel):
             config.token = encrypt(config.token)
 
         if config.params:
-            for key, value in config.params.items():
+            # Guard for static analyzers: ensure dict semantics for params
+            params_dict: dict[str, Any] = (
+                dict(config.params) if isinstance(config.params, dict) else {}
+            )
+            for key, value in params_dict.items():
                 if key == "appid":
-                    config.params[key] = encrypt(value)
+                    params_dict[key] = encrypt(value)
 
                 if key == "token":
-                    config.params[key] = encrypt(value)
+                    params_dict[key] = encrypt(value)
+            config.params = params_dict
 
         return config.model_dump_json()

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/__init__.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/__init__.py
@@ -1,0 +1,6 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+from . import addon

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/addon.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/addon.py
@@ -1,0 +1,19 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+from ten_runtime import (
+    Addon,
+    register_addon_as_extension,
+    TenEnv,
+    LogLevel,
+)
+from .extension import GoogleASRExtension
+
+
+@register_addon_as_extension("google_asr_python")
+class GoogleASRExtensionAddon(Addon):
+    def on_create_instance(self, ten_env: TenEnv, name: str, context) -> None:
+        ten_env.log(LogLevel.INFO, "on_create_instance")
+        ten_env.on_create_instance_done(GoogleASRExtension(name), context)

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/config.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/config.py
@@ -14,9 +14,12 @@ class GoogleASRConfig(BaseModel):
     """
 
     # Google Cloud credentials and project settings
-    project_id: str = ""  # Google Cloud Project ID (optional, will use ADC if not provided)
+    project_id: str = (
+        ""  # Google Cloud Project ID (optional, will use ADC if not provided)
+    )
     location: str = "global"  # Google Cloud location
     adc_credentials_path: str = ""  # Path to ADC credentials file (optional)
+    adc_credentials_string: str = ""  # ADC credentials string (optional)
 
     def get_client_options(self) -> dict[str, str]:
         """Get client options for Google Cloud Speech client."""
@@ -44,7 +47,9 @@ class GoogleASRConfig(BaseModel):
     max_alternatives: int = 1  # Maximum number of recognition alternatives
 
     # Streaming settings
-    single_utterance: bool = False  # Not used in V2 streaming_features; kept for compatibility
+    single_utterance: bool = (
+        False  # Not used in V2 streaming_features; kept for compatibility
+    )
     interim_results: bool = True  # Enable interim results
 
     # Content filtering

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/config.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/config.py
@@ -1,0 +1,183 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+from typing import Any
+from pydantic import BaseModel, Field
+
+
+class GoogleASRConfig(BaseModel):
+    """Google Cloud Speech-to-Text V2 ASR configuration
+
+    Refer to: https://cloud.google.com/speech-to-text/v2/docs/libraries
+    """
+
+    # Google Cloud credentials and project settings
+    project_id: str = ""  # Google Cloud Project ID (optional, will use ADC if not provided)
+    location: str = "global"  # Google Cloud location
+    adc_credentials_path: str = ""  # Path to ADC credentials file (optional)
+
+    def get_client_options(self) -> dict:
+        """Get client options for Google Cloud Speech client."""
+        return {
+            "project_id": self.project_id,
+        }
+
+    # Audio configuration
+    sample_rate: int = 16000  # Audio sample rate in Hz
+    channels: int = 1  # Number of audio channels
+    encoding: str = "LINEAR16"  # Audio encoding (LINEAR16, FLAC, MULAW, etc.)
+
+    # Language and model settings
+    language: str = "en-US"  # Primary language code
+    language_list: list[str] = Field(
+        default_factory=list
+    )  # Alternative language codes
+    model: str = "long"  # Recognition model (V2: "long", "short", etc.)
+
+    # Recognition settings
+    enable_automatic_punctuation: bool = True
+    enable_word_time_offsets: bool = True
+    enable_word_confidence: bool = True
+    enable_speaker_diarization: bool = False
+    diarization_speaker_count: int = 0  # Number of speakers (0 = auto detect)
+    max_alternatives: int = 1  # Maximum number of recognition alternatives
+
+    # Streaming settings
+    single_utterance: bool = False  # Enable single utterance mode
+    interim_results: bool = True  # Enable interim results
+
+    # Content filtering
+    profanity_filter: bool = False  # Enable profanity filter
+
+    # Speech contexts for better recognition (phrases and boost values)
+    speech_contexts: list[dict[str, Any]] = Field(default_factory=list)
+
+    # Audio processing
+    use_enhanced: bool = False  # Use enhanced model (premium pricing)
+
+    # Adaptation settings
+    adaptation_phrase_set_references: list[str] = Field(default_factory=list)
+    adaptation_custom_class_references: list[str] = Field(default_factory=list)
+
+    # Timeout settings
+    recognition_timeout: int = 60  # Recognition timeout in seconds
+    connection_timeout: int = 30  # Connection timeout in seconds
+
+    # Retry settings
+    max_retry_attempts: int = 3  # Maximum retry attempts on failure
+    retry_delay: float = 1.0  # Delay between retry attempts in seconds
+
+    # Extension configuration
+    params: dict[str, Any] = Field(default_factory=dict)
+    black_list_params: list[str] = Field(default_factory=list)
+
+    # Audio dumping settings
+    dump: bool = False
+    dump_path: str = "."
+
+    # Logging
+    enable_detailed_logging: bool = False
+
+    def is_black_list_params(self, key: str) -> bool:
+        """Check if a parameter key is in the blacklist."""
+        return key in self.black_list_params
+
+    def update(self, params: dict[str, Any]) -> None:
+        """Update configuration with provided parameters."""
+        for key, value in params.items():
+            if hasattr(self, key) and not self.is_black_list_params(key):
+                setattr(self, key, value)
+
+        # Process language_list from comma-separated language string
+        if "," in self.language:
+            self.language_list = [
+                lang.strip() for lang in self.language.split(",")
+            ]
+        elif self.language and not self.language_list:
+            self.language_list = [self.language]
+
+    def to_json(self, sensitive_handling: bool = False) -> str:
+        """Convert configuration to JSON string."""
+        if not sensitive_handling:
+            return self.model_dump_json()
+
+        # Handle sensitive data for logging/debugging
+        config = self.model_copy(deep=True)
+        if config.project_id:
+            config.project_id = "***"
+
+        return config.model_dump_json()
+
+    def get_recognition_config(self) -> dict[str, Any]:
+        """Get Google Cloud Speech V2 recognition config dictionary."""
+        # V2 API uses auto_decoding_config instead of explicit encoding/sample_rate
+        config: dict[str, Any] = {
+            "auto_decoding_config": {},  # V2 auto-detects encoding and sample rate
+            "language_codes": (
+                self.language_list if self.language_list else [self.language]
+            ),
+            "model": self.model,
+            "features": {
+                "enable_automatic_punctuation": self.enable_automatic_punctuation,
+                "enable_word_time_offsets": self.enable_word_time_offsets,
+                "enable_word_confidence": self.enable_word_confidence,
+                "profanity_filter": self.profanity_filter,
+                "max_alternatives": self.max_alternatives,
+            },
+        }
+
+        # Add speaker diarization config if enabled (V2 structure)
+        if self.enable_speaker_diarization:
+            diarization_config = {}
+            if self.diarization_speaker_count > 0:
+                diarization_config["min_speaker_count"] = (
+                    self.diarization_speaker_count
+                )
+                diarization_config["max_speaker_count"] = (
+                    self.diarization_speaker_count
+                )
+            config["features"]["diarization_config"] = diarization_config
+
+        # Add speech contexts if provided (V2 structure)
+        if self.speech_contexts:
+            config["features"]["speech_contexts"] = self.speech_contexts
+
+        # Add adaptation settings if provided (V2 structure)
+        adaptation_config = {}
+        if self.adaptation_phrase_set_references:
+            adaptation_config["phrase_set_references"] = (
+                self.adaptation_phrase_set_references
+            )
+        if self.adaptation_custom_class_references:
+            adaptation_config["custom_class_references"] = (
+                self.adaptation_custom_class_references
+            )
+        if adaptation_config:
+            config["adaptation"] = adaptation_config
+
+        return config
+
+    def get_recognizer_path(self) -> str:
+        """Get the recognizer path for V2 API."""
+        # According to Google Cloud Speech V2 docs, recognizer is required
+        # Use default recognizer "_" to avoid permission issues
+        if self.project_id and self.location != "global":
+            return f"projects/{self.project_id}/locations/{self.location}/recognizers/_"
+        elif self.project_id:
+            return f"projects/{self.project_id}/locations/global/recognizers/_"
+        else:
+            # If no project_id, we'll need to get it from ADC
+            return ""
+
+    def validate_config(self) -> tuple[bool, str]:
+        """Validate the configuration and return (is_valid, error_message)."""
+        errors: list[str] = []
+
+        # For ADC authentication, project_id is optional (will be retrieved from ADC)
+        # No validation errors for missing project_id as it will be retrieved from ADC
+
+        if errors:
+            return False, "; ".join(errors)
+        return True, ""

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/extension.py
@@ -5,7 +5,8 @@
 #
 
 
-import json
+import asyncio
+import os
 from ten_runtime import (
     AudioFrame,
     AsyncTenEnv,
@@ -18,10 +19,13 @@ from ten_ai_base.asr import (
     ASRBufferConfigModeKeep,
     ASRResult,
 )
-from ten_ai_base.message import ModuleError, ModuleType
+
+from ten_ai_base.message import ModuleError, ModuleType, ModuleErrorVendorInfo, ModuleErrorCode
+from ten_ai_base.dumper import Dumper
 
 from .config import GoogleASRConfig
 from .google_asr_client import GoogleASRClient
+from .reconnect_manager import ReconnectManager
 
 
 class GoogleASRExtension(AsyncASRBaseExtension):
@@ -31,6 +35,10 @@ class GoogleASRExtension(AsyncASRBaseExtension):
         self.client: GoogleASRClient | None = None
         self.config: GoogleASRConfig | None = None
         self.session_id: str | None = None
+        self.audio_dumper: Dumper | None = None
+        self.reconnect_manager: ReconnectManager | None = None
+        self.stopped: bool = False
+        self._reconnect_task: asyncio.Task | None = None
 
     @override
     def vendor(self) -> str:
@@ -39,17 +47,119 @@ class GoogleASRExtension(AsyncASRBaseExtension):
 
     async def _on_asr_result(self, result: ASRResult):
         """Callback for handling ASR results from the client."""
-        await self.send_asr_result(self.session_id, result)
+        await self.send_asr_result(result)
 
     async def _on_asr_error(self, code: int, message: str):
         """Callback for handling errors from the client."""
+        severity = self._map_to_module_error_code(code, message)
         await self.send_asr_error(
             ModuleError(
                 module=ModuleType.ASR,
-                code=code,
+                code=severity,
                 message=message,
-            )
+            ),
+            ModuleErrorVendorInfo(
+                vendor="google",
+                code=str(code),
+                message=message,
+            ),
         )
+        # For non-fatal errors, attempt reconnect in background
+        if severity == ModuleErrorCode.NON_FATAL_ERROR.value and not self.stopped:
+            try:
+                # Skip reconnect for client-side normal shutdowns
+                if (code == 1) or ("CANCELLED" in (message or "").upper()):
+                    if self.ten_env:
+                        self.ten_env.log_info("Non-fatal CANCELLED received; skip reconnect.")
+                    return
+
+                # Mark as disconnected and stop client before reconnecting
+                self.connected = False
+                if self.client:
+                    try:
+                        await self.client.stop()
+                    except Exception:
+                        ...
+                    self.client = None
+                if self.ten_env:
+                    self.ten_env.log_warn(
+                        f"Scheduling reconnect due to non-fatal error ({code}): {message}"
+                    )
+                # Cancel existing pending reconnect task if any
+                if self._reconnect_task and not self._reconnect_task.done():
+                    self._reconnect_task.cancel()
+                self._reconnect_task = asyncio.create_task(self._handle_reconnect())
+                def _clear_task(_):
+                    self._reconnect_task = None
+                self._reconnect_task.add_done_callback(_clear_task)
+            except Exception:
+                ...
+
+    def _map_to_module_error_code(self, code: int, message: str) -> int:
+        """Map Google Speech v2 / gRPC / HTTP error to fatal vs non-fatal.
+
+        Priority:
+        1) Numeric code (prefer gRPC canonical codes; also handle common HTTP codes)
+        2) Text keywords fallback
+        3) Default to non-fatal (safer)
+
+        CANCELLED is already handled upstream as normal shutdown; if it reaches here, treat as non-fatal.
+
+        see: https://cloud.google.com/speech-to-text/v2/docs/reference/rest/v2/Code
+        """
+        text = (message or "").upper()
+
+        # gRPC canonical codes
+        # Retryable (non-fatal)
+        grpc_retryable = {1, 2, 4, 8, 10, 13, 14}  # CANCELLED, UNKNOWN, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, ABORTED, INTERNAL, UNAVAILABLE
+        # Fatal (non-retryable)
+        grpc_fatal = {3, 5, 6, 7, 9, 11, 12, 15, 16}  # INVALID_ARGUMENT, NOT_FOUND, ALREADY_EXISTS, PERMISSION_DENIED, FAILED_PRECONDITION, OUT_OF_RANGE, UNIMPLEMENTED, DATA_LOSS, UNAUTHENTICATED
+
+        # HTTP mappings commonly seen
+        http_retryable = {429, 503, 504}
+        http_fatal = {400, 401, 403, 404, 501}
+
+        if code in grpc_retryable or code in http_retryable:
+            return ModuleErrorCode.NON_FATAL_ERROR.value
+        if code in grpc_fatal or code in http_fatal:
+            return ModuleErrorCode.FATAL_ERROR.value
+
+        # Keyword fallbacks
+        retryable_hints = [
+            "UNAVAILABLE",
+            "DEADLINE_EXCEEDED",
+            "RESOURCE_EXHAUSTED",
+            "INTERNAL",
+            "ABORTED",
+            "RETRY",
+            "TIMEOUT",
+            "TEMPORARY",
+        ]
+        if any(h in text for h in retryable_hints):
+            return ModuleErrorCode.NON_FATAL_ERROR.value
+
+        if "CANCELLED" in text:
+            return ModuleErrorCode.NON_FATAL_ERROR.value
+
+        fatal_hints = [
+            "UNSUPPORTED",
+            "NOT SUPPORTED",
+            "INVALID",
+            "VALIDATION",
+            "PERMISSION_DENIED",
+            "UNAUTHENTICATED",
+            "NOT_FOUND",
+            "UNIMPLEMENTED",
+            "DATA_LOSS",
+            "OUT_OF_RANGE",
+            "FAILED_PRECONDITION",
+            "ALREADY_EXISTS",
+        ]
+        if any(h in text for h in fatal_hints):
+            return ModuleErrorCode.FATAL_ERROR.value
+
+        # Default non-fatal
+        return ModuleErrorCode.NON_FATAL_ERROR.value
 
     @override
     async def on_init(self, ten_env: AsyncTenEnv) -> None:
@@ -57,8 +167,10 @@ class GoogleASRExtension(AsyncASRBaseExtension):
         await super().on_init(ten_env)
         try:
             config_json, _ = await ten_env.get_property_to_json()
-            config_dict = json.loads(config_json)
-            self.config = GoogleASRConfig(**config_dict.get("params", {}))
+            # Load full config so root-level fields (e.g., dump, dump_path) are honored
+            self.config = GoogleASRConfig.model_validate_json(config_json)
+            # Merge params into top-level fields if provided
+            self.config.update(self.config.params)
 
             # Debug: Print ADC authentication information
             if self.config.project_id:
@@ -77,6 +189,16 @@ class GoogleASRExtension(AsyncASRBaseExtension):
                     f"Google ASR config validation failed: {error_msg}"
                 )
             ten_env.log_info("Google ASR configuration loaded and validated.")
+
+            # Initialize audio dumper if enabled
+            if self.config.dump:
+                dump_dir = self.config.dump_path or "."
+                os.makedirs(dump_dir, exist_ok=True)
+                dump_file_path = os.path.join(dump_dir, "google_asr_in.pcm")
+                self.audio_dumper = Dumper(dump_file_path)
+
+            # Initialize reconnect manager
+            self.reconnect_manager = ReconnectManager(logger=ten_env)
         except Exception as e:
             ten_env.log_error(f"Error during Google ASR initialization: {e}")
             raise Exception(f"Initialization failed: {e}") from e
@@ -94,7 +216,12 @@ class GoogleASRExtension(AsyncASRBaseExtension):
             )
 
         self.ten_env.log_info("Starting Google ASR connection...")
+        self.stopped = False
         try:
+            # Start audio dumper as early as possible so tests that only verify dumping succeed
+            if self.audio_dumper:
+                await self.audio_dumper.start()
+
             self.client = GoogleASRClient(
                 config=self.config,
                 ten_env=self.ten_env,
@@ -104,6 +231,8 @@ class GoogleASRExtension(AsyncASRBaseExtension):
             await self.client.start()
             self.connected = True
             self.ten_env.log_info("Google ASR connection started successfully.")
+            if self.reconnect_manager:
+                self.reconnect_manager.mark_connection_successful()
         except Exception as e:
             self.ten_env.log_error(
                 f"Failed to start Google ASR connection: {e}"
@@ -123,7 +252,13 @@ class GoogleASRExtension(AsyncASRBaseExtension):
             await self.client.stop()
         self.client = None
         self.connected = False
+        if self.audio_dumper:
+            await self.audio_dumper.stop()
         self.ten_env.log_info("Google ASR connection stopped.")
+        self.stopped = True
+        # Cancel any pending reconnect
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
 
     @override
     def is_connected(self) -> bool:
@@ -135,16 +270,20 @@ class GoogleASRExtension(AsyncASRBaseExtension):
         self, frame: AudioFrame, session_id: str | None
     ) -> bool:
         """Sends an audio frame for recognition."""
-        if not self.is_connected() or not self.client:
-            self.ten_env.log_warn("Cannot send audio, client not connected.")
-            return False
-
         if self.session_id != session_id:
             self.session_id = session_id
 
         buf = frame.lock_buf()
         try:
-            await self.client.send_audio(bytes(buf))
+            # Always dump audio if enabled, even if vendor client is not connected
+            if self.audio_dumper:
+                await self.audio_dumper.push_bytes(bytes(buf))
+
+            # Only forward to vendor client when connected
+            if self.is_connected() and self.client:
+                await self.client.send_audio(bytes(buf))
+            else:
+                self.ten_env.log_warn("Client not connected; audio dumped only.")
         finally:
             frame.unlock_buf(buf)
 
@@ -159,7 +298,41 @@ class GoogleASRExtension(AsyncASRBaseExtension):
 
         self.ten_env.log_info(f"Finalizing ASR for session: {session_id}")
         await self.client.finalize()
+        # Optional grace period for provider to deliver final result
+        try:
+            delay = 0.5
+            if self.config and hasattr(self.config, "finalize_grace_seconds"):
+                # type: ignore[attr-defined]
+                delay = float(getattr(self.config, "finalize_grace_seconds", 0.5))
+            await asyncio.sleep(delay)
+        except Exception:
+            ...
         await self.send_asr_finalize_end()
+
+    async def _handle_reconnect(self) -> None:
+        if not self.reconnect_manager:
+            return
+        # Avoid redundant attempts if already connected
+        if self.connected or self.stopped:
+            return
+        try:
+            success = await self.reconnect_manager.handle_reconnect(
+                connection_func=self.start_connection,
+                error_handler=None,
+            )
+            if success:
+                self.ten_env.log_debug("Google ASR reconnect attempt completed")
+        except Exception as e:
+            if self.ten_env:
+                self.ten_env.log_error(f"Reconnect attempt failed with exception: {e}")
+
+    @override
+    async def on_deinit(self, ten_env: AsyncTenEnv) -> None:
+        # Ensure we don't try to reconnect after deinit
+        self.stopped = True
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+        await super().on_deinit(ten_env)
 
     @override
     def input_audio_sample_rate(self) -> int:

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/extension.py
@@ -1,0 +1,174 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+
+
+import json
+from ten_runtime import (
+    AudioFrame,
+    AsyncTenEnv,
+)
+
+from typing_extensions import override
+from ten_ai_base.asr import (
+    AsyncASRBaseExtension,
+    ASRBufferConfig,
+    ASRBufferConfigModeKeep,
+    ASRResult,
+)
+from ten_ai_base.message import ModuleError, ModuleType
+
+from .config import GoogleASRConfig
+from .google_asr_client import GoogleASRClient
+
+
+class GoogleASRExtension(AsyncASRBaseExtension):
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.connected: bool = False
+        self.client: GoogleASRClient | None = None
+        self.config: GoogleASRConfig | None = None
+        self.session_id: str | None = None
+
+    @override
+    def vendor(self) -> str:
+        """Returns the name of the ASR service provider."""
+        return "google"
+
+    async def _on_asr_result(self, result: ASRResult):
+        """Callback for handling ASR results from the client."""
+        await self.send_asr_result(self.session_id, result)
+
+    async def _on_asr_error(self, code: int, message: str):
+        """Callback for handling errors from the client."""
+        await self.send_asr_error(
+            ModuleError(
+                module=ModuleType.ASR,
+                code=code,
+                message=message,
+            )
+        )
+
+    @override
+    async def on_init(self, ten_env: AsyncTenEnv) -> None:
+        """Loads the configuration from property.json."""
+        await super().on_init(ten_env)
+        try:
+            config_json, _ = await ten_env.get_property_to_json()
+            config_dict = json.loads(config_json)
+            self.config = GoogleASRConfig(**config_dict.get("params", {}))
+
+            # Debug: Print ADC authentication information
+            if self.config.project_id:
+                ten_env.log_info(f"Google ASR Project ID: {self.config.project_id}")
+            else:
+                ten_env.log_info("Google ASR Project ID not set, will use ADC default project")
+
+            if self.config.adc_credentials_path:
+                ten_env.log_info(f"Google ASR ADC credentials path: {self.config.adc_credentials_path}")
+            else:
+                ten_env.log_info("Google ASR ADC credentials path not set, will use environment variable or default ADC")
+
+            is_valid, error_msg = self.config.validate_config()
+            if not is_valid:
+                raise Exception(
+                    f"Google ASR config validation failed: {error_msg}"
+                )
+            ten_env.log_info("Google ASR configuration loaded and validated.")
+        except Exception as e:
+            ten_env.log_error(f"Error during Google ASR initialization: {e}")
+            raise Exception(f"Initialization failed: {e}") from e
+
+    @override
+    async def start_connection(self) -> None:
+        """Starts the connection to Google ASR."""
+        if self.connected:
+            self.ten_env.log_warn("Connection already started.")
+            return
+
+        if not self.config or not self.ten_env:
+            raise Exception(
+                "Extension not initialized properly. Config or ten_env is missing."
+            )
+
+        self.ten_env.log_info("Starting Google ASR connection...")
+        try:
+            self.client = GoogleASRClient(
+                config=self.config,
+                ten_env=self.ten_env,
+                on_result_callback=self._on_asr_result,
+                on_error_callback=self._on_asr_error,
+            )
+            await self.client.start()
+            self.connected = True
+            self.ten_env.log_info("Google ASR connection started successfully.")
+        except Exception as e:
+            self.ten_env.log_error(
+                f"Failed to start Google ASR connection: {e}"
+            )
+            self.connected = False
+            await self._on_asr_error(500, f"Failed to start connection: {e}")
+
+    @override
+    async def stop_connection(self) -> None:
+        """Stops the connection to Google ASR."""
+        if not self.connected:
+            self.ten_env.log_warn("Connection already stopped.")
+            return
+
+        self.ten_env.log_info("Stopping Google ASR connection...")
+        if self.client:
+            await self.client.stop()
+        self.client = None
+        self.connected = False
+        self.ten_env.log_info("Google ASR connection stopped.")
+
+    @override
+    def is_connected(self) -> bool:
+        """Checks the connection status."""
+        return self.connected and self.client is not None
+
+    @override
+    async def send_audio(
+        self, frame: AudioFrame, session_id: str | None
+    ) -> bool:
+        """Sends an audio frame for recognition."""
+        if not self.is_connected() or not self.client:
+            self.ten_env.log_warn("Cannot send audio, client not connected.")
+            return False
+
+        if self.session_id != session_id:
+            self.session_id = session_id
+
+        buf = frame.lock_buf()
+        try:
+            await self.client.send_audio(bytes(buf))
+        finally:
+            frame.unlock_buf(buf)
+
+        return True
+
+    @override
+    async def finalize(self, session_id: str | None) -> None:
+        """Finalizes the recognition for the current utterance."""
+        if not self.is_connected() or not self.client:
+            self.ten_env.log_warn("Cannot finalize, client not connected.")
+            return
+
+        self.ten_env.log_info(f"Finalizing ASR for session: {session_id}")
+        await self.client.finalize()
+        await self.send_asr_finalize_end()
+
+    @override
+    def input_audio_sample_rate(self) -> int:
+        """Returns the expected audio sample rate."""
+        if not self.config:
+            return 16000  # Default value
+        return self.config.sample_rate
+
+    @override
+    def buffer_strategy(self) -> ASRBufferConfig:
+        """Defines the audio buffer strategy."""
+        return ASRBufferConfigModeKeep(byte_limit=1024 * 1024 * 10)

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/extension.py
@@ -71,10 +71,7 @@ class GoogleASRExtension(AsyncASRBaseExtension):
             ),
         )
         # For non-fatal errors, attempt reconnect in background
-        if (
-            severity == ModuleErrorCode.NON_FATAL_ERROR.value
-            and not self.stopped
-        ):
+        if severity == ModuleErrorCode.NON_FATAL_ERROR.value and not self.stopped:
             try:
                 # Skip reconnect for client-side normal shutdowns
                 if (code == 1) or ("CANCELLED" in (message or "").upper()):
@@ -99,9 +96,7 @@ class GoogleASRExtension(AsyncASRBaseExtension):
                 # Cancel existing pending reconnect task if any
                 if self._reconnect_task and not self._reconnect_task.done():
                     self._reconnect_task.cancel()
-                self._reconnect_task = asyncio.create_task(
-                    self._handle_reconnect()
-                )
+                self._reconnect_task = asyncio.create_task(self._handle_reconnect())
 
                 def _clear_task(_):
                     self._reconnect_task = None
@@ -230,9 +225,8 @@ class GoogleASRExtension(AsyncASRBaseExtension):
             return
 
         if not self.config or not self.ten_env:
-            raise Exception(
-                "Extension not initialized properly. Config or ten_env is missing."
-            )
+            msg = "Extension not initialized properly. Config or ten_env is missing."
+            raise RuntimeError(msg)
 
         self.ten_env.log_info("Starting Google ASR connection...")
         self.stopped = False
@@ -285,9 +279,7 @@ class GoogleASRExtension(AsyncASRBaseExtension):
         return self.connected and self.client is not None
 
     @override
-    async def send_audio(
-        self, frame: AudioFrame, session_id: str | None
-    ) -> bool:
+    async def send_audio(self, frame: AudioFrame, session_id: str | None) -> bool:
         """Sends an audio frame for recognition."""
         if self.session_id != session_id:
             self.session_id = session_id
@@ -305,9 +297,7 @@ class GoogleASRExtension(AsyncASRBaseExtension):
                 )
                 await self.client.send_audio(bytes(buf))
             else:
-                self.ten_env.log_warn(
-                    "Client not connected; audio dumped only."
-                )
+                self.ten_env.log_warn("Client not connected; audio dumped only.")
         finally:
             frame.unlock_buf(buf)
 
@@ -344,9 +334,7 @@ class GoogleASRExtension(AsyncASRBaseExtension):
                 self.ten_env.log_debug("Google ASR reconnect attempt completed")
         except Exception as e:
             if self.ten_env:
-                self.ten_env.log_error(
-                    f"Reconnect attempt failed with exception: {e}"
-                )
+                self.ten_env.log_error(f"Reconnect attempt failed with exception: {e}")
 
     @override
     async def on_deinit(self, ten_env: AsyncTenEnv) -> None:

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/google_asr_client.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/google_asr_client.py
@@ -1,0 +1,323 @@
+import asyncio
+import os
+import time
+from queue import Queue, Empty
+from typing import Callable, Awaitable, Any
+
+from google.cloud import speech_v2 as speech
+from google.cloud.speech_v2.types import (
+    StreamingRecognitionConfig,
+    StreamingRecognizeRequest,
+)
+from google.api_core import exceptions as gcp_exceptions
+import grpc
+
+from ten_ai_base.struct import ASRResult, ASRWord
+from ten_runtime import AsyncTenEnv
+
+from .config import GoogleASRConfig
+
+
+class GoogleASRClient:
+    """Google Cloud Speech-to-Text V2 streaming client"""
+
+    def __init__(
+        self,
+        config: GoogleASRConfig,
+        ten_env: AsyncTenEnv,
+        on_result_callback: Callable[[ASRResult], Awaitable[None]],
+        on_error_callback: Callable[[int, str], Awaitable[None]],
+    ):
+        self.config = config
+        self.ten_env = ten_env
+        self.on_result_callback = on_result_callback
+        self.on_error_callback = on_error_callback
+
+        self.speech_client: speech.SpeechAsyncClient | None = None
+        self._audio_queue: Queue = Queue()
+        self._recognition_task: asyncio.Task | None = None
+        self._stop_event = asyncio.Event()
+        self.is_finalizing = False
+
+    async def start(self) -> None:
+        """Initializes the client and starts the recognition stream."""
+        self.ten_env.log_info("Starting Google ASR client...")
+        try:
+            await self._initialize_google_client()
+            self._stop_event.clear()
+            self.is_finalizing = False
+            self._recognition_task = asyncio.create_task(
+                self._run_recognition()
+            )
+            self.ten_env.log_info("Google ASR client started successfully.")
+        except Exception as e:
+            self.ten_env.log_error(f"Failed to start Google ASR client: {e}")
+            await self.on_error_callback(
+                500, f"Failed to start client: {str(e)}"
+            )
+            raise
+
+    async def _initialize_google_client(self) -> None:
+        """Initializes the Google Speech async client using ADC."""
+        try:
+            # Check for ADC credentials path from config or environment
+            credentials_path = self.config.adc_credentials_path or os.getenv('GOOGLE_APPLICATION_CREDENTIALS')
+
+            self.ten_env.log_info(f"ADC credentials path: {credentials_path}")
+
+            if credentials_path:
+                self.ten_env.log_info(f"Using Service Account credentials from: {credentials_path}")
+                if not os.path.exists(credentials_path):
+                    raise FileNotFoundError(f"Service Account file not found: {credentials_path}")
+
+                # Set the environment variable for Google Cloud SDK
+                os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = credentials_path
+            else:
+                self.ten_env.log_info("No ADC credentials path specified, using default ADC")
+
+            # Create client with ADC (Application Default Credentials)
+            # This will automatically use the best available credentials
+            if credentials_path:
+                # Explicitly pass credentials to ensure they are used
+                from google.auth import default
+                credentials, project = default()
+                self.speech_client = speech.SpeechAsyncClient(credentials=credentials)
+                self.ten_env.log_info(
+                    f"Initialized Google Speech V2 client with explicit credentials from {credentials_path}"
+                )
+            else:
+                # Use default ADC
+                self.speech_client = speech.SpeechAsyncClient()
+                self.ten_env.log_info(
+                    "Initialized Google Speech V2 client with Application Default Credentials"
+                )
+        except Exception as e:
+            self.ten_env.log_error(
+                f"Failed to initialize Google Speech client: {e}"
+            )
+            raise
+
+    async def stop(self) -> None:
+        """Stops the recognition stream and cleans up resources."""
+        self.ten_env.log_info("Stopping Google ASR client...")
+        if self._recognition_task and not self._recognition_task.done():
+            self._stop_event.set()
+            # Drain the queue to unblock the generator
+            while not self._audio_queue.empty():
+                self._audio_queue.get_nowait()
+            self._audio_queue.put(None)  # Signal generator to stop
+            try:
+                await asyncio.wait_for(self._recognition_task, timeout=5.0)
+            except asyncio.TimeoutError:
+                self.ten_env.log_warn(
+                    "Recognition task did not stop gracefully, cancelling."
+                )
+                self._recognition_task.cancel()
+        self.speech_client = None
+        self.ten_env.log_info("Google ASR client stopped.")
+
+    async def send_audio(self, chunk: bytes) -> None:
+        """Adds an audio chunk to the processing queue."""
+        if not self._stop_event.is_set():
+            self._audio_queue.put(chunk)
+
+    async def finalize(self) -> None:
+        """Signals that the current utterance is complete."""
+        self.ten_env.log_info("Finalizing utterance.")
+        self.is_finalizing = True
+        self._audio_queue.put(None)  # Signal end of audio stream
+
+    async def _audio_generator(self):
+        """Yields audio chunks from the queue for the gRPC stream."""
+        try:
+            # First request contains the configuration
+            config = self.config.get_recognition_config()
+            streaming_config = StreamingRecognitionConfig(
+                config=config,
+                streaming_features={
+                    "interim_results": self.config.interim_results
+                },
+            )
+            recognizer_path = self.config.get_recognizer_path()
+
+            self.ten_env.log_info(f"Using recognizer: {recognizer_path}")
+            self.ten_env.log_info(f"Using streaming config: {streaming_config}")
+
+            # First request must contain recognizer and streaming_config, not audio
+            # recognizer format: projects/{project}/locations/{location}/recognizers/{recognizer}
+            # According to Google Cloud Speech V2 docs, recognizer is required
+            recognizer_path = self.config.get_recognizer_path()
+            if recognizer_path:
+                self.ten_env.log_info(f"Using recognizer: {recognizer_path}")
+                yield StreamingRecognizeRequest(
+                    recognizer=recognizer_path,
+                    streaming_config=streaming_config
+                )
+            else:
+                # If no recognizer path, we need to get project_id from ADC
+                # This is a fallback for when project_id is not provided in config
+                self.ten_env.log_error("No recognizer path available. Please provide project_id in config.")
+                raise ValueError("Recognizer path is required for Google Cloud Speech V2 API")
+
+            while not self._stop_event.is_set():
+                try:
+                    chunk = self._audio_queue.get_nowait()
+                    if chunk is None:
+                        self.ten_env.log_info("Received end-of-stream signal")
+                        break
+                    # self.ten_env.log_info(
+                    #     f"Sending audio chunk of size {len(chunk)} bytes"
+                    # )
+                    yield speech.StreamingRecognizeRequest(audio=chunk)
+                except Empty:
+                    await asyncio.sleep(0.01)  # Wait for more audio
+        except Exception as e:
+            self.ten_env.log_error(f"Error in audio generator: {e}")
+            await self.on_error_callback(500, str(e))
+
+    async def _run_recognition(self) -> None:
+        """Run the streaming recognition loop with retry logic."""
+        retry_count = 0
+        while (
+            not self._stop_event.is_set()
+            and retry_count < self.config.max_retry_attempts
+        ):
+            try:
+                if not self.speech_client:
+                    raise ConnectionError(
+                        "Google Speech client is not initialized."
+                    )
+                requests = self._audio_generator()
+                self.ten_env.log_info("Starting streaming recognition...")
+                try:
+                    responses = await self.speech_client.streaming_recognize(
+                        requests=requests
+                    )
+                    self.ten_env.log_info("Got streaming response iterator")
+                    self.ten_env.log_info(f"Responses: {responses}")
+
+                    async for response in responses:
+                        if self._stop_event.is_set():
+                            break
+                        self.ten_env.log_info(f"Received response: {response}")
+                        await self._process_response(response)
+                except Exception as e:
+                    self.ten_env.log_error(f"Error in streaming_recognize: {e}")
+                    await self.on_error_callback(500, str(e))
+
+                # If the loop finishes without exceptions, reset retry count
+                retry_count = 0
+                if self.is_finalizing:
+                    break  # Clean exit after finalize
+
+            except (gcp_exceptions.GoogleAPICallError, grpc.RpcError) as e:
+                error_code = (
+                    e.code().value[0]
+                    if hasattr(e, "code") and hasattr(e.code(), "value")
+                    else 500
+                )
+                error_message = e.details() if hasattr(e, "details") else str(e)
+
+                # Provide more specific error information for common issues
+                if "IAM_PERMISSION_DENIED" in error_message:
+                    self.ten_env.log_error(
+                        f"Google Cloud Speech API permission denied ({error_code}): {error_message}"
+                    )
+                    self.ten_env.log_error(
+                        "Please ensure the service account has the following roles:"
+                    )
+                    self.ten_env.log_error(
+                        "- Speech-to-Text API User (roles/speech.client)"
+                    )
+                    self.ten_env.log_error(
+                        "- Or custom role with 'speech.recognizers.recognize' permission"
+                    )
+                else:
+                    self.ten_env.log_error(
+                        f"Google API/gRPC error ({error_code}): {error_message}"
+                    )
+
+                await self.on_error_callback(error_code, error_message)
+
+                if self._is_retryable_error(e):
+                    retry_count += 1
+                    self.ten_env.log_warn(
+                        f"Retryable error encountered. Attempt {retry_count}/{self.config.max_retry_attempts}. Retrying in {self.config.retry_delay}s..."
+                    )
+                    await asyncio.sleep(self.config.retry_delay)
+                else:
+                    self.ten_env.log_error(
+                        "Non-retryable error encountered. Stopping recognition."
+                    )
+                    break  # Non-retryable error
+
+            except Exception as e:
+                self.ten_env.log_error(
+                    f"Unexpected error in recognition loop: {e}"
+                )
+                await self.on_error_callback(500, str(e))
+                break
+
+    async def _process_response(
+        self, response: speech.StreamingRecognizeResponse
+    ) -> None:
+        """Process a streaming recognition response and trigger callbacks."""
+        self.ten_env.log_info(
+            f"Processing response with {len(response.results)} results"
+        )
+        for result in response.results:
+            if not result.alternatives:
+                self.ten_env.log_info("Skipping result with no alternatives")
+                continue
+
+            # We'll use the first alternative as the primary result.
+            first_alt = result.alternatives[0]
+            words = [
+                ASRWord(
+                    text=word.word,
+                    start_ms=int(word.start_offset.total_seconds() * 1000),
+                    duration_ms=int(
+                        (word.end_offset - word.start_offset).total_seconds()
+                        * 1000
+                    ),
+                    confidence=word.confidence,
+                )
+                for word in first_alt.words
+            ]
+
+            asr_result = ASRResult(
+                is_final=result.is_final,
+                text=first_alt.transcript,
+                words=words,
+                confidence=first_alt.confidence,
+                language=result.language_code,
+                start_ms=(int(words[0].start_ms) if words else 0),
+                duration_ms=(
+                    int(
+                        words[-1].start_ms
+                        + words[-1].duration_ms
+                        - words[0].start_ms
+                    )
+                    if words
+                    else 0
+                ),
+            )
+            await self.on_result_callback(asr_result)
+
+    def _is_retryable_error(self, error: Exception) -> bool:
+        """Check if a gRPC/API error is retryable."""
+        if isinstance(error, gcp_exceptions.RetryError):
+            return True
+        if isinstance(error, grpc.RpcError):
+            # List of retryable gRPC status codes
+            retryable_codes = [
+                grpc.StatusCode.UNAVAILABLE,
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                grpc.StatusCode.INTERNAL,
+            ]
+            # Don't retry permission denied errors
+            if error.code() == grpc.StatusCode.PERMISSION_DENIED:
+                return False
+            return error.code() in retryable_codes
+        return False

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/google_asr_client.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/google_asr_client.py
@@ -1,8 +1,7 @@
 import asyncio
 import os
-import time
-from queue import Queue, Empty
-from typing import Callable, Awaitable, Any
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from google.cloud import speech_v2 as speech
 from google.cloud.speech_v2.types import (
@@ -10,9 +9,11 @@ from google.cloud.speech_v2.types import (
     StreamingRecognizeRequest,
 )
 from google.api_core import exceptions as gcp_exceptions
+from google.api_core.client_options import ClientOptions
 import grpc
 
 from ten_ai_base.struct import ASRResult, ASRWord
+
 from ten_runtime import AsyncTenEnv
 
 from .config import GoogleASRConfig
@@ -34,10 +35,25 @@ class GoogleASRClient:
         self.on_error_callback = on_error_callback
 
         self.speech_client: speech.SpeechAsyncClient | None = None
-        self._audio_queue: Queue = Queue()
+        self._audio_queue: asyncio.Queue = asyncio.Queue()
         self._recognition_task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
         self.is_finalizing = False
+        self._has_sent_final_result = False
+
+    def _normalize_language_code(self, code: str | None) -> str:
+        """Normalize provider language codes to framework-expected ones.
+
+        - Map Google V2 Chinese codes like `cmn-Hans-CN`/`cmn-Hans` to `zh-CN`
+        - Preserve known English code `en-US`
+        - Fallback to original code if no mapping is needed
+        """
+        if not code:
+            return ""
+        lowered = code.strip()
+        if lowered.startswith("cmn-Hans"):
+            return "zh-CN"
+        return lowered
 
     async def start(self) -> None:
         """Initializes the client and starts the recognition stream."""
@@ -75,19 +91,39 @@ class GoogleASRClient:
             else:
                 self.ten_env.log_info("No ADC credentials path specified, using default ADC")
 
+            # Choose regional endpoint if location is set and not global
+            api_endpoint: str | None = None
+            if getattr(self.config, "location", "global") and self.config.location != "global":
+                api_endpoint = f"{self.config.location}-speech.googleapis.com"
+                self.ten_env.log_info(f"Using regional endpoint: {api_endpoint}")
+
+            client_options = ClientOptions(api_endpoint=api_endpoint) if api_endpoint else None
+
             # Create client with ADC (Application Default Credentials)
             # This will automatically use the best available credentials
             if credentials_path:
                 # Explicitly pass credentials to ensure they are used
                 from google.auth import default
                 credentials, project = default()
-                self.speech_client = speech.SpeechAsyncClient(credentials=credentials)
+                if client_options:
+                    self.speech_client = speech.SpeechAsyncClient(
+                        credentials=credentials, client_options=client_options
+                    )
+                else:
+                    self.speech_client = speech.SpeechAsyncClient(
+                        credentials=credentials
+                    )
                 self.ten_env.log_info(
                     f"Initialized Google Speech V2 client with explicit credentials from {credentials_path}"
                 )
             else:
                 # Use default ADC
-                self.speech_client = speech.SpeechAsyncClient()
+                if client_options:
+                    self.speech_client = speech.SpeechAsyncClient(
+                        client_options=client_options
+                    )
+                else:
+                    self.speech_client = speech.SpeechAsyncClient()
                 self.ten_env.log_info(
                     "Initialized Google Speech V2 client with Application Default Credentials"
                 )
@@ -104,10 +140,13 @@ class GoogleASRClient:
             self._stop_event.set()
             # Drain the queue to unblock the generator
             while not self._audio_queue.empty():
-                self._audio_queue.get_nowait()
-            self._audio_queue.put(None)  # Signal generator to stop
+                try:
+                    await self._audio_queue.get()
+                except Exception:
+                    break
+            await self._audio_queue.put(None)  # Signal generator to stop
             try:
-                await asyncio.wait_for(self._recognition_task, timeout=5.0)
+                await asyncio.wait_for(self._recognition_task, timeout=1.0)
             except asyncio.TimeoutError:
                 self.ten_env.log_warn(
                     "Recognition task did not stop gracefully, cancelling."
@@ -119,13 +158,13 @@ class GoogleASRClient:
     async def send_audio(self, chunk: bytes) -> None:
         """Adds an audio chunk to the processing queue."""
         if not self._stop_event.is_set():
-            self._audio_queue.put(chunk)
+            await self._audio_queue.put(chunk)
 
     async def finalize(self) -> None:
         """Signals that the current utterance is complete."""
         self.ten_env.log_info("Finalizing utterance.")
         self.is_finalizing = True
-        self._audio_queue.put(None)  # Signal end of audio stream
+        await self._audio_queue.put(None)  # Signal end of audio stream
 
     async def _audio_generator(self):
         """Yields audio chunks from the queue for the gRPC stream."""
@@ -135,7 +174,7 @@ class GoogleASRClient:
             streaming_config = StreamingRecognitionConfig(
                 config=config,
                 streaming_features={
-                    "interim_results": self.config.interim_results
+                    "interim_results": self.config.interim_results,
                 },
             )
             recognizer_path = self.config.get_recognizer_path()
@@ -160,17 +199,11 @@ class GoogleASRClient:
                 raise ValueError("Recognizer path is required for Google Cloud Speech V2 API")
 
             while not self._stop_event.is_set():
-                try:
-                    chunk = self._audio_queue.get_nowait()
-                    if chunk is None:
-                        self.ten_env.log_info("Received end-of-stream signal")
-                        break
-                    # self.ten_env.log_info(
-                    #     f"Sending audio chunk of size {len(chunk)} bytes"
-                    # )
-                    yield speech.StreamingRecognizeRequest(audio=chunk)
-                except Empty:
-                    await asyncio.sleep(0.01)  # Wait for more audio
+                chunk = await self._audio_queue.get()
+                if chunk is None:
+                    self.ten_env.log_info("Received end-of-stream signal")
+                    break
+                yield speech.StreamingRecognizeRequest(audio=chunk)
         except Exception as e:
             self.ten_env.log_error(f"Error in audio generator: {e}")
             await self.on_error_callback(500, str(e))
@@ -193,14 +226,27 @@ class GoogleASRClient:
                     responses = await self.speech_client.streaming_recognize(
                         requests=requests
                     )
-                    self.ten_env.log_info("Got streaming response iterator")
-                    self.ten_env.log_info(f"Responses: {responses}")
+                    if getattr(self.config, "enable_detailed_logging", False):
+                        self.ten_env.log_info("Got streaming response iterator")
+                        self.ten_env.log_debug(f"Responses: {responses}")
 
                     async for response in responses:
                         if self._stop_event.is_set():
                             break
-                        self.ten_env.log_info(f"Received response: {response}")
+                        if getattr(self.config, "enable_detailed_logging", False):
+                            self.ten_env.log_debug(f"Received response: {response}")
                         await self._process_response(response)
+                except grpc.RpcError as e:
+                    error_code = (
+                        e.code().value[0]
+                        if hasattr(e, "code") and hasattr(e.code(), "value")
+                        else 500
+                    )
+                    error_message = e.details() if hasattr(e, "details") else str(e)
+                    self.ten_env.log_error(
+                        f"gRPC error in streaming_recognize ({error_code}): {error_message}"
+                    )
+                    await self.on_error_callback(error_code, error_message)
                 except Exception as e:
                     self.ten_env.log_error(f"Error in streaming_recognize: {e}")
                     await self.on_error_callback(500, str(e))
@@ -262,9 +308,10 @@ class GoogleASRClient:
         self, response: speech.StreamingRecognizeResponse
     ) -> None:
         """Process a streaming recognition response and trigger callbacks."""
-        self.ten_env.log_info(
-            f"Processing response with {len(response.results)} results"
-        )
+        if getattr(self.config, "enable_detailed_logging", False):
+            self.ten_env.log_info(
+                f"Processing response with {len(response.results)} results"
+            )
         for result in response.results:
             if not result.alternatives:
                 self.ten_env.log_info("Skipping result with no alternatives")
@@ -272,25 +319,32 @@ class GoogleASRClient:
 
             # We'll use the first alternative as the primary result.
             first_alt = result.alternatives[0]
-            words = [
-                ASRWord(
-                    text=word.word,
-                    start_ms=int(word.start_offset.total_seconds() * 1000),
-                    duration_ms=int(
-                        (word.end_offset - word.start_offset).total_seconds()
-                        * 1000
-                    ),
-                    confidence=word.confidence,
+            words = []
+            for w in first_alt.words:
+                start_ms = int(w.start_offset.total_seconds() * 1000)
+                duration_ms = int(
+                    (w.end_offset - w.start_offset).total_seconds() * 1000
                 )
-                for word in first_alt.words
-            ]
+                # Align with ASRWord schema used elsewhere in the project
+                words.append(
+                    ASRWord(
+                        word=w.word,
+                        start_ms=start_ms,
+                        duration_ms=duration_ms,
+                        stable=bool(result.is_final),
+                    )
+                )
+
+            normalized_lang = self._normalize_language_code(result.language_code)
+            if not normalized_lang:
+                normalized_lang = self._normalize_language_code(self.config.language)
 
             asr_result = ASRResult(
-                is_final=result.is_final,
+                final=result.is_final,
                 text=first_alt.transcript,
                 words=words,
                 confidence=first_alt.confidence,
-                language=result.language_code,
+                language=normalized_lang,
                 start_ms=(int(words[0].start_ms) if words else 0),
                 duration_ms=(
                     int(
@@ -303,6 +357,8 @@ class GoogleASRClient:
                 ),
             )
             await self.on_result_callback(asr_result)
+            if result.is_final:
+                self._has_sent_final_result = True
 
     def _is_retryable_error(self, error: Exception) -> bool:
         """Check if a gRPC/API error is retryable."""

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/manifest.json
@@ -1,0 +1,35 @@
+{
+    "type": "extension",
+    "name": "google_asr_python",
+    "version": "0.1.0",
+    "dependencies": [
+        {
+            "type": "system",
+            "name": "ten_runtime_python",
+            "version": "0.10"
+        },
+        {
+            "type": "system",
+            "name": "ten_ai_base",
+            "version": "=0.6.21"
+        }
+    ],
+    "api": {
+        "property": {
+            "properties": {
+                "project_id": {
+                    "type": "string"
+                },
+                "api_key": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/manifest.json
@@ -11,7 +11,7 @@
         {
             "type": "system",
             "name": "ten_ai_base",
-            "version": "=0.6.21"
+            "version": "=0.6.26"
         }
     ],
     "api": {
@@ -20,7 +20,10 @@
                 "project_id": {
                     "type": "string"
                 },
-                "api_key": {
+                "adc_credentials_path": {
+                    "type": "string"
+                },
+                "location": {
                     "type": "string"
                 },
                 "model": {

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/manifest.json
@@ -11,7 +11,7 @@
         {
             "type": "system",
             "name": "ten_ai_base",
-            "version": "=0.6.26"
+            "version": "0.6"
         }
     ],
     "api": {

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/property.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/property.json
@@ -1,0 +1,17 @@
+{
+    "params": {
+        "project_id": "${env:GOOGLE_ASR_PROJECT_ID}",
+        "location": "global",
+        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS}",
+        "language": "en-US",
+        "sample_rate": 16000,
+        "channels": 1,
+        "encoding": "LINEAR16",
+        "enable_automatic_punctuation": true,
+        "enable_word_time_offsets": true,
+        "enable_word_confidence": true,
+        "interim_results": true,
+        "max_retry_attempts": 3,
+        "retry_delay": 1.0
+    }
+}

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/property.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/property.json
@@ -2,7 +2,8 @@
     "params": {
         "project_id": "${env:GOOGLE_ASR_PROJECT_ID}",
         "location": "global",
-        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS}",
+        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS_PATH}",
+        "adc_credentials_string": "${env:GOOGLE_APPLICATION_CREDENTIALS_STRING}",
         "language": "en-US",
         "model": "long",
         "sample_rate": 16000,

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/reconnect_manager.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/reconnect_manager.py
@@ -1,0 +1,98 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+
+from ten_ai_base.message import ModuleError, ModuleErrorCode, ModuleType
+
+
+class ReconnectManager:
+    """
+    Manages reconnection attempts with fixed retry limit and exponential backoff.
+
+    - Fixed retry limit (default: 5 attempts)
+    - Exponential backoff: 300ms, 600ms, 1.2s, 2.4s, 4.8s
+    - Counter resets after successful connection
+    """
+
+    def __init__(
+        self,
+        max_attempts: int = 5,
+        base_delay: float = 0.3,
+        logger=None,
+    ):
+        self.max_attempts = max_attempts
+        self.base_delay = base_delay
+        self.logger = logger
+
+        self.attempts = 0
+        self._connection_successful = False
+
+    def reset_counter(self) -> None:
+        self.attempts = 0
+        if self.logger:
+            self.logger.log_debug("Reconnect counter reset")
+
+    def mark_connection_successful(self) -> None:
+        self._connection_successful = True
+        self.reset_counter()
+
+    def can_retry(self) -> bool:
+        return self.attempts < self.max_attempts
+
+    def get_attempts_info(self) -> dict:
+        return {
+            "current_attempts": self.attempts,
+            "max_attempts": self.max_attempts,
+            "can_retry": self.can_retry(),
+        }
+
+    async def handle_reconnect(
+        self,
+        connection_func: Callable[[], Awaitable[None]],
+        error_handler: Callable[[ModuleError], Awaitable[None]] | None = None,
+    ) -> bool:
+        if not self.can_retry():
+            if self.logger:
+                self.logger.log_error(
+                    f"Maximum reconnection attempts ({self.max_attempts}) reached. No more attempts allowed."
+                )
+            if error_handler:
+                await error_handler(
+                    ModuleError(
+                        module=ModuleType.ASR,
+                        code=ModuleErrorCode.FATAL_ERROR.value,
+                        message=f"Failed to reconnect after {self.max_attempts} attempts",
+                    )
+                )
+            return False
+
+        self._connection_successful = False
+        self.attempts += 1
+
+        delay = self.base_delay * (2 ** (self.attempts - 1))
+        if self.logger:
+            self.logger.log_warn(
+                f"Attempting reconnection #{self.attempts}/{self.max_attempts} after {delay} seconds delay..."
+            )
+
+        try:
+            await asyncio.sleep(delay)
+            await connection_func()
+            if self.logger:
+                self.logger.log_debug(
+                    f"Connection function completed for attempt #{self.attempts}"
+                )
+            return True
+        except Exception as e:
+            if self.logger:
+                self.logger.log_error(
+                    f"Reconnection attempt #{self.attempts} failed: {e}"
+                )
+            if self.attempts >= self.max_attempts and error_handler:
+                await error_handler(
+                    ModuleError(
+                        module=ModuleType.ASR,
+                        code=ModuleErrorCode.FATAL_ERROR.value,
+                        message=f"All reconnection attempts failed. Last error: {str(e)}",
+                    )
+                )
+            return False

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/requirements.txt
@@ -1,0 +1,3 @@
+# Google Cloud Speech-to-Text client library
+google-cloud-speech
+pytest==8.3.4

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/bin/start
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/bin/start
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+export PYTHONPATH=.ten/app:.ten/app/ten_packages/system/ten_runtime_python/lib:.ten/app/ten_packages/system/ten_runtime_python/interface:.ten/app/ten_packages/system/ten_ai_base/interface:$PYTHONPATH
+
+# If the Python app imports some modules that are compiled with a different
+# version of libstdc++ (ex: PyTorch), the Python app may encounter confusing
+# errors. To solve this problem, we can preload the correct version of
+# libstdc++.
+#
+# export LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6
+#
+# Another solution is to make sure the module 'ten_runtime_python' is imported
+# _after_ the module that requires another version of libstdc++ is imported.
+#
+# Refer to https://github.com/pytorch/pytorch/issues/102360?from_wecom=1#issuecomment-1708989096
+
+pytest tests/ "$@"

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_en.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_en.json
@@ -4,12 +4,12 @@
         "location": "global",
         "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS}",
         "language": "en-US",
+        "model": "long",
         "sample_rate": 16000,
         "channels": 1,
         "encoding": "LINEAR16",
         "enable_automatic_punctuation": true,
         "enable_word_time_offsets": true,
-        "enable_word_confidence": true,
         "interim_results": true,
         "max_retry_attempts": 3,
         "retry_delay": 1.0

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_en.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_en.json
@@ -1,0 +1,17 @@
+{
+    "params": {
+        "project_id": "${env:GOOGLE_ASR_PROJECT_ID}",
+        "location": "global",
+        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS}",
+        "language": "en-US",
+        "sample_rate": 16000,
+        "channels": 1,
+        "encoding": "LINEAR16",
+        "enable_automatic_punctuation": true,
+        "enable_word_time_offsets": true,
+        "enable_word_confidence": true,
+        "interim_results": true,
+        "max_retry_attempts": 3,
+        "retry_delay": 1.0
+    }
+}

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_en.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_en.json
@@ -2,7 +2,8 @@
     "params": {
         "project_id": "${env:GOOGLE_ASR_PROJECT_ID}",
         "location": "global",
-        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS}",
+        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS_PATH}",
+        "adc_credentials_string": "${env:GOOGLE_APPLICATION_CREDENTIALS_STRING}",
         "language": "en-US",
         "model": "long",
         "sample_rate": 16000,

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_invalid.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_invalid.json
@@ -1,10 +1,10 @@
 {
     "params": {
         "project_id": "${env:GOOGLE_ASR_PROJECT_ID}",
-        "location": "global",
+        "location": "asia-southeast1",
         "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS}",
-        "language": "en-US",
-        "model": "long",
+        "language": "cmn-Hans-CN",
+        "model": "chirp",
         "sample_rate": 16000,
         "channels": 1,
         "encoding": "LINEAR16",

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_invalid.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_invalid.json
@@ -2,7 +2,8 @@
     "params": {
         "project_id": "${env:GOOGLE_ASR_PROJECT_ID}",
         "location": "asia-southeast1",
-        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS}",
+        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS_PATH}",
+        "adc_credentials_string": "${env:GOOGLE_APPLICATION_CREDENTIALS_STRING}",
         "language": "cmn-Hans-CN",
         "model": "chirp",
         "sample_rate": 16000,

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_zh.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_zh.json
@@ -1,15 +1,15 @@
 {
     "params": {
         "project_id": "${env:GOOGLE_ASR_PROJECT_ID}",
-        "location": "global",
+        "location": "us-central1",
         "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS}",
-        "language": "en-US",
-        "model": "long",
+        "language": "cmn-Hans-CN",
+        "model": "chirp_2",
         "sample_rate": 16000,
         "channels": 1,
         "encoding": "LINEAR16",
         "enable_automatic_punctuation": true,
-        "enable_word_time_offsets": true,
+        "enable_word_time_offsets": false,
         "interim_results": true,
         "max_retry_attempts": 3,
         "retry_delay": 1.0

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_zh.json
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/configs/property_zh.json
@@ -2,7 +2,8 @@
     "params": {
         "project_id": "${env:GOOGLE_ASR_PROJECT_ID}",
         "location": "us-central1",
-        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS}",
+        "adc_credentials_path": "${env:GOOGLE_APPLICATION_CREDENTIALS_PATH}",
+        "adc_credentials_string": "${env:GOOGLE_APPLICATION_CREDENTIALS_STRING}",
         "language": "cmn-Hans-CN",
         "model": "chirp_2",
         "sample_rate": 16000,

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/mock.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/mock.py
@@ -1,0 +1,33 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+@pytest.fixture
+def patch_google_asr():
+    """
+    Pytest fixture to patch the Google Cloud Speech client.
+    This fixture mocks the SpeechAsyncClient to prevent actual network calls
+    and allow simulating responses from the Google ASR service.
+    """
+
+    # Mock the SpeechAsyncClient instance that will be created
+    recognizer_instance = MagicMock()
+
+    # Mock the main client class
+    speech_client_mock = MagicMock()
+    speech_client_mock.return_value = recognizer_instance
+
+    # Since SpeechAsyncClient is used with 'from google.cloud import speech_v2 as speech',
+    # we need to patch 'speech.SpeechAsyncClient'.
+    # However, for simplicity and to avoid complex patching issues with namespaces,
+    # we will inject this mock manually in the test.
+    # This fixture will provide the necessary mocked objects.
+
+    # We will also mock the from_service_account_file class method
+    from_service_account_mock = MagicMock()
+    from_service_account_mock.return_value = recognizer_instance
+
+    return {
+        "client_class": speech_client_mock,
+        "recognizer_instance": recognizer_instance,
+        "from_service_account_file": from_service_account_mock
+    }

--- a/ai_agents/agents/ten_packages/extension/google_asr_python/tests/test_extension.py
+++ b/ai_agents/agents/ten_packages/extension/google_asr_python/tests/test_extension.py
@@ -1,0 +1,114 @@
+import asyncio
+import json
+import threading
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from ten_runtime import (
+    AsyncExtensionTester,
+    AsyncTenEnvTester,
+    Data,
+    TenError,
+    TenErrorCode,
+)
+from ten_ai_base.struct import ASRResult
+
+
+class GoogleAsrExtensionTester(AsyncExtensionTester):
+    """
+    A dedicated tester for the Google ASR Extension.
+    Its main role is to check the results received from the extension.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.asr_final_result_received = False
+
+    async def on_data(
+        self, ten_env_tester: AsyncTenEnvTester, data: Data
+    ) -> None:
+        data_name = data.get_name()
+        if data_name == "asr_result":
+            self.asr_final_result_received = True
+            ten_env_tester.log_info("Final ASR result received, stopping test.")
+            ten_env_tester.stop_test()
+
+    async def on_stop(self, ten_env_tester: AsyncTenEnvTester) -> None:
+        if not self.asr_final_result_received:
+            err = TenError.create(
+                TenErrorCode.ErrorCodeGeneric,
+                "Test finished without receiving a final ASR result",
+            )
+            ten_env_tester.set_error(err)
+
+
+def test_initialization_and_connection():
+    """
+    Tests the basic initialization and connection flow by mocking the GoogleASRClient.
+    """
+
+    captured_on_result_callback = None
+    main_loop = asyncio.get_event_loop()
+
+    def trigger_final_response():
+        """
+        Runs in a thread, sends a result back to the main event loop.
+        """
+        if not captured_on_result_callback:
+            return
+
+        final_result = ASRResult(
+            is_final=True,
+            text="hello world",
+            words=[],
+            confidence=0.9,
+            language="en-US",
+        )
+
+        asyncio.run_coroutine_threadsafe(
+            captured_on_result_callback(final_result), loop=main_loop
+        )
+
+    # This is now a synchronous function, just like in the Azure example
+    def fake_start():
+        threading.Timer(0.5, trigger_final_response).start()
+
+    def fake_init(
+        self,
+        config,
+        ten_env,
+        on_result_callback: callable,
+        on_error_callback: callable,
+    ):
+        nonlocal captured_on_result_callback
+        captured_on_result_callback = on_result_callback
+
+        # Assign the synchronous fake_start directly to the start method.
+        # The 'await' in the extension will handle the None return value correctly.
+        self.start = fake_start
+        self.stop = AsyncMock()
+        self.send_audio = AsyncMock()
+        self.finalize = AsyncMock()
+
+    MockGoogleASRClient = MagicMock()
+    MockGoogleASRClient.side_effect = fake_init
+
+    with patch("extension.GoogleASRClient", MockGoogleASRClient):
+        property_json = {
+            "params": {
+                "project_id": "fake-project-id",
+                "language_codes": ["en-US"],
+                "model": "long",
+            }
+        }
+
+        tester = GoogleAsrExtensionTester()
+        tester.set_test_mode_single(
+            "google_asr_python", json.dumps(property_json)
+        )
+
+        err = tester.run()
+
+        assert (
+            err is None
+        ), f"test_initialization_and_connection failed with error: {err}"
+        assert tester.asr_final_result_received is True


### PR DESCRIPTION
- Google ASR
  - Add ADC credentials via JSON string
    - New config `adc_credentials_string` and env `GOOGLE_APPLICATION_CREDENTIALS_STRING`
    - Priority: adc_credentials_path > adc_credentials_string > default ADC
    - In-memory JSON (no temp files)
  - Streamline logs
    - Move high-frequency/sensitive info to debug (credentials source, streaming config, recognizer)
    - Keep lifecycle at info (start/stop/start recognition)
  - Error handling
    - Use str(e) for gRPC errors to avoid static-analysis callability issues
    - Use RuntimeError for init validation failures

- Bytedance ASR
  - Fix lint (E1101): copy `config.params` to dict before encrypting to avoid FieldInfo no-member

- Usage example
```bash
export GOOGLE_APPLICATION_CREDENTIALS_STRING='{"type":"service_account","project_id":"xxx","private_key_id":"...","private_key":"-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n","client_email":"...","client_id":"...","token_uri":"https://oauth2.googleapis.com/token"}'
```

- Impact
  - Backward compatible; path-based ADC still works
  - Cleaner logs; improved robustness in error reporting

- Key files
  - ai_agents/agents/ten_packages/extension/google_asr_python/google_asr_client.py
  - ai_agents/agents/ten_packages/extension/google_asr_python/extension.py
  - ai_agents/agents/ten_packages/extension/google_asr_python/property.json
  - ai_agents/agents/ten_packages/extension/bytedance_asr/config.py