### PR TITLE
fix: intermediate rust files too big for CI

### DIFF
--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -152,13 +152,7 @@ jobs:
           if [ "${{ matrix.arch }}" = "x86" ]; then
             EXTRA_ARGS="is_clang=false ten_enable_ten_rust=false ten_enable_ten_manager=false ten_manager_enable_tests=false ten_enable_go_binding=false ten_enable_python_binding=false ten_enable_nodejs_binding=false ten_manager_enable_frontend=false ten_enable_integration_tests_prebuilt=false"
           else
-            if [ "${{ matrix.compiler }}" = "clang" ] && [ "${{ matrix.build_type }}" = "debug" ]; then
-              TEN_RUST_FORCE_RELEASE="true"
-            else
-              TEN_RUST_FORCE_RELEASE="false"
-            fi
-
-            EXTRA_ARGS="is_clang=${{ matrix.compiler == 'gcc' && 'false' || 'true' }} ten_rust_force_release=${TEN_RUST_FORCE_RELEASE} log_level=1 enable_serialized_actions=true ten_enable_serialized_rust_action=true ten_rust_enable_gen_cargo_config=false ten_enable_cargo_clean=true ten_enable_go_lint=true ten_enable_rust_incremental_build=false ten_manager_enable_frontend=false ten_enable_integration_tests_prebuilt=false ten_enable_ffmpeg_extensions=true"
+            EXTRA_ARGS="is_clang=${{ matrix.compiler == 'gcc' && 'false' || 'true' }} ten_rust_force_release=true log_level=1 enable_serialized_actions=true ten_enable_serialized_rust_action=true ten_rust_enable_gen_cargo_config=false ten_enable_cargo_clean=true ten_enable_go_lint=true ten_enable_rust_incremental_build=false ten_manager_enable_frontend=false ten_enable_integration_tests_prebuilt=false ten_enable_ffmpeg_extensions=true"
           fi
 
           echo $EXTRA_ARGS

--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -152,7 +152,13 @@ jobs:
           if [ "${{ matrix.arch }}" = "x86" ]; then
             EXTRA_ARGS="is_clang=false ten_enable_ten_rust=false ten_enable_ten_manager=false ten_manager_enable_tests=false ten_enable_go_binding=false ten_enable_python_binding=false ten_enable_nodejs_binding=false ten_manager_enable_frontend=false ten_enable_integration_tests_prebuilt=false"
           else
-            EXTRA_ARGS="is_clang=${{ matrix.compiler == 'gcc' && 'false' || 'true' }} log_level=1 enable_serialized_actions=true ten_enable_serialized_rust_action=true ten_rust_enable_gen_cargo_config=false ten_enable_cargo_clean=true ten_enable_go_lint=true ten_enable_rust_incremental_build=false ten_manager_enable_frontend=false ten_enable_integration_tests_prebuilt=false ten_enable_ffmpeg_extensions=true"
+            if [ "${{ matrix.compiler }}" = "clang" ] && [ "${{ matrix.build_type }}" = "debug" ]; then
+              TEN_RUST_FORCE_RELEASE="true"
+            else
+              TEN_RUST_FORCE_RELEASE="false"
+            fi
+
+            EXTRA_ARGS="is_clang=${{ matrix.compiler == 'gcc' && 'false' || 'true' }} ten_rust_force_release=${TEN_RUST_FORCE_RELEASE} log_level=1 enable_serialized_actions=true ten_enable_serialized_rust_action=true ten_rust_enable_gen_cargo_config=false ten_enable_cargo_clean=true ten_enable_go_lint=true ten_enable_rust_incremental_build=false ten_manager_enable_frontend=false ten_enable_integration_tests_prebuilt=false ten_enable_ffmpeg_extensions=true"
           fi
 
           echo $EXTRA_ARGS

--- a/build/options.gni
+++ b/build/options.gni
@@ -37,6 +37,12 @@ declare_args() {
   # Rust's incremental build requires additional disk space, so this option
   # allows it to be disabled in CI environments.
   ten_enable_rust_incremental_build = true
+
+  # Force ten_rust to use release mode regardless of the global is_debug setting.
+  # When set to true, ten_rust will always be compiled in release mode.
+  # This configuration is mainly used to reduce the disk space consumption when
+  # building rust codes in CI environments.
+  ten_rust_force_release = false
 }
 
 declare_args() {

--- a/build/ten_common/rust/rust.gni
+++ b/build/ten_common/rust/rust.gni
@@ -32,7 +32,7 @@ template("rust_target") {
       "--build-type",
     ]
 
-    if (is_debug) {
+    if (is_debug && !ten_rust_force_release) {
       args += [ "debug" ]
     } else {
       args += [ "release" ]
@@ -159,7 +159,7 @@ template("rust_target") {
     }
 
     output_path = "${target_path}/${target}/"
-    if (is_debug) {
+    if (is_debug && !ten_rust_force_release) {
       output_path = "${output_path}/debug"
     } else {
       output_path = "${output_path}/release"
@@ -218,7 +218,7 @@ template("rust_test") {
     }
 
     args += [ "--build-type" ]
-    if (is_debug) {
+    if (is_debug && !ten_rust_force_release) {
       args += [ "debug" ]
     } else {
       args += [ "release" ]


### PR DESCRIPTION
Force debug mode to change to release mode when all conditions below are met:

- platform: linux x86_64
- github workflow
- building rust codes