### PR TITLE
feat: add a config for soniox to hold final tokens before asr_finalize_end

### DIFF
--- a/ai_agents/agents/ten_packages/extension/soniox_asr_python/config.py
+++ b/ai_agents/agents/ten_packages/extension/soniox_asr_python/config.py
@@ -18,6 +18,7 @@ class SonioxASRConfig(BaseModel):
     dump: bool = False
     dump_path: str = "."
     finalize_mode: FinalizeMode = FinalizeMode.DEFAULT
+    finalize_holding: bool = False
     mute_pkg_duration_ms: int = 800
 
     def update(self, params: dict[str, Any]):
@@ -27,6 +28,7 @@ class SonioxASRConfig(BaseModel):
             "dump",
             "dump_path",
             "finalize_mode",
+            "finalize_holding",
             "mute_pkg_duration_ms",
         ]
         for key in special_params:

--- a/ai_agents/agents/ten_packages/extension/soniox_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/soniox_asr_python/extension.py
@@ -71,6 +71,9 @@ class SonioxASRExtension(AsyncASRBaseExtension):
         self.last_transcript_duration_ms: int = 0
         self.last_transcript_is_final: bool = False
 
+        self.holding = False
+        self.holding_final_tokens: list[SonioxTranscriptToken] = []
+
     @override
     def vendor(self) -> str:
         return "soniox"
@@ -88,6 +91,12 @@ class SonioxASRExtension(AsyncASRBaseExtension):
                 f"config: {self.config.to_str(sensitive_handling=True)}",
                 category=LOG_CATEGORY_KEY_POINT,
             )
+
+            if self.config.finalize_mode == FinalizeMode.IGNORE:
+                assert (
+                    "enable_endpoint_detection" in self.config.params
+                    and self.config.params["enable_endpoint_detection"]
+                ), "endpoint detection must be enabled when finalize_mode is IGNORE"
 
             if self.config.dump:
                 dump_file_path = os.path.join(
@@ -214,10 +223,11 @@ class SonioxASRExtension(AsyncASRBaseExtension):
         await super().on_data(ten_env, data)
         if data.get_name() == "asr_finalize":
             self.last_finalize_timestamp = int(time.time() * 1000)
-            if self.config.finalize_mode == FinalizeMode.IGNORE:
-                return
             if self.config.finalize_mode == FinalizeMode.MUTE_PKG:
                 await self._real_finalize_by_mute_pkg()
+                return
+            self.holding = True
+            if self.config.finalize_mode == FinalizeMode.IGNORE:
                 return
             # NOTE: We need this extra parameter for manual finalization in order to achieve lower finalization latency.
             # Refer to: https://soniox.com/docs/stt/rt/manual-finalization#trailing-silence
@@ -267,6 +277,14 @@ class SonioxASRExtension(AsyncASRBaseExtension):
 
     async def _finalize_end(self) -> None:
         self.ten_env.log_info("finalize end")
+        if self.holding:
+            # TODO: what if asr_finalize_end is before asr_finalize?
+            self.holding = False
+            if self.holding_final_tokens:
+                tokens = self.holding_final_tokens
+                self.holding_final_tokens = []
+                await self._send_transcript_and_translation(tokens, [], True)
+
         if self.last_finalize_timestamp != 0:
             timestamp = int(time.time() * 1000)
             latency = timestamp - self.last_finalize_timestamp
@@ -414,14 +432,19 @@ class SonioxASRExtension(AsyncASRBaseExtension):
 
         # Process final transcripts first (they come before non-final)
         if final_transcripts:
-            await self._send_transcript_and_translation(
-                final_transcripts, translation_tokens, is_final=True
-            )
+            if self.config.finalize_holding:
+                self.holding_final_tokens.extend(final_transcripts)
+            else:
+                await self._send_transcript_and_translation(
+                    final_transcripts, translation_tokens, is_final=True
+                )
 
         # Process non-final transcripts
         if non_final_transcripts:
             await self._send_transcript_and_translation(
-                non_final_transcripts, translation_tokens, is_final=False
+                [*self.holding_final_tokens, *non_final_transcripts],
+                translation_tokens,
+                is_final=False,
             )
 
     async def _send_transcript_and_translation(

--- a/ai_agents/agents/ten_packages/extension/soniox_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/soniox_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "soniox_asr_python",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "dependencies": [
     {
       "type": "system",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New option to hold and conditionally aggregate final transcripts and translations for controlled delivery.
  * Latency-aware finalization: can defer, batch, and flush final transcript/translation segments to reduce fragmentation.
  * Validation added to require endpoint-detection when using incompatible finalization modes.

* **Chores**
  * Extension version updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->