### PR TITLE
fix: unify log timestamp format in xfyun ASR extensions

### DIFF
--- a/ai_agents/agents/ten_packages/extension/xfyun_asr_bigmodel_python/recognition.py
+++ b/ai_agents/agents/ten_packages/extension/xfyun_asr_bigmodel_python/recognition.py
@@ -217,8 +217,9 @@ class XfyunWSRecognition:
 
         except Exception as e:
             error_msg = f"Error processing message: {e}"
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
             self._log_debug(
-                f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {error_msg}"
+                f"[{timestamp}] {error_msg}"
             )
             if self.callback:
                 await self.callback.on_error(error_msg)

--- a/ai_agents/agents/ten_packages/extension/xfyun_asr_dialect_python/recognition.py
+++ b/ai_agents/agents/ten_packages/extension/xfyun_asr_dialect_python/recognition.py
@@ -252,8 +252,9 @@ class XfyunWSRecognition:
 
         except Exception as e:
             error_msg = f"Error processing message: {e}"
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
             self.ten_env.log_error(
-                f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {error_msg}"
+                f"[{timestamp}] {error_msg}"
             )
             if self.callback:
                 await self.callback.on_error(error_msg)

--- a/ai_agents/agents/ten_packages/extension/xfyun_asr_python/recognition.py
+++ b/ai_agents/agents/ten_packages/extension/xfyun_asr_python/recognition.py
@@ -197,8 +197,9 @@ class XfyunWSRecognition:
 
         except Exception as e:
             error_msg = f"Error processing message: {e}"
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
             self.ten_env.log_info(
-                f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {error_msg}"
+                f"[{timestamp}] {error_msg}"
             )
             await self.callback.on_error(error_msg)
 


### PR DESCRIPTION
## Summary

Fixed inconsistent timestamp format in three xfyun ASR extensions to address issue #302: log format not consistent.

## Changes

- xfyun_asr_bigmodel_python/recognition.py
- xfyun_asr_dialect_python/recognition.py
- xfyun_asr_python/recognition.py

Changed from `%Y-%m-%d %H:%M:%S` (without milliseconds) to `%Y-%m-%d %H:%M:%S.%f` with milliseconds to match the format used in other log statements in these files.

All log timestamps now consistently use the format YYYY-MM-DD HH:MM:SS.mmm (ISO 8601 with milliseconds).