### PR TITLE
chore: disable debug and measurement logging in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1444,8 +1444,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: out/linux/x64/coverage/coverage_filtered.lcov
           format: lcov
-          debug: true    #enable debug logging.
-          measure: true  #enable time measurement logging.
+          debug: false #enable debug logging.
+          measure: false #enable time measurement logging.
 
       - name: Upload filtered coverage report to artifacts
         if: success() || failure()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Turn off `debug` and `measure` options for the Coveralls upload step in `.github/workflows/coverage.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1518f029078728287c6ecb8d5999943faed0ecd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->