### PR TITLE
fix: fix wrong dump file naming convention in OpenaiTTSExtension

### DIFF
--- a/ai_agents/agents/ten_packages/extension/openai_tts2_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/openai_tts2_python/extension.py
@@ -196,7 +196,7 @@ class OpenaiTTSExtension(AsyncTTS2BaseExtension):
                     if t.request_id not in self.recorder_map:
                         dump_file_path = os.path.join(
                             self.config.dump_path,
-                            f"minimax_dump_{t.request_id}.pcm",
+                            f"openai_dump_{t.request_id}.pcm",
                         )
                         self.recorder_map[t.request_id] = PCMWriter(
                             dump_file_path

--- a/ai_agents/agents/ten_packages/extension/openai_tts2_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/openai_tts2_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "openai_tts2_python",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": [
     {
       "type": "system",


### PR DESCRIPTION
* fix: fix wrong dump file naming convention in OpenaiTTSExtension
* chore: update version to 0.1.3 in openai_tts2_python manifest