### PR TITLE
fix: add missing config keyword in deepgram tts log

### DIFF
--- a/ai_agents/agents/ten_packages/extension/deepgram_tts/extension.py
+++ b/ai_agents/agents/ten_packages/extension/deepgram_tts/extension.py
@@ -59,7 +59,7 @@ class DeepgramTTSExtension(AsyncTTS2BaseExtension):
             self.config = DeepgramTTSConfig.model_validate_json(config_json_str)
             self.config.update_params()
             ten_env.log_info(
-                self.config.to_str(sensitive_handling=True),
+                f"config: {self.config.to_str(sensitive_handling=True)}",
                 category=LOG_CATEGORY_KEY_POINT,
             )
 

--- a/ai_agents/agents/ten_packages/extension/deepgram_tts/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/deepgram_tts/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "deepgram_tts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": [
     {
       "type": "system",


### PR DESCRIPTION
## Summary
- The deepgram TTS extension logs its config without a `config:` prefix keyword, while all other TTS extensions include one (`config:` or `LOG_CATEGORY_KEY_POINT:`)
- This causes the QA automation test regex (`(?:config|LOG_CATEGORY_KEY_POINT|KEYPOINT config):`) to fail when validating `TTS:deepgram: vendor_config`
- Add the `config:` prefix to match the convention used by other TTS extensions

## Test plan
- [ ] Verify `test_convoAI_tts_autocase_by_uads` for deepgram now passes
- [ ] Confirm deepgram TTS still initializes and synthesizes correctly