### PR TITLE
refactor: streamline Coveralls upload process in GitHub Actions workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1210,41 +1210,8 @@ jobs:
           "${OBJECT_ARGS[@]}" \
           > "out/linux/x64/coverage/coverage.lcov"
 
-      - name: Upload coverage report to Coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.TEN_COVERALLS_REPO_TOKEN }}
-          COVERALLS_SERVICE_NAME: github-actions
+      - name: Filter coverage.lcov for core directory
         run: |
-          pip install --user cpp-coveralls
-          echo "cpp-coveralls installed successfully"
-
-          # Add user bin directory to PATH
-          export PATH="$HOME/.local/bin:$PATH"
-          echo "Updated PATH: $PATH"
-
-          # Determine branch name based on event type
-          # For pull_request events, use github.head_ref; for push events, use github.ref_name
-          # Fallback to git branch name if needed
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            COVERALLS_GIT_BRANCH="${{ github.head_ref }}"
-          else
-            COVERALLS_GIT_BRANCH="${{ github.ref_name }}"
-          fi
-
-          # If branch name is still empty, get it from git
-          if [ -z "$COVERALLS_GIT_BRANCH" ]; then
-            COVERALLS_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          fi
-
-          export COVERALLS_GIT_BRANCH
-          echo "Coveralls branch: $COVERALLS_GIT_BRANCH"
-          echo "Event name: ${{ github.event_name }}"
-          echo "github.head_ref: ${{ github.head_ref }}"
-          echo "github.ref_name: ${{ github.ref_name }}"
-
-          # Verify coveralls command is available
-          which coveralls || echo "coveralls command not found in PATH"
-
           if [ -f "out/linux/x64/coverage/coverage.lcov" ]; then
             echo "Filtering coverage.lcov to include only core directory..."
 
@@ -1256,49 +1223,19 @@ jobs:
 
             echo "Filtered coverage file created"
             ls -lh out/linux/x64/coverage/coverage_filtered.lcov
-
-            echo "Uploading filtered coverage to Coveralls..."
-
-            # Capture coveralls output to extract the job URL
-            COVERALLS_OUTPUT=$(coveralls --lcov-file out/linux/x64/coverage/coverage_filtered.lcov --verbose 2>&1)
-            COVERALLS_EXIT_CODE=$?
-
-            echo "$COVERALLS_OUTPUT"
-
-            if [ $COVERALLS_EXIT_CODE -eq 0 ]; then
-              echo "Coverage uploaded to Coveralls successfully"
-
-              # Extract the URL from coveralls output
-              # The output format is: {'message': 'Job ##125.1', 'url': 'https://coveralls.io/jobs/173760015'}
-              # Use sed as fallback if grep -P is not available
-              if echo "$COVERALLS_OUTPUT" | grep -P "'url'" > /dev/null 2>&1; then
-                COVERALLS_JOB_URL=$(echo "$COVERALLS_OUTPUT" | grep -oP "(?<='url': ')[^']*" | tail -1)
-              else
-                # Fallback to sed for systems without grep -P
-                COVERALLS_JOB_URL=$(echo "$COVERALLS_OUTPUT" | sed -n "s/.*'url': '\([^']*\)'.*/\1/p" | tail -1)
-              fi
-
-              if [ -n "$COVERALLS_JOB_URL" ]; then
-                echo "Coveralls job URL: $COVERALLS_JOB_URL"
-                echo "COVERALLS_JOB_URL=$COVERALLS_JOB_URL" >> "$GITHUB_ENV"
-              else
-                echo "Could not extract Coveralls job URL from output"
-                # Fallback to repository URL
-                COVERALLS_JOB_URL="https://coveralls.io/github/${{ github.repository }}?branch=${{ github.ref_name }}"
-                echo "COVERALLS_JOB_URL=$COVERALLS_JOB_URL" >> "$GITHUB_ENV"
-              fi
-            else
-              echo "Error: Coverage upload to Coveralls failed with exit code $COVERALLS_EXIT_CODE"
-              # Set fallback URL even on failure
-              COVERALLS_JOB_URL="https://coveralls.io/github/${{ github.repository }}?branch=${{ github.ref_name }}"
-              echo "COVERALLS_JOB_URL=$COVERALLS_JOB_URL" >> "$GITHUB_ENV"
-              exit 1
-            fi
           else
-            echo "Warning: coverage.lcov file not found, skipping Coveralls upload"
+            echo "Warning: coverage.lcov file not found, cannot prepare filtered coverage"
             ls -la out/linux/x64/coverage/ || true
             exit 1
           fi
+
+      - name: Upload coverage report to Coveralls
+        uses: coverallsapp/github-action@v2
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.TEN_COVERALLS_REPO_TOKEN }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: out/linux/x64/coverage/coverage_filtered.lcov
 
       - name: Upload filtered coverage report to artifacts
         if: success() || failure()
@@ -1317,14 +1254,9 @@ jobs:
           echo "**Branch/Tag**: ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          # Use the URL from coveralls output if available
-          if [ -n "${COVERALLS_JOB_URL:-}" ]; then
-            echo "**Coverage Report**: [${COVERALLS_JOB_URL}](${COVERALLS_JOB_URL})" >> "$GITHUB_STEP_SUMMARY"
-          else
-            # Fallback URL
-            COVERALLS_URL="https://coveralls.io/github/${{ github.repository }}?branch=${{ github.ref_name }}"
-            echo "**Coverage Report**: [${COVERALLS_URL}](${COVERALLS_URL})" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          # Coverage report URL (branch overview)
+          COVERALLS_URL="https://coveralls.io/github/${{ github.repository }}?branch=${{ github.ref_name }}"
+          echo "**Coverage Report**: [${COVERALLS_URL}](${COVERALLS_URL})" >> "$GITHUB_STEP_SUMMARY"
 
           echo "**Please refresh the website after several minutes to see the correct coverage data, especially for the tree structure view**" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the custom Coveralls upload script with the official action, filters coverage to core, and simplifies the job summary link.
> 
> - **GitHub Actions: coverage workflow**
>   - Replace manual Coveralls upload (pip install, env setup, output parsing) with `coverallsapp/github-action@v2` using `coverage_filtered.lcov`.
>   - Add/retain step to filter `coverage.lcov` to core-only `coverage_filtered.lcov`; improve missing-file warning.
>   - Simplify job summary coverage link to branch overview URL.
>   - No other build/test/coverage generation logic changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96462603785516004f09f02848828acae286c7a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->