### PR TITLE
add ESP32 ADF submodule branch info

### DIFF
--- a/ai_agents/esp32-client/ESP32-S3-Korvo-V3/README.cn.md
+++ b/ai_agents/esp32-client/ESP32-S3-Korvo-V3/README.cn.md
@@ -80,6 +80,18 @@ git submodule update --init --recursive
 ```
 
 本例程支持 ADF v2.7 tag (commit id: 9cf556de500019bb79f3bb84c821fda37668c052)
+```bash
+cd $ADF_PATH
+git checkout 9cf556de500019bb79f3bb84c821fda37668c052
+git pull
+git submodule update --init --recursive
+cd components/esp-adf-libs/
+git checkout 5bf018a92a9fba7e0df240f4b83bbcfef8df9d3e
+cd ../esp-sr
+git checkout 394aae67b578cf45ed13dad9c2e0c428f5d599f0
+cd 
+```
+
 
 #### 打上 IDF 补丁
 

--- a/ai_agents/esp32-client/ESP32-S3-Korvo-V3/README.md
+++ b/ai_agents/esp32-client/ESP32-S3-Korvo-V3/README.md
@@ -82,7 +82,19 @@ git pull
 git submodule update --init --recursive
 ```
 
-This example supports ADF v2.7 tag (commit id: 9cf556de500019bb79f3bb84c821fda37668c052).
+本例程支持 ADF v2.7 tag (commit id: 9cf556de500019bb79f3bb84c821fda37668c052)
+```bash
+cd $ADF_PATH
+git checkout 9cf556de500019bb79f3bb84c821fda37668c052
+git pull
+git submodule update --init --recursive
+cd components/esp-adf-libs/
+git checkout 5bf018a92a9fba7e0df240f4b83bbcfef8df9d3e
+cd ../esp-sr
+git checkout 394aae67b578cf45ed13dad9c2e0c428f5d599f0
+cd 
+```
+
 
 #### Applying the IDF Patch
 


### PR DESCRIPTION
因為ESP 32 adf 的子模組的分支不一樣會造成編譯失敗