### PR TITLE
chore: update GitHub Actions coverage workflow to improve fetch depth and add environment variables for Coveralls (#1725)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1106,7 +1106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           submodules: false
 
       - name: Install LLVM 21 tools
@@ -1209,6 +1209,8 @@ jobs:
       - name: Upload coverage report to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.TEN_COVERALLS_REPO_TOKEN }}
+          COVERALLS_GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+          COVERALLS_SERVICE_NAME: github-actions
         run: |
           pip install --user cpp-coveralls
           echo "cpp-coveralls installed successfully"


### PR DESCRIPTION
#1725

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use full git history (fetch-depth: 0) and pass COVERALLS_GIT_BRANCH and COVERALLS_SERVICE_NAME to Coveralls in `coverage.yml`.
> 
> - **CI Workflow** (`.github/workflows/coverage.yml`):
>   - Set `actions/checkout` `fetch-depth` to `0`.
>   - In Coveralls upload step, add env vars `COVERALLS_GIT_BRANCH` and `COVERALLS_SERVICE_NAME`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae209cd046b77b40f9087fcc5f69c35bb62d7e8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->