### PR TITLE
refactor: update DesignerGraphMessageFlow to use Option for name and names fields

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "env": {
         "LD_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/tests/standalone/",
         "ASAN_OPTIONS": "abort_on_error=1"
-      },
+      }
     },
     {
       "name": "ten_utils_unit_test (cppdbg)",
@@ -188,20 +188,20 @@
         "env": {
           "CARGO_TARGET_DIR": "${workspaceFolder}/out/linux/x64/ten_manager/",
           "CLINGO_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/gen/cmake/clingo/install/lib/",
-          "RUST_BACKTRACE": "full",
-        },
+          "RUST_BACKTRACE": "full"
+        }
       },
       "args": [
         "--config-file=${workspaceFolder}/out/linux/x64/tests/local_registry/config.json",
-        "install",
+        "install"
       ],
       "env": {
         "LD_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/gen/cmake/clingo/install/lib/",
-        "RUST_BACKTRACE": "full",
+        "RUST_BACKTRACE": "full"
       },
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman test (rust)",
@@ -222,19 +222,19 @@
         "env": {
           "CARGO_TARGET_DIR": "${workspaceFolder}/out/linux/x64/ten_manager/",
           "CLINGO_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/gen/cmake/clingo/install/lib/",
-          "RUST_BACKTRACE": "full",
-        },
+          "RUST_BACKTRACE": "full"
+        }
       },
       "args": [
         "--test-threads=1"
       ],
       "env": {
         "LD_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/ten_manager/lib/",
-        "RUST_BACKTRACE": "full",
+        "RUST_BACKTRACE": "full"
       },
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman install (lldb)",
@@ -248,7 +248,7 @@
       "env": {},
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman delete (lldb)",
@@ -260,12 +260,12 @@
         "delete",
         "extension",
         "uap",
-        "0.1.1",
+        "0.1.1"
       ],
       "env": {},
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman_test (lldb)",
@@ -276,7 +276,7 @@
       "args": [],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman check (lldb)",
@@ -289,7 +289,7 @@
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman create app (lldb)",
@@ -305,7 +305,7 @@
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman install_cpp_app_oss (lldb)",
@@ -325,7 +325,7 @@
       },
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman install_nodejs_app_mock (lldb)",
@@ -337,11 +337,11 @@
         "--config-file=${workspaceFolder}/out/linux/x64/tests/local_registry/config.json",
         "install",
         "app",
