### PR TITLE
fix(security): replace shell=True with shlex.split() to prevent shell injection

### DIFF
--- a/ai_agents/agents/examples/voice-assistant-nodejs/tenapp/ten_packages/extension/main_nodejs/tools/run_script.py
+++ b/ai_agents/agents/examples/voice-assistant-nodejs/tenapp/ten_packages/extension/main_nodejs/tools/run_script.py
@@ -8,6 +8,7 @@ import argparse
 import subprocess
 import sys
 import os
+import shlex
 
 
 def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
@@ -15,7 +16,7 @@ def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
     if env is None:
         env = os.environ.copy()
     print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    result = subprocess.run(shlex.split(cmd), check=True, env=env)
     return result.returncode
 
 

--- a/packages/core_apps/default_app_cpp/tools/run_script.py
+++ b/packages/core_apps/default_app_cpp/tools/run_script.py
@@ -9,6 +9,7 @@ import argparse
 import platform
 import subprocess
 import sys
+import shlex
 
 
 BUILD_TYPE = "debug"
@@ -52,7 +53,7 @@ def detect_arch() -> str:
 def run_cmd(cmd: str) -> int:
     """Run a shell command."""
     print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True)
+    result = subprocess.run(shlex.split(cmd), check=True)
     return result.returncode
 
 

--- a/packages/core_extensions/default_extension_nodejs/tools/run_script.py
+++ b/packages/core_extensions/default_extension_nodejs/tools/run_script.py
@@ -8,6 +8,7 @@ import argparse
 import subprocess
 import sys
 import os
+import shlex
 
 
 def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
@@ -15,7 +16,7 @@ def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
     if env is None:
         env = os.environ.copy()
     print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    result = subprocess.run(shlex.split(cmd), check=True, env=env)
     return result.returncode
 
 

--- a/packages/example_apps/transcriber_demo/ten_packages/extension/vtt_nodejs/tools/run_script.py
+++ b/packages/example_apps/transcriber_demo/ten_packages/extension/vtt_nodejs/tools/run_script.py
@@ -8,6 +8,7 @@ import argparse
 import subprocess
 import sys
 import os
+import shlex
 
 
 def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
@@ -15,7 +16,7 @@ def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
     if env is None:
         env = os.environ.copy()
     print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    result = subprocess.run(shlex.split(cmd), check=True, env=env)
     return result.returncode
 
 


### PR DESCRIPTION
Fixes #2107 and #2106

This change addresses security vulnerabilities where subprocess.run() was called with shell=True, which allows shell injection attacks.

Replaced with shlex.split() to properly parse commands without invoking a shell interpreter.

Files modified:
- ai_agents/agents/examples/voice-assistant-nodejs/tenapp/ten_packages/extension/main_nodejs/tools/run_script.py
- packages/core_apps/default_app_cpp/tools/run_script.py
- packages/core_extensions/default_extension_nodejs/tools/run_script.py
- packages/example_apps/transcriber_demo/ten_packages/extension/vtt_nodejs/tools/run_script.py