### PR TITLE
fix: fix tencent tts block cpu issue

### DIFF
--- a/ai_agents/agents/ten_packages/extension/tencent_tts_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/tencent_tts_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "tencent_tts_python",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "dependencies": [
     {
       "name": "ten_runtime_python",

--- a/ai_agents/agents/ten_packages/extension/tencent_tts_python/src/flowing_speech_synthesizer.py
+++ b/ai_agents/agents/ten_packages/extension/tencent_tts_python/src/flowing_speech_synthesizer.py
@@ -231,6 +231,11 @@ class FlowingSpeechSynthesizer:
                         )
                     )
                     self.listener.on_synthesis_fail(resp)
+                    # Unblock wait_ready so callers don't have to wait for the
+                    # full timeout when the server already rejected the request
+                    # (e.g. invalid voice_type).
+                    if not self.ready:
+                        self.ready_event.set()
                     return
                 if "final" in resp and resp["final"] == 1:
                     logger.info("recv FINAL frame")

--- a/ai_agents/agents/ten_packages/extension/tencent_tts_python/tencent_tts.py
+++ b/ai_agents/agents/ten_packages/extension/tencent_tts_python/tencent_tts.py
@@ -193,7 +193,25 @@ class TencentTTSClient:
 
         try:
             synthesizer.start()
-            synthesizer.wait_ready(5000)
+            # wait_ready uses threading.Event.wait() which blocks the current
+            # thread.  Running it on the event-loop thread would freeze the
+            # entire asyncio loop and prevent other extensions from
+            # initialising.  Offload to a worker thread so the loop stays
+            # responsive.
+            ready = await asyncio.get_event_loop().run_in_executor(
+                None, synthesizer.wait_ready, 5000
+            )
+            if not ready:
+                raise TimeoutError(
+                    "Tencent TTS synthesizer wait_ready timed out"
+                )
+            # ready_event is now also set on synthesis failure (e.g. invalid
+            # voice_type), so double-check the actual ready flag.
+            if not synthesizer.ready:
+                raise RuntimeError(
+                    "Tencent TTS synthesizer failed during startup "
+                    "(check voice_type and credentials)"
+                )
         except Exception as e:
             self.ten_env.log_error(f"Error starting TTS: {e}")
             raise e
@@ -205,7 +223,14 @@ class TencentTTSClient:
 
     async def stop(self) -> None:
         """Stop the TTS client and clean up resources."""
+        # Check for fatal conditions before restarting
+        has_auth_error = self._callback and self._callback.auth_error
         self.close()
+        if has_auth_error:
+            self.ten_env.log_warn(
+                "Not restarting TTS client due to authentication error"
+            )
+            return
         # restart the synthesizer
         asyncio.create_task(self.start())
 

