### PR TITLE
refactor: update from_utf8_lossy to String::from_utf8_lossy in PtyMessage formatting

### DIFF
--- a/core/src/ten_manager/src/designer/terminal/mod.rs
+++ b/core/src/ten_manager/src/designer/terminal/mod.rs
@@ -16,7 +16,6 @@ use actix::{Actor, AsyncContext, Message, StreamHandler};
 use actix_web::{web, Error, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
 use pty_manager::PtyManager;
-use serde::__private::from_utf8_lossy;
 use serde_json::Value;
 
 // The message to/from the pty.
@@ -32,7 +31,7 @@ impl Display for PtyMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PtyMessage::Buffer(data) => {
-                write!(f, "Buffer({:?})", from_utf8_lossy(data))
+                write!(f, "Buffer({:?})", String::from_utf8_lossy(data))
             }
             PtyMessage::Exit(code) => {
                 write!(f, "Exit({code})")


### PR DESCRIPTION
- Replaced the deprecated `from_utf8_lossy` function with `String::from_utf8_lossy` for improved clarity and consistency in the `PtyMessage` display implementation.
- This change enhances code readability and aligns with current Rust best practices.