### PR TITLE
fix: enhance Coveralls upload process in GitHub Actions workflow

### DIFF
--- a/.github/workflows/trigger_sync_remote_docs.yml
+++ b/.github/workflows/trigger_sync_remote_docs.yml
@@ -1,0 +1,31 @@
+name: Trigger Sync Remote Docs
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag name"
+        required: false
+        type: string
+        default: "latest"
+
+jobs:
+  trigger_sync_remote_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger remote workflow_dispatch
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.TEN_FRAMEWORK_PORTAL_ACTION_PAT }} # need repo + workflow permissions
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'TEN-framework',
+              repo: 'portal',
+              workflow_id: 'sync-remote-docs.yml', // target workflow
+              ref: 'main', // branch
+              inputs: {
+                target_tag: '${{ github.event.release.tag_name || github.event.inputs.tag_name }}' // workflow_dispatch.inputs.target_tag
+              }
+            });


### PR DESCRIPTION
fix #1738

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a GitHub Actions workflow that dispatches TEN-framework/portal's docs sync workflow on releases or manual runs, forwarding the tag.
> 
> - **CI/GitHub Actions**:
>   - **New workflow**: `/.github/workflows/trigger_sync_remote_docs.yml`
>     - Triggers on `release` (created) and `workflow_dispatch` (input: `tag_name`, default `latest`).
>     - Uses `actions/github-script@v8` to call `actions.createWorkflowDispatch` on `TEN-framework/portal` targeting `sync-remote-docs.yml` on `main` with `inputs.target_tag` from release tag or manual input.
>     - Authenticates via `secrets.TEN_FRAMEWORK_PORTAL_ACTION_PAT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b54a34aa73d96c174a90ce1742adc2e6c01316bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->