### PR TITLE
chore: update macOS runner versions in CI workflows to macos-15-intel and macos-latest

### DIFF
--- a/.github/workflows/from_scratch.yml
+++ b/.github/workflows/from_scratch.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs-on: macos-13
+          - runs-on: macos-15-intel
             platform_name: "macOS x64"
             arch: "x64"
-          - runs-on: macos-14
+          - runs-on: macos-latest
             platform_name: "macOS ARM64"
             arch: "arm64"
           - runs-on: ubuntu-22.04

--- a/.github/workflows/mac_x64.yml
+++ b/.github/workflows/mac_x64.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     needs: call-check-pr-status
     if: ${{ needs.call-check-pr-status.outputs.should_continue == 'true' }}
-    runs-on: macos-13
+    runs-on: macos-15-intel
     strategy:
       matrix:
         build_type: [release]
@@ -386,7 +386,7 @@ jobs:
 
   test-standalone:
     needs: build
-    runs-on: macos-13
+    runs-on: macos-15-intel
     strategy:
       matrix:
         build_type: [release]
@@ -531,7 +531,7 @@ jobs:
 
   test-integration-ten-manager:
     needs: build
-    runs-on: macos-13
+    runs-on: macos-15-intel
     strategy:
       matrix:
         build_type: [release]
@@ -626,7 +626,7 @@ jobs:
 
   test-integration-cpp:
     needs: build
-    runs-on: macos-13
+    runs-on: macos-15-intel
     strategy:
       matrix:
         build_type: [release]
@@ -729,7 +729,7 @@ jobs:
 
   test-integration-go:
     needs: build
-    runs-on: macos-13
+    runs-on: macos-15-intel
     strategy:
       matrix:
         build_type: [release]
@@ -832,7 +832,7 @@ jobs:
 
   test-integration-python:
     needs: build
-    runs-on: macos-13
+    runs-on: macos-15-intel
     strategy:
       matrix:
         build_type: [release]

--- a/.github/workflows/tman_full_mac_x64.yml
+++ b/.github/workflows/tman_full_mac_x64.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     needs: call-check-pr-status
     if: ${{ needs.call-check-pr-status.outputs.should_continue == 'true' }}
-    runs-on: macos-13
+    runs-on: macos-15-intel
     strategy:
       matrix:
         build_type: [release]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates CI to use macos-15-intel for x64 jobs and macos-latest for ARM across relevant workflows.
> 
> - **CI Workflows**:
>   - `from_scratch.yml`:
>     - Matrix: `runs-on` updated `macos-13` → `macos-15-intel` for `macOS x64` and `macos-14` → `macos-latest` for `macOS ARM64`.
>   - `mac_x64.yml`:
>     - `runs-on` updated `macos-13` → `macos-15-intel` for `build` and all `test-*` jobs.
>   - `tman_full_mac_x64.yml`:
>     - `runs-on` updated `macos-13` → `macos-15-intel` for `build` job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 681a872727f788275ccf7d584305e513534d6b5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->