--- a/ai_agents/agents/ten_packages/extension/tencent_tts_python/tests/test_start_no_block.py
+++ b/ai_agents/agents/ten_packages/extension/tencent_tts_python/tests/test_start_no_block.py
@@ -1,0 +1,151 @@
+import asyncio
+import threading
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ..tencent_tts import TencentTTSClient
+from ..config import TencentTTSConfig
+
+
+def _make_config(**overrides) -> TencentTTSConfig:
+    defaults = dict(
+        app_id="123456",
+        secret_id="fake_id",
+        secret_key="fake_key",
+        voice_type=0,
+    )
+    defaults.update(overrides)
+    return TencentTTSConfig(**defaults)
+
+
+def _make_mock_ten_env() -> MagicMock:
+    env = MagicMock()
+    env.log_debug = MagicMock()
+    env.log_info = MagicMock()
+    env.log_error = MagicMock()
+    env.log_warn = MagicMock()
+    return env
+
+
+class FakeSynthesizerFail:
+    """Simulates a synthesizer whose server rejects the request
+    (e.g. invalid voice_type)."""
+
+    def __init__(self, callback):
+        self.callback = callback
+        self.ready = False
+        self.ready_event = threading.Event()
+
+    def set_voice_type(self, v):
+        pass
+
+    def set_codec(self, v):
+        pass
+
+    def set_sample_rate(self, v):
+        pass
+
+    def set_enable_subtitle(self, v):
+        pass
+
+    def set_speed(self, v):
+        pass
+
+    def set_volume(self, v):
+        pass
+
+    def set_emotion_category(self, v):
+        pass
+
+    def set_emotion_intensity(self, v):
+        pass
+
+    def start(self):
+        def _bg():
+            time.sleep(0.05)
+            self.callback.on_synthesis_fail(
+                {
+                    "code": 12345,
+                    "message": "invalid voice type",
+                    "request_id": "r1",
+                }
+            )
+            if not self.ready:
+                self.ready_event.set()
+
+        threading.Thread(target=_bg, daemon=True).start()
+
+    def wait_ready(self, timeout_ms):
+        return self.ready_event.wait(timeout_ms / 1000.0)
+
+    def is_alive(self):
+        return False
+
+
+def test_start_does_not_block_event_loop_on_failure():
+    """Verify start() does not block the asyncio event loop.
+
+    Run start() and a probe coroutine via gather(). The probe just
+    does ``await asyncio.sleep(0)`` (a single yield). If the loop is
+    free the probe completes; if start() blocks the loop thread the
+    probe never gets scheduled.
+    """
+
+    async def _run():
+        config = _make_config(voice_type=999999)
+        ten_env = _make_mock_ten_env()
+        client = TencentTTSClient(config, ten_env, "tencent")
+
+        probe_ran = False
+
+        async def probe():
+            nonlocal probe_ran
+            await asyncio.sleep(0)
+            probe_ran = True
+
+        with patch(
+            "tencent_tts_python.tencent_tts.FlowingSpeechSynthesizer",
+            side_effect=lambda appid, cred, cb: FakeSynthesizerFail(cb),
+        ):
+            t0 = time.monotonic()
+
+            start_exc = None
+            try:
+                await asyncio.gather(client.start(), probe())
+            except Exception as e:
+                start_exc = e
+
+            elapsed = time.monotonic() - t0
+
+        # start() should have raised (synthesizer.ready is False)
+        assert start_exc is not None, "start() should have raised on failure"
+
+        # probe must have run, proving the loop was not blocked
+        assert (
+            probe_ran
+        ), "Probe coroutine never ran - event loop was blocked by start()"
+
+        # Should complete quickly, not wait for the 5s timeout
+        assert elapsed < 2.0, f"start() took {elapsed:.2f}s, expected < 2s"
+
+    asyncio.run(_run())
+
+
+def test_stop_does_not_restart_on_auth_error():
+    """stop() should NOT auto-restart when there was an auth error."""
+
+    async def _run():
+        config = _make_config()
+        ten_env = _make_mock_ten_env()
+        client = TencentTTSClient(config, ten_env, "tencent")
+
+        fake_callback = MagicMock()
+        fake_callback.auth_error = True
+        client._callback = fake_callback
+        client.synthesizer = MagicMock()
+
+        client.start = AsyncMock()
+        await client.stop()
+        client.start.assert_not_called()
+
+    asyncio.run(_run())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes startup and restart behavior in the Tencent TTS extension; mistakes could prevent the client from coming up or alter reconnect behavior under failure/auth-error conditions.
> 
> **Overview**
> Prevents `TencentTTSClient.start()` from blocking the asyncio event loop by offloading `synthesizer.wait_ready()` to a worker thread, and fails fast with clearer errors when startup times out or the server rejects the request.
> 
> Updates the WebSocket synthesizer to set `ready_event` on synthesis failure (so callers don’t wait the full timeout), and changes `stop()` to skip auto-restart when an authentication error was observed. Adds regression tests covering non-blocking startup on failure and no-restart-on-auth-error, and bumps the extension version to `0.4.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff91b12ed21987ee7c9c785ab64a4c8d7c31fe54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->