### PR TITLE
fix(security): replace shell=True with shell=False in subprocess calls

### DIFF
--- a/ai_agents/agents/examples/voice-assistant-nodejs/tenapp/ten_packages/extension/main_nodejs/tools/run_script.py
+++ b/ai_agents/agents/examples/voice-assistant-nodejs/tenapp/ten_packages/extension/main_nodejs/tools/run_script.py
@@ -5,6 +5,7 @@
 # See the LICENSE file for more information.
 #
 import argparse
+import shlex
 import subprocess
 import sys
 import os
@@ -15,7 +16,7 @@ def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
     if env is None:
         env = os.environ.copy()
     print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    result = subprocess.run(shlex.split(cmd), shell=False, check=True, env=env)
     return result.returncode
 
 

--- a/packages/core_apps/default_app_cpp/tools/run_script.py
+++ b/packages/core_apps/default_app_cpp/tools/run_script.py
@@ -7,6 +7,7 @@
 
 import argparse
 import platform
+import shlex
 import subprocess
 import sys
 
@@ -52,7 +53,7 @@ def detect_arch() -> str:
 def run_cmd(cmd: str) -> int:
     """Run a shell command."""
     print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True)
+    result = subprocess.run(shlex.split(cmd), shell=False, check=True)
     return result.returncode
 
 

--- a/packages/core_extensions/default_extension_cpp/tools/run_script.py
+++ b/packages/core_extensions/default_extension_cpp/tools/run_script.py
@@ -6,6 +6,7 @@
 #
 import argparse
 import platform
+import shlex
 import subprocess
 import sys
 import os as os_module
@@ -53,7 +54,7 @@ def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
     if env is None:
         env = os_module.environ.copy()
     print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    result = subprocess.run(shlex.split(cmd), shell=False, check=True, env=env)
     return result.returncode
 
 

--- a/packages/core_extensions/default_extension_nodejs/tools/run_script.py
+++ b/packages/core_extensions/default_extension_nodejs/tools/run_script.py
@@ -5,6 +5,7 @@
 # See the LICENSE file for more information.
 #
 import argparse
+import shlex
 import subprocess
 import sys
 import os
@@ -15,7 +16,7 @@ def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
     if env is None:
         env = os.environ.copy()
     print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    result = subprocess.run(shlex.split(cmd), shell=False, check=True, env=env)
     return result.returncode
 
 

--- a/packages/example_apps/transcriber_demo/ten_packages/extension/vtt_nodejs/tools/run_script.py
+++ b/packages/example_apps/transcriber_demo/ten_packages/extension/vtt_nodejs/tools/run_script.py
@@ -5,6 +5,7 @@
 # See the LICENSE file for more information.
 #
 import argparse
+import shlex
 import subprocess
 import sys
 import os
@@ -15,7 +16,7 @@ def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
     if env is None:
         env = os.environ.copy()
     print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    result = subprocess.run(shlex.split(cmd), shell=False, check=True, env=env)
     return result.returncode
 
 


### PR DESCRIPTION
Good day,

This PR addresses security vulnerabilities reported in issues #2107 and #2106.

## Problem

Using `shell=True` in `subprocess.run()` calls makes command construction bugs easier to exploit by propagating current shell settings and variables. This is a well-known security anti-pattern.

## Solution

Replaced `shell=True` with `shell=False` and used `shlex.split()` to properly parse command strings into list arguments.

## Changes

- Added `shlex` import to properly parse command strings
- Changed `subprocess.run(cmd, shell=True, ...)` to `subprocess.run(shlex.split(cmd), shell=False, ...)`
- Applied fixes to 5 files with the same vulnerability pattern:
  - `ai_agents/agents/examples/voice-assistant-nodejs/tenapp/ten_packages/extension/main_nodejs/tools/run_script.py`
  - `packages/core_apps/default_app_cpp/tools/run_script.py`
  - `packages/core_extensions/default_extension_cpp/tools/run_script.py`
  - `packages/core_extensions/default_extension_nodejs/tools/run_script.py`
  - `packages/example_apps/transcriber_demo/ten_packages/extension/vtt_nodejs/tools/run_script.py`

## Testing

The code changes have been reviewed locally. The `shlex.split()` function correctly handles:
- Simple commands (`npm install`)
- Commands with arguments (`npm run build`)
- Commands with multiple arguments

Local testing with Python 3 shows the modified code works correctly with the new approach.

---

感谢你们的奉献，希望能提供帮助。如果我解决得有问题或有待商妥的地方，请在下面留言，我会来处理。

Warmly,
Jah-yee