### PR TITLE
fix: improve ulimit and sysctl settings in GitHub Actions workflow to handle concurrent connections more effectively

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -552,15 +552,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4
@@ -702,15 +712,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4
@@ -852,15 +872,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4
@@ -1022,15 +1052,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -289,15 +289,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -503,28 +503,28 @@ jobs:
           df -h .
           tree -I ".*|*.h|*.hpp|*.py" out/linux/${{ matrix.arch }}
 
-          - name: Set ulimit and sysctl
-          run: |
-            # Increase max number of open file descriptors as much as allowed.
-            TARGET=102400
-            HARD=$(ulimit -Hn)
+      - name: Set ulimit and sysctl
+        run: |
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-            echo "Current hard limit for open files: $HARD"
-            if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
-              echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
-              TARGET="$HARD"
-            fi
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
 
-            # Try to set the soft limit; if it fails, just warn and continue.
-            if ! ulimit -n "$TARGET"; then
-              echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
-            fi
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
 
-            # Adjust somaxconn; ignore failure if not permitted.
-            if ! sysctl -w net.core.somaxconn=8192; then
-              echo "WARNING: failed to set net.core.somaxconn, continuing."
-            fi
-          shell: bash
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
+        shell: bash
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -757,15 +757,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4
@@ -915,15 +925,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4
@@ -1062,15 +1082,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4
@@ -1209,15 +1239,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4
@@ -1376,15 +1416,25 @@ jobs:
 
       - name: Set ulimit and sysctl
         run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          # Increase max number of open file descriptors as much as allowed.
+          TARGET=102400
+          HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
+          echo "Current hard limit for open files: $HARD"
+          if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+            echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+            TARGET="$HARD"
+          fi
+
+          # Try to set the soft limit; if it fails, just warn and continue.
+          if ! ulimit -n "$TARGET"; then
+            echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+          fi
+
+          # Adjust somaxconn; ignore failure if not permitted.
+          if ! sysctl -w net.core.somaxconn=8192; then
+            echo "WARNING: failed to set net.core.somaxconn, continuing."
+          fi
         shell: bash
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -503,18 +503,28 @@ jobs:
           df -h .
           tree -I ".*|*.h|*.hpp|*.py" out/linux/${{ matrix.arch }}
 
-      - name: Set ulimit and sysctl
-        run: |
-          # Because there are concurrent test cases which involves many
-          # concurrent socket connections, we need to enlarge the maximum number
-          # of the opened file descriptor.
-          ulimit -n 102400
+          - name: Set ulimit and sysctl
+          run: |
+            # Increase max number of open file descriptors as much as allowed.
+            TARGET=102400
+            HARD=$(ulimit -Hn)
 
-          # Because there are concurrent test cases (in 'smoke' and
-          # 'integration') which will create many concurrent connections
-          # simutaneously, we increase the TCP listening backlog value to 8192.
-          sysctl -w net.core.somaxconn=8192
-        shell: bash
+            echo "Current hard limit for open files: $HARD"
+            if [ "$HARD" != "unlimited" ] && [ "$HARD" -lt "$TARGET" ]; then
+              echo "Target ($TARGET) is greater than hard limit ($HARD), using hard limit instead."
+              TARGET="$HARD"
+            fi
+
+            # Try to set the soft limit; if it fails, just warn and continue.
+            if ! ulimit -n "$TARGET"; then
+              echo "WARNING: failed to increase ulimit -n to $TARGET, continuing with existing limit."
+            fi
+
+            # Adjust somaxconn; ignore failure if not permitted.
+            if ! sysctl -w net.core.somaxconn=8192; then
+              echo "WARNING: failed to set net.core.somaxconn, continuing."
+            fi
+          shell: bash
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes ulimit and somaxconn setup in CI more robust with bounds checks and non-fatal fallbacks across coverage and linux workflows.
> 
> - **CI Workflows**
>   - **`coverage.yml`** and **`linux_ubuntu2204.yml`**:
>     - Replace fixed `ulimit -n 102400` with logic to cap to hard limit (`ulimit -Hn`) and attempt `ulimit -n "$TARGET"` with warning on failure.
>     - Set `net.core.somaxconn=8192` via `sysctl -w`, continuing with a warning if not permitted.
>     - Apply the above in all jobs that run tests across architectures and languages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8be1247a20960ed288811fe3cdb7d2a9b354d6cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->