### PR TITLE
fix: replace bare except with specific exception handling

### DIFF
--- a/ai_agents/agents/examples/voice-assistant-sip-plivo/tenapp/ten_packages/extension/main_python/server.py
+++ b/ai_agents/agents/examples/voice-assistant-sip-plivo/tenapp/ten_packages/extension/main_python/server.py
@@ -457,7 +457,7 @@ class PlivoCallServer:
                 # Try to close the connection gracefully
                 try:
                     await websocket.close()
-                except:
+                except Exception:
                     pass
             finally:
                 self._log_info("WebSocket connection closed")

--- a/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/server.py
+++ b/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/server.py
@@ -407,7 +407,7 @@ class TelnyxCallServer:
                 # Try to close the connection gracefully
                 try:
                     await websocket.close()
-                except:
+                except Exception:
                     pass
             finally:
                 self._log_info("WebSocket connection closed")

--- a/ai_agents/agents/examples/voice-assistant-sip-twilio/tenapp/ten_packages/extension/main_python/server.py
+++ b/ai_agents/agents/examples/voice-assistant-sip-twilio/tenapp/ten_packages/extension/main_python/server.py
@@ -436,7 +436,7 @@ class TwilioCallServer:
                 # Try to close the connection gracefully
                 try:
                     await websocket.close()
-                except:
+                except Exception:
                     pass
             finally:
                 self._log_info("WebSocket connection closed")

--- a/ai_agents/agents/ten_packages/extension/tencent_tts_python/src/speech_synthesizer.py
+++ b/ai_agents/agents/ten_packages/extension/tencent_tts_python/src/speech_synthesizer.py
@@ -96,7 +96,7 @@ class SpeechSynthesizer:
                     response["Message"] = rsp["Response"]["Error"]["Message"]
                     self.listener.on_fail(response)
                     return
-                except:
+                except (json.JSONDecodeError, UnicodeDecodeError):
                     data = chunk
                     response["data"] = data
                     self.listener.on_message(response)


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with specific exception types in:

- **SIP server examples** (Plivo, Telnyx, Twilio): `except:` → `except Exception:`
- **Tencent TTS**: `except:` → `except (json.JSONDecodeError, UnicodeDecodeError):`

## Why

Bare `except:` clauses catch `KeyboardInterrupt` and `SystemExit`, which is not recommended per PEP 8. Using specific exceptions improves code clarity and prevents unintended signal suppression.