### PR TITLE
fix: try adding CI_BRANCH to notify coveralls

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1212,6 +1212,7 @@ jobs:
 
       - name: Upload coverage report to Coveralls
         env:
+          CI_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
           COVERALLS_REPO_TOKEN: ${{ secrets.TEN_COVERALLS_REPO_TOKEN }}
         run: |
           pip install --user cpp-coveralls


### PR DESCRIPTION
<img width="1052" height="153" alt="image" src="https://github.com/user-attachments/assets/0f976a0c-a7a7-4708-9461-c1e0e072467c" />
In the light of the src code of cpp-coveralls (shown above), try to tell coveralls website about the branch name using environment variable CI_BRANCH, rather than letting cpp-coveralls retrieve by itself. This is expected to solve the issue that coveralls won't show branch names ( only "?") , as well as the coverage badge stays "unknown".