### PR TITLE
docs: update coverage badge URLs in multiple language READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Image](https://github.com/user-attachments/assets/2a560a74-68f3-4f4a-9ec8-89464c42a9c7)
 
 [![TEN Releases]( https://img.shields.io/github/v/release/ten-framework/ten-framework?color=369eff&labelColor=gray&logo=github&style=flat-square )](https://github.com/TEN-framework/ten-framework/releases)
-[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg)](https://coveralls.io/github/TEN-framework/ten-framework)
+[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg?branch=HEAD)](https://coveralls.io/github/TEN-framework/ten-framework?branch=HEAD)
 [![](https://img.shields.io/github/release-date/ten-framework/ten-framework?labelColor=gray&style=flat-square)](https://github.com/TEN-framework/ten-framework/releases)
 [![Discussion posts](https://img.shields.io/github/discussions/TEN-framework/ten_framework?labelColor=gray&color=%20%23f79009)](https://github.com/TEN-framework/ten-framework/discussions/)
 [![Commits](https://img.shields.io/github/commit-activity/m/TEN-framework/ten_framework?labelColor=gray&color=pink)](https://github.com/TEN-framework/ten-framework/graphs/commit-activity)

--- a/docs/README-CN.md
+++ b/docs/README-CN.md
@@ -3,7 +3,7 @@
 ![Image](https://github.com/user-attachments/assets/2a560a74-68f3-4f4a-9ec8-89464c42a9c7)
 
 [![TEN Releases]( https://img.shields.io/github/v/release/ten-framework/ten-framework?color=369eff&labelColor=gray&logo=github&style=flat-square )](https://github.com/TEN-framework/ten-framework/releases)
-[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg)](https://coveralls.io/github/TEN-framework/ten-framework)
+[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg?branch=HEAD)](https://coveralls.io/github/TEN-framework/ten-framework?branch=HEAD)
 [![](https://img.shields.io/github/release-date/ten-framework/ten-framework?labelColor=gray&style=flat-square)](https://github.com/TEN-framework/ten-framework/releases)
 [![Discussion posts](https://img.shields.io/github/discussions/TEN-framework/ten_framework?labelColor=gray&color=%20%23f79009)](https://github.com/TEN-framework/ten-framework/discussions/)
 [![Commits](https://img.shields.io/github/commit-activity/m/TEN-framework/ten_framework?labelColor=gray&color=pink)](https://github.com/TEN-framework/ten-framework/graphs/commit-activity)

--- a/docs/README-ES.md
+++ b/docs/README-ES.md
@@ -3,7 +3,7 @@
 ![Image](https://github.com/user-attachments/assets/2a560a74-68f3-4f4a-9ec8-89464c42a9c7)
 
 [![TEN Releases]( https://img.shields.io/github/v/release/ten-framework/ten-framework?color=369eff&labelColor=gray&logo=github&style=flat-square )](https://github.com/TEN-framework/ten-framework/releases)
-[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg)](https://coveralls.io/github/TEN-framework/ten-framework)
+[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg?branch=HEAD)](https://coveralls.io/github/TEN-framework/ten-framework?branch=HEAD)
 [![](https://img.shields.io/github/release-date/ten-framework/ten-framework?labelColor=gray&style=flat-square)](https://github.com/TEN-framework/ten-framework/releases)
 [![Discussion posts](https://img.shields.io/github/discussions/TEN-framework/ten_framework?labelColor=gray&color=%20%23f79009)](https://github.com/TEN-framework/ten-framework/discussions/)
 [![Commits](https://img.shields.io/github/commit-activity/m/TEN-framework/ten_framework?labelColor=gray&color=pink)](https://github.com/TEN-framework/ten-framework/graphs/commit-activity)
@@ -59,6 +59,7 @@
 </details>
 
 <a name="welcome-to-ten"></a>
+
 ## Bienvenido a TEN
 
 TEN es un marco de código abierto para agentes conversacionales de voz impulsados por IA.
@@ -78,6 +79,7 @@ El [ecosistema TEN](#ten-ecosystem) incluye [TEN Framework](https://github.com/t
 <br>
 
 <a name="agent-examples"></a>
+
 ## Ejemplos de agente
 
 <br>
@@ -156,9 +158,11 @@ Consulta la <a href="https://github.com/TEN-framework/ten-framework/tree/main/ai
 </div>
 
 <a name="quick-start-with-agent-examples"></a>
+
 ## Inicio rápido con los ejemplos de agente
 
 <a name="localhost"></a>
+
 ### Entorno local
 
 #### Paso ⓵ - Requisitos previos
@@ -277,6 +281,7 @@ Cuando el ejemplo esté en marcha podrás usar estas interfaces:
 <br>
 
 <a name="codespaces"></a>
+
 ### Codespaces
 
 GitHub ofrece Codespaces gratuitos para cada repositorio. Puedes ejecutar los ejemplos de agente allí sin usar Docker, y normalmente inicia más rápido que un entorno local con contenedores.
@@ -295,9 +300,11 @@ Consulta [esta guía](https://theten.ai/docs/ten_agent/setup_development_env/set
 <br>
 
 <a name="agent-examples-self-hosting"></a>
+
 ## Auto-hospedaje de los ejemplos de agente
 
 <a name="deploying-with-docker"></a>
+
 ### Implementar con Docker
 
 Cuando personalices tu agente (ya sea con TMAN Designer o editando `property.json`), crea una imagen de Docker lista para producción y despliega tu servicio.
@@ -324,6 +331,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="deploying-with-other-cloud-services"></a>
+
 ### Implementar en otros servicios en la nube
 
 Puedes dividir el despliegue en dos partes si deseas alojar TEN en proveedores como [Vercel](https://vercel.com) o [Netlify](https://www.netlify.com).
@@ -344,6 +352,7 @@ Con esta arquitectura, el backend gestiona los procesos de larga duración y el 
 <br>
 
 <a name="stay-tuned"></a>
+
 ## Mantente al día
 
 Recibe notificaciones instantáneas sobre nuevas versiones y actualizaciones. Tu apoyo nos ayuda a seguir mejorando TEN.
@@ -362,6 +371,7 @@ Recibe notificaciones instantáneas sobre nuevas versiones y actualizaciones. Tu
 <br>
 
 <a name="ten-ecosystem"></a>
+
 ## Ecosistema TEN
 
 <br>
@@ -384,6 +394,7 @@ Recibe notificaciones instantáneas sobre nuevas versiones y actualizaciones. Tu
 <br>
 
 <a name="questions"></a>
+
 ## Preguntas
 
 TEN Framework también está disponible en plataformas de preguntas y respuestas impulsadas por IA. Ofrecen soporte multilingüe para todo, desde la configuración básica hasta la implementación avanzada.
@@ -401,6 +412,7 @@ TEN Framework también está disponible en plataformas de preguntas y respuestas
 </div>
 
 <a name="contributing"></a>
+
 ## Cómo contribuir
 
 ¡Toda forma de colaboración de código abierto es bienvenida! Ya sea que corrijas bugs, agregues funciones, mejores la documentación o compartas ideas, tus aportes ayudan a impulsar herramientas de IA personalizadas. Revisa los Issues y Projects de GitHub para encontrar oportunidades y mostrar tus habilidades. ¡Construyamos juntas y juntos algo increíble!
@@ -420,11 +432,13 @@ TEN Framework también está disponible en plataformas de preguntas y respuestas
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="code-contributors"></a>
+
 ### Personas contribuidoras
 
 [![TEN](https://contrib.rocks/image?repo=TEN-framework/ten-agent)](https://github.com/TEN-framework/ten-agent/graphs/contributors)
 
 <a name="contribution-guidelines"></a>
+
 ### Guía de contribución
 
 ¡Contribuye cuando quieras! Lee primero la [guía de contribución](./code-of-conduct/contributing.md).
@@ -434,6 +448,7 @@ TEN Framework también está disponible en plataformas de preguntas y respuestas
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="license"></a>
+
 ### Licencia
 
 1. Todo TEN Framework, salvo los directorios listados más abajo, se publica bajo la licencia Apache 2.0 con restricciones adicionales. Consulta el archivo [LICENSE](./../LICENSE) en la raíz del proyecto.

--- a/docs/README-FR.md
+++ b/docs/README-FR.md
@@ -3,7 +3,7 @@
 ![Image](https://github.com/user-attachments/assets/2a560a74-68f3-4f4a-9ec8-89464c42a9c7)
 
 [![TEN Releases]( https://img.shields.io/github/v/release/ten-framework/ten-framework?color=369eff&labelColor=gray&logo=github&style=flat-square )](https://github.com/TEN-framework/ten-framework/releases)
-[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg)](https://coveralls.io/github/TEN-framework/ten-framework)
+[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg?branch=HEAD)](https://coveralls.io/github/TEN-framework/ten-framework?branch=HEAD)
 [![](https://img.shields.io/github/release-date/ten-framework/ten-framework?labelColor=gray&style=flat-square)](https://github.com/TEN-framework/ten-framework/releases)
 [![Discussion posts](https://img.shields.io/github/discussions/TEN-framework/ten_framework?labelColor=gray&color=%20%23f79009)](https://github.com/TEN-framework/ten-framework/discussions/)
 [![Commits](https://img.shields.io/github/commit-activity/m/TEN-framework/ten_framework?labelColor=gray&color=pink)](https://github.com/TEN-framework/ten-framework/graphs/commit-activity)
@@ -59,6 +59,7 @@
 </details>
 
 <a name="welcome-to-ten"></a>
+
 ## Bienvenue chez TEN
 
 TEN est un framework open source pour créer des agents conversationnels vocaux pilotés par l’IA.
@@ -78,6 +79,7 @@ L’[écosystème TEN](#ten-ecosystem) comprend [TEN Framework](https://github.c
 <br>
 
 <a name="agent-examples"></a>
+
 ## Exemples d’agents
 
 <br>
@@ -156,9 +158,11 @@ Voir le <a href="https://github.com/TEN-framework/ten-framework/tree/main/ai_age
 </div>
 
 <a name="quick-start-with-agent-examples"></a>
+
 ## Démarrage rapide avec les exemples d’agents
 
 <a name="localhost"></a>
+
 ### En local
 
 #### Étape ⓵ - Prérequis
@@ -277,6 +281,7 @@ Une fois l’exemple démarré, ces interfaces sont disponibles :
 <br>
 
 <a name="codespaces"></a>
+
 ### Codespaces
 
 GitHub fournit des Codespaces gratuits par dépôt. Vous pouvez exécuter les exemples d’agents sans Docker, avec des temps de démarrage souvent plus courts qu’en local.
@@ -295,9 +300,11 @@ Consultez [ce guide](https://theten.ai/docs/ten_agent/setup_development_env/sett
 <br>
 
 <a name="agent-examples-self-hosting"></a>
+
 ## Auto-hébergement des exemples d’agents
 
 <a name="deploying-with-docker"></a>
+
 ### Déployer avec Docker
 
 Après avoir personnalisé votre agent (via TMAN Designer ou en modifiant `property.json`), générez une image Docker prête pour la production et déployez votre service.
@@ -324,6 +331,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="deploying-with-other-cloud-services"></a>
+
 ### Déployer sur d’autres services cloud
 
 Divisez le déploiement en deux parties pour héberger TEN sur des plateformes comme [Vercel](https://vercel.com) ou [Netlify](https://www.netlify.com).
@@ -344,6 +352,7 @@ Ainsi, le backend gère les workers longue durée tandis que le frontend héberg
 <br>
 
 <a name="stay-tuned"></a>
+
 ## Restez informé·e
 
 Recevez instantanément les nouvelles versions et les mises à jour. Votre soutien nous aide à faire grandir TEN.
@@ -362,6 +371,7 @@ Recevez instantanément les nouvelles versions et les mises à jour. Votre souti
 <br>
 
 <a name="ten-ecosystem"></a>
+
 ## Écosystème TEN
 
 <br>
@@ -384,6 +394,7 @@ Recevez instantanément les nouvelles versions et les mises à jour. Votre souti
 <br>
 
 <a name="questions"></a>
+
 ## Questions
 
 TEN Framework est présent sur des plateformes de questions/réponses alimentées par l’IA. Elles fournissent des réponses multilingues, de la configuration de base aux cas avancés.
@@ -401,6 +412,7 @@ TEN Framework est présent sur des plateformes de questions/réponses alimentée
 </div>
 
 <a name="contributing"></a>
+
 ## Contribuer
 
 Nous accueillons toute forme de collaboration open source ! Corrections de bugs, nouvelles fonctionnalités, documentation ou idées : vos contributions font progresser les outils d’IA personnalisés. Consultez les Issues et Projects GitHub pour trouver des sujets sur lesquels intervenir et montrer votre expertise. Ensemble, faisons grandir TEN !
@@ -420,11 +432,13 @@ Nous accueillons toute forme de collaboration open source ! Corrections de bugs
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="code-contributors"></a>
+
 ### Contributrices et contributeurs
 
 [![TEN](https://contrib.rocks/image?repo=TEN-framework/ten-agent)](https://github.com/TEN-framework/ten-agent/graphs/contributors)
 
 <a name="contribution-guidelines"></a>
+
 ### Guide de contribution
 
 Les contributions sont les bienvenues ! Lisez d’abord le [guide de contribution](./code-of-conduct/contributing.md).
@@ -434,6 +448,7 @@ Les contributions sont les bienvenues ! Lisez d’abord le [guide de contributi
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="license"></a>
+
 ### Licence
 
 1. L’ensemble de TEN Framework (hors dossiers listés ci-dessous) est publié sous licence Apache 2.0 avec restrictions additionnelles. Voir le fichier [LICENSE](./../LICENSE) à la racine.

--- a/docs/README-IT.md
+++ b/docs/README-IT.md
@@ -3,7 +3,7 @@
 ![Image](https://github.com/user-attachments/assets/2a560a74-68f3-4f4a-9ec8-89464c42a9c7)
 
 [![TEN Releases]( https://img.shields.io/github/v/release/ten-framework/ten-framework?color=369eff&labelColor=gray&logo=github&style=flat-square )](https://github.com/TEN-framework/ten-framework/releases)
-[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg)](https://coveralls.io/github/TEN-framework/ten-framework)
+[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg?branch=HEAD)](https://coveralls.io/github/TEN-framework/ten-framework?branch=HEAD)
 [![](https://img.shields.io/github/release-date/ten-framework/ten-framework?labelColor=gray&style=flat-square)](https://github.com/TEN-framework/ten-framework/releases)
 [![Discussion posts](https://img.shields.io/github/discussions/TEN-framework/ten_framework?labelColor=gray&color=%20%23f79009)](https://github.com/TEN-framework/ten-framework/discussions/)
 [![Commits](https://img.shields.io/github/commit-activity/m/TEN-framework/ten_framework?labelColor=gray&color=pink)](https://github.com/TEN-framework/ten-framework/graphs/commit-activity)
@@ -59,6 +59,7 @@
 </details>
 
 <a name="welcome-to-ten"></a>
+
 ## Benvenuto in TEN
 
 TEN è un framework open source per creare agenti vocali conversazionali.
@@ -78,6 +79,7 @@ L’[ecosistema TEN](#ten-ecosystem) comprende [TEN Framework](https://github.co
 <br>
 
 <a name="agent-examples"></a>
+
 ## Esempi di agenti
 
 <br>
@@ -156,9 +158,11 @@ Consulta la <a href="https://github.com/TEN-framework/ten-framework/tree/main/ai
 </div>
 
 <a name="quick-start-with-agent-examples"></a>
+
 ## Guida rapida agli esempi di agenti
 
 <a name="localhost"></a>
+
 ### Ambiente locale
 
 #### Passaggio ⓵ - Prerequisiti
@@ -277,6 +281,7 @@ Quando l’esempio è in esecuzione puoi usare queste interfacce:
 <br>
 
 <a name="codespaces"></a>
+
 ### Codespaces
 
 GitHub offre Codespaces gratuiti per ogni repository. Puoi eseguire gli esempi senza Docker e, in genere, l’avvio è più rapido rispetto all’ambiente locale basato su container.
@@ -295,9 +300,11 @@ Consulta [questa guida](https://theten.ai/docs/ten_agent/setup_development_env/s
 <br>
 
 <a name="agent-examples-self-hosting"></a>
+
 ## Auto-hosting degli esempi
 
 <a name="deploying-with-docker"></a>
+
 ### Distribuire con Docker
 
 Dopo aver personalizzato l’agente (con TMAN Designer o modificando `property.json`), crea un’immagine Docker di release e distribuiscila.
@@ -324,6 +331,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="deploying-with-other-cloud-services"></a>
+
 ### Distribuire su altri servizi cloud
 
 Puoi dividere il deployment in due parti quando ospiti TEN su piattaforme come [Vercel](https://vercel.com) o [Netlify](https://www.netlify.com).
@@ -344,6 +352,7 @@ In questo modo il backend gestisce i processi di lunga durata e il frontend host
 <br>
 
 <a name="stay-tuned"></a>
+
 ## Rimani aggiornato
 
 Ricevi notifiche immediate su nuove release e aggiornamenti. Il tuo supporto ci aiuta a migliorare TEN!
@@ -362,6 +371,7 @@ Ricevi notifiche immediate su nuove release e aggiornamenti. Il tuo supporto ci 
 <br>
 
 <a name="ten-ecosystem"></a>
+
 ## Ecosistema TEN
 
 <br>
@@ -384,6 +394,7 @@ Ricevi notifiche immediate su nuove release e aggiornamenti. Il tuo supporto ci 
 <br>
 
 <a name="questions"></a>
+
 ## Domande
 
 TEN Framework è presente anche su piattaforme di Q&A alimentate dall’IA. Offrono risposte multilingue, dalla configurazione di base agli scenari avanzati.
@@ -401,6 +412,7 @@ TEN Framework è presente anche su piattaforme di Q&A alimentate dall’IA. Offr
 </div>
 
 <a name="contributing"></a>
+
 ## Contribuire
 
 Accogliamo qualsiasi forma di collaborazione open source! Bugfix, nuove funzionalità, documentazione o idee: ogni contributo aiuta a far crescere strumenti di IA personalizzati. Dai un’occhiata a Issues e Projects su GitHub per trovare attività su cui lavorare e mostrare le tue competenze. Costruiamo TEN insieme!
@@ -420,11 +432,13 @@ Accogliamo qualsiasi forma di collaborazione open source! Bugfix, nuove funziona
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="code-contributors"></a>
+
 ### Contributor del codice
 
 [![TEN](https://contrib.rocks/image?repo=TEN-framework/ten-agent)](https://github.com/TEN-framework/ten-agent/graphs/contributors)
 
 <a name="contribution-guidelines"></a>
+
 ### Linee guida per contribuire
 
 Le contribuzioni sono benvenute! Leggi prima le [linee guida per contribuire](./code-of-conduct/contributing.md).
@@ -434,6 +448,7 @@ Le contribuzioni sono benvenute! Leggi prima le [linee guida per contribuire](./
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="license"></a>
+
 ### Licenza
 
 1. L’intero TEN Framework (esclusi i folder elencati qui sotto) è rilasciato sotto Apache License 2.0 con restrizioni aggiuntive. Consulta il file [LICENSE](./../LICENSE) nella root del progetto.

--- a/docs/README-JP.md
+++ b/docs/README-JP.md
@@ -3,7 +3,7 @@
 ![Image](https://github.com/user-attachments/assets/2a560a74-68f3-4f4a-9ec8-89464c42a9c7)
 
 [![TEN Releases]( https://img.shields.io/github/v/release/ten-framework/ten-framework?color=369eff&labelColor=gray&logo=github&style=flat-square )](https://github.com/TEN-framework/ten-framework/releases)
-[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg)](https://coveralls.io/github/TEN-framework/ten-framework)
+[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg?branch=HEAD)](https://coveralls.io/github/TEN-framework/ten-framework?branch=HEAD)
 [![](https://img.shields.io/github/release-date/ten-framework/ten-framework?labelColor=gray&style=flat-square)](https://github.com/TEN-framework/ten-framework/releases)
 [![Discussion posts](https://img.shields.io/github/discussions/TEN-framework/ten_framework?labelColor=gray&color=%20%23f79009)](https://github.com/TEN-framework/ten-framework/discussions/)
 [![Commits](https://img.shields.io/github/commit-activity/m/TEN-framework/ten_framework?labelColor=gray&color=pink)](https://github.com/TEN-framework/ten-framework/graphs/commit-activity)
@@ -59,6 +59,7 @@
 </details>
 
 <a name="welcome-to-ten"></a>
+
 ## TEN へようこそ
 
 TEN は音声会話型 AI エージェント向けのオープンソースフレームワークです。
@@ -78,6 +79,7 @@ TEN は音声会話型 AI エージェント向けのオープンソースフレ
 <br>
 
 <a name="agent-examples"></a>
+
 ## エージェント事例
 
 <br>
@@ -156,9 +158,11 @@ TEN は音声会話型 AI エージェント向けのオープンソースフレ
 </div>
 
 <a name="quick-start-with-agent-examples"></a>
+
 ## エージェント事例のクイックスタート
 
 <a name="localhost"></a>
+
 ### ローカル環境
 
 #### ステップ ⓵ - 事前準備
@@ -277,6 +281,7 @@ task run
 <br>
 
 <a name="codespaces"></a>
+
 ### Codespaces
 
 GitHub はリポジトリごとに無料の Codespaces を提供しています。Docker を使わずにエージェント事例を実行でき、通常ローカル環境よりも起動が速くなります。
@@ -295,9 +300,11 @@ GitHub はリポジトリごとに無料の Codespaces を提供しています�
 <br>
 
 <a name="agent-examples-self-hosting"></a>
+
 ## エージェント事例のセルフホスティング
 
 <a name="deploying-with-docker"></a>
+
 ### Docker でデプロイ
 
 TMAN Designer でカスタマイズするか `property.json` を編集したら、本番用の Docker イメージを作成してサービスをデプロイしましょう。
@@ -324,6 +331,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="deploying-with-other-cloud-services"></a>
+
 ### その他のクラウドサービスへデプロイ
 
 [TEN を Vercel](https://vercel.com) や [Netlify](https://www.netlify.com) などでホストする場合、バックエンドとフロントエンドを分けて配置できます。
@@ -344,6 +352,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 <br>
 
 <a name="stay-tuned"></a>
+
 ## 最新情報
 
 新しいリリースやアップデートを即座に受け取れます。あなたのサポートが TEN を成長させます！
@@ -362,6 +371,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 <br>
 
 <a name="ten-ecosystem"></a>
+
 ## TEN エコシステム
 
 <br>
@@ -384,6 +394,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 <br>
 
 <a name="questions"></a>
+
 ## 質問
 
 TEN Framework は AI 駆動の Q&A プラットフォームにも掲載されています。マルチリンガルでの検索が可能で、初期設定から高度な実装までサポートします。
@@ -401,6 +412,7 @@ TEN Framework は AI 駆動の Q&A プラットフォームにも掲載されて
 </div>
 
 <a name="contributing"></a>
+
 ## コントリビュート
 
 バグ修正、機能追加、ドキュメント改善、アイデア共有など、あらゆる OSS での協力を歓迎します。GitHub の Issues や Projects をチェックして活躍の場を見つけ、スキルを発揮してください。一緒に TEN をより良いものにしましょう！
@@ -420,11 +432,13 @@ TEN Framework は AI 駆動の Q&A プラットフォームにも掲載されて
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="code-contributors"></a>
+
 ### コードコントリビューター
 
 [![TEN](https://contrib.rocks/image?repo=TEN-framework/ten-agent)](https://github.com/TEN-framework/ten-agent/graphs/contributors)
 
 <a name="contribution-guidelines"></a>
+
 ### 貢献ガイドライン
 
 いつでも歓迎です！まずは[貢献ガイドライン](./code-of-conduct/contributing.md)をご確認ください。
@@ -434,6 +448,7 @@ TEN Framework は AI 駆動の Q&A プラットフォームにも掲載されて
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="license"></a>
+
 ### ライセンス
 
 1. 下記のディレクトリを除き、TEN Framework 全体は追加条件付きの Apache License 2.0 で配布されています。プロジェクトルートの [LICENSE](./../LICENSE) を参照してください。

--- a/docs/README-KR.md
+++ b/docs/README-KR.md
@@ -3,7 +3,7 @@
 ![Image](https://github.com/user-attachments/assets/2a560a74-68f3-4f4a-9ec8-89464c42a9c7)
 
 [![TEN Releases]( https://img.shields.io/github/v/release/ten-framework/ten-framework?color=369eff&labelColor=gray&logo=github&style=flat-square )](https://github.com/TEN-framework/ten-framework/releases)
-[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg)](https://coveralls.io/github/TEN-framework/ten-framework)
+[![Coverage Status](https://coveralls.io/repos/github/TEN-framework/ten-framework/badge.svg?branch=HEAD)](https://coveralls.io/github/TEN-framework/ten-framework?branch=HEAD)
 [![](https://img.shields.io/github/release-date/ten-framework/ten-framework?labelColor=gray&style=flat-square)](https://github.com/TEN-framework/ten-framework/releases)
 [![Discussion posts](https://img.shields.io/github/discussions/TEN-framework/ten_framework?labelColor=gray&color=%20%23f79009)](https://github.com/TEN-framework/ten-framework/discussions/)
 [![Commits](https://img.shields.io/github/commit-activity/m/TEN-framework/ten_framework?labelColor=gray&color=pink)](https://github.com/TEN-framework/ten-framework/graphs/commit-activity)
@@ -59,6 +59,7 @@
 </details>
 
 <a name="welcome-to-ten"></a>
+
 ## TEN 소개
 
 TEN은 음성 대화형 AI 에이전트를 위한 오픈소스 프레임워크입니다.
@@ -78,6 +79,7 @@ TEN은 음성 대화형 AI 에이전트를 위한 오픈소스 프레임워크�
 <br>
 
 <a name="agent-examples"></a>
+
 ## 에이전트 예시
 
 <br>
@@ -156,9 +158,11 @@ TEN은 음성 대화형 AI 에이전트를 위한 오픈소스 프레임워크�
 </div>
 
 <a name="quick-start-with-agent-examples"></a>
+
 ## 에이전트 예시 빠른 시작
 
 <a name="localhost"></a>
+
 ### 로컬 환경
 
 #### 단계 ⓵ - 준비 사항
@@ -277,6 +281,7 @@ task run
 <br>
 
 <a name="codespaces"></a>
+
 ### Codespaces
 
 GitHub는 저장소마다 무료 Codespaces를 제공합니다. Docker 없이도 에이전트 예시를 실행할 수 있으며, 일반적으로 로컬 Docker 환경보다 빠르게 시작됩니다.
@@ -295,9 +300,11 @@ GitHub는 저장소마다 무료 Codespaces를 제공합니다. Docker 없이도
 <br>
 
 <a name="agent-examples-self-hosting"></a>
+
 ## 에이전트 예시 셀프 호스팅
 
 <a name="deploying-with-docker"></a>
+
 ### Docker 배포
 
 TMAN Designer 또는 `property.json` 수정으로 에이전트를 커스터마이징했다면, 서비스용 Docker 릴리스 이미지를 만들어 배포할 수 있습니다.
@@ -324,6 +331,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="deploying-with-other-cloud-services"></a>
+
 ### 기타 클라우드 제공업체 배포
 
 [TEN을 Vercel](https://vercel.com)이나 [Netlify](https://www.netlify.com) 같은 플랫폼에 호스팅할 때는 백엔드와 프런트엔드를 분리할 수 있습니다.
@@ -344,6 +352,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 <br>
 
 <a name="stay-tuned"></a>
+
 ## 소식 받기
 
 새 릴리스와 업데이트를 즉시 받아보세요. 여러분의 응원이 TEN을 성장시킵니다!
@@ -362,6 +371,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 <br>
 
 <a name="ten-ecosystem"></a>
+
 ## TEN 에코시스템
 
 <br>
@@ -384,6 +394,7 @@ docker run --rm -it --env-file .env -p 3000:3000 example-app
 <br>
 
 <a name="questions"></a>
+
 ## 질문
 
 TEN Framework는 AI 기반 Q&A 플랫폼에서도 만나볼 수 있습니다. 멀티랭귀지를 지원하며 기본 설정부터 고급 구현까지 빠르게 답을 찾을 수 있습니다.
@@ -401,6 +412,7 @@ TEN Framework는 AI 기반 Q&A 플랫폼에서도 만나볼 수 있습니다. �
 </div>
 
 <a name="contributing"></a>
+
 ## 기여하기
 
 버그 수정, 기능 추가, 문서 개선, 아이디어 공유 등 모든 형태의 오픈소스 협업을 환영합니다. GitHub Issues와 Projects에서 참여할 작업을 찾아 능력을 보여주세요. 함께 멋진 TEN을 만들어봅시다!
@@ -420,11 +432,13 @@ TEN Framework는 AI 기반 Q&A 플랫폼에서도 만나볼 수 있습니다. �
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="code-contributors"></a>
+
 ### 코드 기여자
 
 [![TEN](https://contrib.rocks/image?repo=TEN-framework/ten-agent)](https://github.com/TEN-framework/ten-agent/graphs/contributors)
 
 <a name="contribution-guidelines"></a>
+
 ### 기여 가이드
 
 기여를 환영합니다! 먼저 [기여 가이드](./code-of-conduct/contributing.md)를 읽어 주세요.
@@ -434,6 +448,7 @@ TEN Framework는 AI 기반 Q&A 플랫폼에서도 만나볼 수 있습니다. �
 ![divider](https://github.com/user-attachments/assets/aec54c94-ced9-4683-ae58-0a5a7ed803bd)
 
 <a name="license"></a>
+
 ### 라이선스
 
 1. 아래에 명시된 디렉터리를 제외한 TEN Framework 전체는 추가 제한이 포함된 Apache License 2.0으로 배포됩니다. 루트 디렉터리의 [LICENSE](./../LICENSE)를 참고하세요.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Coveralls coverage badge URLs in the root and localized READMEs to include branch=HEAD for accurate coverage display.
> 
> - **Documentation**:
>   - Update Coveralls badge URLs to include `?branch=HEAD` in `README.md` and localized docs (`docs/README-CN.md`, `docs/README-ES.md`, `docs/README-FR.md`, `docs/README-IT.md`, `docs/README-JP.md`, `docs/README-KR.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e459bb17269cbc24a70ba1a09f052f8dde3224. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->