### PR TITLE
fix: deepgram text format

### DIFF
--- a/ai_agents/agents/ten_packages/extension/deepgram_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/deepgram_asr_python/extension.py
@@ -229,6 +229,8 @@ class DeepgramASRExtension(AsyncASRBaseExtension):
         if final:
             await self._finalize_end()
 
+        text = text if text.startswith(" ") else " " + text
+
         asr_result = ASRResult(
             text=text,
             final=final,

--- a/ai_agents/agents/ten_packages/extension/deepgram_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/deepgram_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
     "type": "extension",
     "name": "deepgram_asr_python",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "dependencies": [
         {
             "type": "system",


### PR DESCRIPTION
fix: deepgram text format
<img width="1382" height="806" alt="企业微信截图_6c5ffc7e-4265-40d6-a9e0-2494cb75a3f1" src="https://github.com/user-attachments/assets/6b644b95-10ba-4f4c-98c7-0c087b11bf27" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text formatting in speech recognition output to ensure consistent leading space handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->