-        "smart_meeting_minutes",
+        "smart_meeting_minutes"
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman install_extension_mock (lldb)",
@@ -352,11 +352,11 @@
       "args": [
         "--config-file=${workspaceFolder}/out/linux/x64/tests/local_registry/config.json",
         "install",
-        "--standalone",
+        "--standalone"
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman install_protocol_mock (lldb)",
@@ -373,7 +373,7 @@
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman install_app_mock (lldb)",
@@ -391,7 +391,7 @@
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman install_all (lldb)",
@@ -402,11 +402,11 @@
       "args": [
         "--verbose",
         "--config-file=${workspaceFolder}/out/linux/x64/tests/local_registry/config.json",
-        "install",
+        "install"
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman fetch (lldb)",
@@ -423,7 +423,7 @@
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman publish_mock (lldb)",
@@ -433,11 +433,11 @@
       "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/ten_manager/install/extension/mock_extension",
       "args": [
         "--config-file=${workspaceFolder}/out/linux/x64/tests/local_registry/config.json",
-        "install",
+        "install"
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman publish extension (lldb)",
@@ -447,25 +447,34 @@
       "cwd": "${workspaceFolder}/out/linux/x64/ten_packages/extension/default_extension_cpp",
       "args": [
         "--config-file=${workspaceFolder}/out/linux/x64/tests/local_registry/config.json",
-        "publish",
+        "publish"
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman designer (lldb)",
       "type": "lldb",
       "request": "launch",
-      "program": "tman",
-      "cwd": "${workspaceFolder}/core/src/ten_manager/tests/test_data/cmd_check_predefined_graph_with_subgraph",
+      "program": "${workspaceFolder}/out/linux/x64/ten_manager/bin/tman",
+      "cwd": "/home/wei/MyData/Temp/",
       "args": [
+        "--verbose",
         "--config-file=${workspaceFolder}/out/linux/x64/tests/local_registry/config.json",
-        "designer",
+        "designer"
+      ],
+      "initCommands": [
+        "break set -n rust_panic",
+        "break set -n rust_begin_unwind",
+        "break set -n core::panicking::panic_fmt"
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
+      // "env": {
+      //   "RUST_BACKTRACE": "full"
+      // }
     },
     {
       "name": "tman check_cmd (lldb)",
@@ -477,11 +486,11 @@
         "check_cmd",
         "../../../tests/ten_runtime/integration/ten_manager/res/source_manifest.json",
         "../../../tests/ten_runtime/integration/ten_manager/res/dest_manifest.json",
-        "hello_world",
+        "hello_world"
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "tman check graph (lldb)",
@@ -496,7 +505,7 @@
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "ten_rust (rust)",
@@ -514,18 +523,18 @@
         "env": {
           "TEN_UTILS_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/obj/core/src/utils/",
           "RUST_BACKTRACE": "full",
-          "RUSTFLAGS": "-Zsanitizer=address",
-        },
+          "RUSTFLAGS": "-Zsanitizer=address"
+        }
       },
       "env": {
-        "RUST_BACKTRACE": "full",
+        "RUST_BACKTRACE": "full"
       },
       "args": [
         "test_create_schema_invalid_json"
       ],
       "preRunCommands": [
         "script import pathlib;import subprocess;import lldb;rustc_sysroot = subprocess.getoutput(\"rustc --print sysroot\");rustlib_etc = pathlib.Path(rustc_sysroot) / \"lib\" / \"rustlib\" / \"etc\";lldb.debugger.HandleCommand(f'command script import \"{rustlib_etc / \"lldb_lookup.py\"}\"');lldb.debugger.HandleCommand(f'command source -s 0 \"{rustlib_etc / \"lldb_commands\"}\"')"
-      ],
+      ]
     },
     {
       "name": "app (c/c++) (lldb, launch)",
@@ -535,8 +544,8 @@
       "args": [],
       "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/cpp/import_graph/import_graph_app",
       "env": {
-        "ASAN_OPTIONS": "use_sigaltstack=0",
-      },
+        "ASAN_OPTIONS": "use_sigaltstack=0"
+      }
     },
     {
       "name": "app (c/c++) (cppdbg, launch)",
@@ -587,7 +596,7 @@
       "env": {
         "LD_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/cpp/restful/http_basic/restful/http_basic_app/lib"
       },
-      "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/cpp/restful/http_basic/restful/http_basic_app/",
+      "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/cpp/restful/http_basic/restful/http_basic_app/"
     },
     {
       "name": "app (python) (debugpy, launch)",
@@ -602,8 +611,8 @@
         "TEN_APP_BASE_DIR": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/call_api_after_closing_python/call_api_after_closing_python_app/",
         "LD_PRELOAD": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/call_api_after_closing_python/call_api_after_closing_python_app/ten_packages/system/ten_runtime/lib/libasan.so",
         "PYTHONMALLOC": "malloc",
-        "TEN_ENABLE_PYTHON_DEBUG": "true",
-      },
+        "TEN_ENABLE_PYTHON_DEBUG": "true"
+      }
     },
     {
       "name": "app (python) (debugpy, remote attach)",
@@ -620,7 +629,7 @@
       "name": "app (python) (debugpy, local attach)",
       "type": "debugpy",
       "request": "attach",
-      "processId": "${command:pickProcess}",
+      "processId": "${command:pickProcess}"
     },
     {
       "name": "app (python) (cppdbg, launch)",
@@ -650,7 +659,7 @@
       ],
       "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/send_cmd_set_object_python/send_cmd_set_object_python_app",
       "additionalSOLibSearchPath": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/send_cmd_set_object_python/send_cmd_set_object_python_app/ten_packages/system/ten_runtime_python/lib:${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/send_cmd_set_object_python/send_cmd_set_object_python_app/ten_packages/system/ten_runtime/lib",
-      "MIMode": "gdb",
+      "MIMode": "gdb"
     },
     {
       "name": "app (python) (lldb, launch)",
@@ -666,7 +675,7 @@
         "LD_PRELOAD": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/aio_http_server_python/aio_http_server_python_app/ten_packages/system/ten_runtime/lib/libasan.so",
         "PYTHONMALLOC": "malloc"
       },
-      "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/aio_http_server_python/aio_http_server_python_app",
+      "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/aio_http_server_python/aio_http_server_python_app"
     },
     {
       "name": "app (python) (cppdbg, attach)",
@@ -687,7 +696,7 @@
           "editorPath": "${workspaceFolder}",
           "useForBreakpoints": "true"
         }
-      },
+      }
     },
     {
       "name": "app (nodejs, native) (lldb, launch)",
@@ -701,8 +710,8 @@
       "env": {
         "LD_PRELOAD": "ten_packages/system/ten_runtime/lib/libasan.so",
         "NODE_PATH": "ten_packages/system/ten_runtime_nodejs/lib:$NODE_PATH",
-        "LD_LIBRARY_PATH": "ten_packages/system/ten_runtime/lib",
-      },
+        "LD_LIBRARY_PATH": "ten_packages/system/ten_runtime/lib"
+      }
     },
     {
       "name": "app (nodejs, native) (cppdbg, launch)",
@@ -752,7 +761,7 @@
       "args": [
         "--expose-gc",
         "build/start.js"
-      ],
+      ]
     },
     {
       "name": "app (nodejs, js) (launch)",
@@ -763,8 +772,8 @@
       "outputCapture": "std",
       "env": {
         "LD_PRELOAD": "lib/libasan.so",
-        "NODE_PATH": "lib:$NODE_PATH",
-      },
+        "NODE_PATH": "lib:$NODE_PATH"
+      }
     },
     {
       "name": "app (golang) (go, launch)",
@@ -800,7 +809,7 @@
         "DYLD_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/nodejs/go_app_websocket_server_nodejs/go_app_websocket_server_nodejs_app/lib",
         "CGO_LDFLAGS": "-L${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/nodejs/go_app_websocket_server_nodejs/go_app_websocket_server_nodejs_app/ten_packages/system/ten_runtime_go/lib -lten_runtime_go -Wl,-rpath,@loader_path/lib -Wl,-rpath,@loader_path/../lib",
         "TEN_ENABLE_PYTHON_DEBUG": "true",
-        "NODE_PATH": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/nodejs/go_app_websocket_server_nodejs/go_app_websocket_server_nodejs_app/ten_packages/system/ten_runtime_nodejs/lib:$NODE_PATH",
+        "NODE_PATH": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/nodejs/go_app_websocket_server_nodejs/go_app_websocket_server_nodejs_app/ten_packages/system/ten_runtime_nodejs/lib:$NODE_PATH"
       },
       "initCommands": [
         "process handle SIGURG --stop false --pass true"
@@ -824,8 +833,8 @@
       "args": [],
       "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/cpp/standalone_test_cpp/ext",
       "env": {
-        "ASAN_OPTIONS": "use_sigaltstack=0",
-      },
+        "ASAN_OPTIONS": "use_sigaltstack=0"
+      }
     },
     {
       "name": "standalone test (python) (cppdbg, launch)",
@@ -858,7 +867,7 @@
       ],
       "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/standalone_test_async_python/default_async_extension_python",
       "additionalSOLibSearchPath": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/standalone_test_async_python/default_async_extension_python/.ten/app/ten_packages/system/ten_runtime_python/lib:${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/python/standalone_test_async_python/default_async_extension_python/.ten/app/ten_packages/system/ten_runtime/lib",
-      "MIMode": "gdb",
+      "MIMode": "gdb"
     },
     {
       "name": "standalone test (python) (lldb, launch)",
@@ -880,7 +889,7 @@
         "TEN_ENABLE_MEMORY_TRACKING": "true",
         "MALLOC_CHECK_": "3",
         "ASAN_OPTIONS": "detect_stack_use_after_return=1:color=always:unmap_shadow_on_exit=1:abort_on_error=1"
-      },
+      }
     },
     {
       "name": "standalone test (python) (debugpy, launch)",
@@ -905,7 +914,7 @@
       ],
       "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/go/standalone_test_2_go/default_extension_go",
       "env": {
-        "LD_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/go/standalone_test_2_go/default_extension_go/.ten/app/ten_packages/system/ten_runtime/lib:${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/go/standalone_test_2_go/default_extension_go/.ten/app/ten_packages/system/ten_runtime_go/lib",
+        "LD_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/go/standalone_test_2_go/default_extension_go/.ten/app/ten_packages/system/ten_runtime/lib:${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/go/standalone_test_2_go/default_extension_go/.ten/app/ten_packages/system/ten_runtime_go/lib"
       },
       "initCommands": [
         "process handle SIGURG --stop false --pass true"
@@ -922,7 +931,7 @@
       ],
       "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/nodejs/standalone_test_nodejs/default_extension_nodejs/tests",
       "env": {
-        "NODE_PATH": "../.ten/app/ten_packages/system/ten_runtime_nodejs/lib:$NODE_PATH",
+        "NODE_PATH": "../.ten/app/ten_packages/system/ten_runtime_nodejs/lib:$NODE_PATH"
       }
     },
     {
@@ -934,17 +943,17 @@
       "args": [
         "--no-timeouts",
         "--package",
-        "package.json",
+        "package.json"
       ],
       "cwd": "${workspaceFolder}/out/linux/x64/tests/ten_runtime/integration/nodejs/standalone_test_nodejs/default_extension_nodejs/tests",
       "env": {
-        "NODE_PATH": "../.ten/app/ten_packages/system/ten_runtime_nodejs/lib:$NODE_PATH",
+        "NODE_PATH": "../.ten/app/ten_packages/system/ten_runtime_nodejs/lib:$NODE_PATH"
       },
       "runtimeArgs": [
         "--expose-gc",
         "--loader",
         "ts-node/esm",
-        "--no-warnings",
+        "--no-warnings"
       ]
     },
     {
@@ -956,7 +965,7 @@
       "env": {
         "LD_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64",
         "DYLD_LIBRARY_PATH": "${workspaceFolder}/out/linux/x64",
-        "CGO_LDFLAGS": "-L${workspaceFolder}/out/linux/x64 -lten_runtime_go -Wl,-rpath,@loader_path/lib -Wl,-rpath,@loader_path/../lib",
+        "CGO_LDFLAGS": "-L${workspaceFolder}/out/linux/x64 -lten_runtime_go -Wl,-rpath,@loader_path/lib -Wl,-rpath,@loader_path/../lib"
       },
       "args": [
         "-test.run",

--- a/core/src/ten_manager/src/designer/graphs/connections/mod.rs
+++ b/core/src/ten_manager/src/designer/graphs/connections/mod.rs
@@ -52,11 +52,20 @@ impl Default for DesignerGraphLoc {
 
 impl From<DesignerGraphMessageFlow> for GraphMessageFlow {
     fn from(designer_msg_flow: DesignerGraphMessageFlow) -> Self {
-        GraphMessageFlow::new(
-            designer_msg_flow.name,
-            designer_msg_flow.dest.into_iter().map(|d| d.into()).collect(),
-            designer_msg_flow.source.into_iter().map(|s| s.into()).collect(),
-        )
+        GraphMessageFlow {
+            name: designer_msg_flow.name,
+            names: designer_msg_flow.names,
+            dest: designer_msg_flow
+                .dest
+                .into_iter()
+                .map(|d| d.into())
+                .collect(),
+            source: designer_msg_flow
+                .source
+                .into_iter()
+                .map(|s| s.into())
+                .collect(),
+        }
     }
 }
 
@@ -89,7 +98,11 @@ impl From<DesignerGraphSource> for GraphSource {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct DesignerGraphMessageFlow {
-    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub names: Option<Vec<String>>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dest: Vec<DesignerGraphDestination>,
@@ -101,10 +114,8 @@ pub struct DesignerGraphMessageFlow {
 impl From<GraphMessageFlow> for DesignerGraphMessageFlow {
     fn from(msg_flow: GraphMessageFlow) -> Self {
         DesignerGraphMessageFlow {
-            name: msg_flow.name.expect(
-                "name field should be Some when converting to \
-                 DesignerMessageFlow",
-            ),
+            name: msg_flow.name,
+            names: msg_flow.names,
             dest: get_designer_destination_from_property(msg_flow.dest),
             source: get_designer_source_from_property(msg_flow.source),
         }

--- a/core/src/ten_manager/tests/test_case/designer/graphs/connections/get.rs
+++ b/core/src/ten_manager/tests/test_case/designer/graphs/connections/get.rs
@@ -120,7 +120,8 @@ mod tests {
                 selector: None,
             },
             cmd: Some(vec![DesignerGraphMessageFlow {
-                name: "hello_world".to_string(),
+                name: Some("hello_world".to_string()),
+                names: None,
                 dest: vec![DesignerGraphDestination {
                     loc: DesignerGraphLoc {
                         app: None,
@@ -275,7 +276,8 @@ mod tests {
                 selector: None,
             },
             cmd: Some(vec![DesignerGraphMessageFlow {
-                name: "hello_world".to_string(),
+                name: Some("hello_world".to_string()),
+                names: None,
                 dest: vec![DesignerGraphDestination {
                     loc: DesignerGraphLoc {
                         app: None,
@@ -288,7 +290,8 @@ mod tests {
                 source: vec![],
             }]),
             data: Some(vec![DesignerGraphMessageFlow {
-                name: "data".to_string(),
+                name: Some("data".to_string()),
+                names: None,
                 dest: vec![DesignerGraphDestination {
                     loc: DesignerGraphLoc {
                         app: None,
@@ -301,7 +304,8 @@ mod tests {
                 source: vec![],
             }]),
             audio_frame: Some(vec![DesignerGraphMessageFlow {
-                name: "pcm".to_string(),
+                name: Some("pcm".to_string()),
+                names: None,
                 dest: vec![DesignerGraphDestination {
                     loc: DesignerGraphLoc {
                         app: None,
@@ -314,7 +318,8 @@ mod tests {
                 source: vec![],
             }]),
             video_frame: Some(vec![DesignerGraphMessageFlow {
-                name: "image".to_string(),
+                name: Some("image".to_string()),
+                names: None,
                 dest: vec![DesignerGraphDestination {
                     loc: DesignerGraphLoc {
                         app: None,

--- a/core/src/ten_manager/tests/test_case/designer/graphs/get.rs
+++ b/core/src/ten_manager/tests/test_case/designer/graphs/get.rs
@@ -425,7 +425,7 @@ mod tests {
         assert_eq!(cmd_list.len(), 1);
 
         let cmd = &cmd_list[0];
-        assert_eq!(cmd.name, "hello_world");
+        assert_eq!(cmd.name, Some("hello_world".to_string()));
 
         // Verify the source is properly set
         let sources = &cmd.source;
@@ -570,7 +570,7 @@ mod tests {
         assert_eq!(cmd_list.len(), 1);
 
         let cmd = &cmd_list[0];
-        assert_eq!(cmd.name, "multi_source_cmd");
+        assert_eq!(cmd.name, Some("multi_source_cmd".to_string()));
 
         // Verify multiple sources are properly set
         let sources = &cmd.source;
@@ -775,7 +775,10 @@ mod tests {
         let connection = &connections[0];
         assert_eq!(connection.loc.extension, Some("addon_a".to_string()));
         assert_eq!(connection.cmd.as_ref().unwrap().len(), 1);
-        assert_eq!(connection.cmd.as_ref().unwrap()[0].name, "C");
+        assert_eq!(
+            connection.cmd.as_ref().unwrap()[0].name,
+            Some("C".to_string())
+        );
         assert_eq!(connection.cmd.as_ref().unwrap()[0].dest.len(), 1);
         assert_eq!(
             connection.cmd.as_ref().unwrap()[0].dest[0].loc.extension,


### PR DESCRIPTION
- Changed `name` and `names` fields in `DesignerGraphMessageFlow` to be of type `Option<String>` and
`Option<Vec<String>>`, respectively, allowing for optional values.
- Updated conversion implementations to handle the new structure.
- Adjusted related test cases to reflect the changes in the data structure.