### PR TITLE
fix(ai_agents): align Telnyx SIP example with Call Control events

### DIFF
--- a/ai_agents/agents/examples/voice-assistant-sip-telnyx/README.md
+++ b/ai_agents/agents/examples/voice-assistant-sip-telnyx/README.md
@@ -227,17 +227,17 @@ docker run --rm -it --env-file .env -p 9000:9000 -p 3000:3000 voice-assistant-si
 
 ### RESTful API Endpoints
 
-- `POST /api/calls` - Create new outbound call
+- `POST /api/call` - Create new outbound call
 - `GET /api/calls` - List all active calls
-- `GET /api/calls/{call_id}` - Get call information
-- `DELETE /api/calls/{call_id}` - Stop and delete call
+- `GET /api/call/{call_id}` - Get call information
+- `DELETE /api/call/{call_id}` - Stop and delete call
 - `POST /webhook/status` - Telnyx status callback
 - `GET /health` - Health check
 
 ### Starting a Call
 
 ```bash
-curl -X POST http://localhost:9000/api/calls \
+curl -X POST http://localhost:9000/api/call \
   -H "Content-Type: application/json" \
   -d '{
     "phone_number": "+1234567890",
@@ -248,7 +248,7 @@ curl -X POST http://localhost:9000/api/calls \
 ### Getting Call Information
 
 ```bash
-curl http://localhost:9000/api/calls/CAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+curl http://localhost:9000/api/call/v3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ### Listing All Calls
@@ -260,14 +260,14 @@ curl http://localhost:9000/api/calls
 ### Stopping a Call
 
 ```bash
-curl -X DELETE http://localhost:9000/api/calls/CAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+curl -X DELETE http://localhost:9000/api/call/v3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ## Learn More
 
 - [Telnyx Programmable Voice Documentation](https://developers.telnyx.com/api/v2)
 - [Telnyx Media Streams Documentation](https://developers.telnyx.com/api/v2/calls/voice)
-- [Telnyx Python SDK](https://github.com/team-telnyx/telnyx-python)
+- [Telnyx Call Control API](https://developers.telnyx.com/api-reference/call-commands/dial)
 - [Deepgram API Documentation](https://developers.deepgram.com/)
 - [OpenAI API Documentation](https://platform.openai.com/docs)
 - [ElevenLabs API Documentation](https://docs.elevenlabs.io/)

--- a/ai_agents/agents/examples/voice-assistant-sip-telnyx/server/requirements.txt
+++ b/ai_agents/agents/examples/voice-assistant-sip-telnyx/server/requirements.txt
@@ -2,5 +2,4 @@
 fastapi>=0.100.0
 uvicorn>=0.23.0
 pydantic>=2.0.0
-telnyx>=1.0.0
 python-multipart>=0.0.6

--- a/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/extension.py
+++ b/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/extension.py
@@ -537,13 +537,8 @@ class TelnyxControlExtension(AsyncExtension):
             # Encode μ-law audio data to base64
             audio_base64 = base64.b64encode(mulaw_data).decode("utf-8")
 
-            stream_id = self.server_instance.active_call_sessions[call_id].get(
-                "stream_id"
-            )
-
             message = {
                 "event": "media",
-                "streamSid": stream_id,
                 "media": {"payload": audio_base64},
             }
 

--- a/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/requirements.txt
+++ b/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/requirements.txt
@@ -3,5 +3,4 @@ pydantic>=2.0.0
 aiohttp>=3.9.0
 fastapi>=0.100.0
 uvicorn>=0.23.0
-telnyx>=1.0.0
 python-multipart>=0.0.6

--- a/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/server.py
+++ b/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/server.py
@@ -4,20 +4,20 @@ Telnyx Server for Voice Call Handling
 Handles call creation, media streaming, and webhook status
 """
 import asyncio
+import aiohttp
 import json
 import os
 import signal
 import sys
 from typing import Dict, Any, Optional
 from datetime import datetime
+from urllib.parse import quote
+from urllib import request as urllib_request
 
 import uvicorn
 from fastapi import FastAPI, Request, HTTPException, WebSocket
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
-from telnyx import Telnyx
-from telnyx.api.call import Call
-from telnyx.models.control import Control
 
 from .config import TelnyxConfig
 
@@ -38,9 +38,6 @@ class TelnyxCallServer:
             allow_methods=["*"],  # Allow all methods
             allow_headers=["*"],  # Allow all headers
         )
-
-        # Telnyx client
-        self.telnyx_client = Telnyx(config.telnyx_api_key)
 
         # Active call sessions
         self.active_call_sessions: Dict[str, Dict[str, Any]] = {}
@@ -69,6 +66,151 @@ class TelnyxCallServer:
         else:
             print(f"DEBUG: {message}")
 
+    def _media_ws_url(self) -> Optional[str]:
+        if not self.config.telnyx_public_server_url:
+            return None
+
+        ws_protocol = "wss" if self.config.telnyx_use_wss else "ws"
+        return f"{ws_protocol}://{self.config.telnyx_public_server_url}/media"
+
+    def _webhook_url(self) -> Optional[str]:
+        if not self.config.telnyx_public_server_url:
+            return None
+
+        http_protocol = "https" if self.config.telnyx_use_https else "http"
+        return (
+            f"{http_protocol}://"
+            f"{self.config.telnyx_public_server_url}/webhook/status"
+        )
+
+    def _streaming_params(self) -> Dict[str, Any]:
+        media_ws_url = self._media_ws_url()
+        if not media_ws_url:
+            return {}
+
+        return {
+            "stream_url": media_ws_url,
+            "stream_track": "both_tracks",
+            "stream_codec": "PCMU",
+            "stream_bidirectional_mode": "rtp",
+            "stream_bidirectional_codec": "PCMU",
+        }
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.config.telnyx_api_key}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    async def _post_telnyx(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"https://api.telnyx.com/v2{path}"
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                headers=self._headers(),
+                json=payload,
+            ) as response:
+                response_body = await response.text()
+                if response.status >= 400:
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=response_body,
+                    )
+                if not response_body:
+                    return {}
+                return json.loads(response_body)
+
+    def _post_telnyx_sync(
+        self, path: str, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        data = json.dumps(payload).encode("utf-8")
+        request = urllib_request.Request(
+            f"https://api.telnyx.com/v2{path}",
+            data=data,
+            headers=self._headers(),
+            method="POST",
+        )
+        with urllib_request.urlopen(request, timeout=10) as response:
+            response_body = response.read().decode("utf-8")
+            if not response_body:
+                return {}
+            return json.loads(response_body)
+
+    async def _dial_call(self, phone_number: str) -> Dict[str, Any]:
+        call_params = {
+            "to": phone_number,
+            "from": self.config.telnyx_from_number,
+            "connection_id": self.config.telnyx_connection_id,
+            **self._streaming_params(),
+        }
+
+        webhook_url = self._webhook_url()
+        if webhook_url:
+            call_params["webhook_url"] = webhook_url
+            call_params["webhook_url_method"] = "POST"
+
+        return await self._post_telnyx("/calls", call_params)
+
+    async def _hangup_call(self, call_control_id: str) -> Dict[str, Any]:
+        encoded_call_control_id = quote(call_control_id, safe="")
+        return await self._post_telnyx(
+            f"/calls/{encoded_call_control_id}/actions/hangup", {}
+        )
+
+    async def _answer_call(self, call_control_id: str) -> Dict[str, Any]:
+        encoded_call_control_id = quote(call_control_id, safe="")
+        return await self._post_telnyx(
+            f"/calls/{encoded_call_control_id}/actions/answer",
+            self._streaming_params(),
+        )
+
+    def _get_or_create_session(self, call_control_id: str) -> Dict[str, Any]:
+        if call_control_id not in self.active_call_sessions:
+            self.active_call_sessions[call_control_id] = {
+                "call_id": call_control_id,
+                "status": "unknown",
+                "created_at": datetime.now().isoformat(),
+            }
+
+        return self.active_call_sessions[call_control_id]
+
+    @staticmethod
+    def _parse_telnyx_event(
+        body: Dict[str, Any]
+    ) -> tuple[Optional[str], Dict[str, Any]]:
+        data = body.get("data") or {}
+        return data.get("event_type"), data.get("payload") or {}
+
+    def _update_session_from_event(
+        self, event_type: Optional[str], payload: Dict[str, Any]
+    ) -> Optional[str]:
+        call_control_id = payload.get("call_control_id")
+        if not call_control_id:
+            return None
+
+        session = self._get_or_create_session(call_control_id)
+        session.update(
+            {
+                "call_id": call_control_id,
+                "call_control_id": call_control_id,
+                "call_leg_id": payload.get("call_leg_id"),
+                "call_session_id": payload.get("call_session_id"),
+                "phone_number": payload.get("to") or session.get("phone_number"),
+                "from_number": payload.get("from") or session.get("from_number"),
+                "direction": payload.get("direction") or session.get("direction"),
+                "status": payload.get("state") or event_type or session["status"],
+                "last_event": event_type,
+                "updated_at": datetime.now().isoformat(),
+            }
+        )
+
+        if event_type in {"call.hangup", "streaming.stopped", "streaming.failed"}:
+            session["status"] = "completed"
+            session["ended_at"] = datetime.now().isoformat()
+
+        return call_control_id
+
     def _setup_routes(self):
         """Setup FastAPI routes"""
 
@@ -89,38 +231,37 @@ class TelnyxCallServer:
                     f"Creating call to {phone_number} with message: {message}"
                 )
 
-                # Build WebSocket URL for media streaming
-                if self.config.telnyx_public_server_url:
-                    ws_protocol = "wss" if self.config.telnyx_use_wss else "ws"
-                    media_ws_url = f"{ws_protocol}://{self.config.telnyx_public_server_url}/media"
+                if self._media_ws_url():
                     self._log_info(
-                        f"Adding media stream to WebSocket: {media_ws_url}"
+                        f"Adding media stream to WebSocket: {self._media_ws_url()}"
                     )
                 else:
-                    media_ws_url = None
                     self._log_info(
                         "No public server URL configured - media streaming disabled"
                     )
 
-                # Create Telnyx call
-                call_params = {
-                    "to": phone_number,
-                    "from_": self.config.telnyx_from_number,
-                    "connection_id": self.config.telnyx_connection_id,
-                    "answer_url": (
-                        f"{media_ws_url}/control" if media_ws_url else None
-                    ),
-                }
-
-                # Create the call using Telnyx SDK
-                call = self.telnyx_client.calls.create(**call_params)
+                response = await self._dial_call(phone_number)
+                call_data = response.get("data", response)
 
                 # Store call session
-                call_id = call.id if hasattr(call, "id") else str(call)
+                call_id = (
+                    call_data.get("call_control_id")
+                    or call_data.get("call_leg_id")
+                    or call_data.get("id")
+                )
+                if not call_id:
+                    raise HTTPException(
+                        status_code=502,
+                        detail="Telnyx call response did not include a call id",
+                    )
+
                 self.active_call_sessions[call_id] = {
                     "phone_number": phone_number,
                     "message": message,
                     "call_id": call_id,
+                    "call_control_id": call_data.get("call_control_id"),
+                    "call_leg_id": call_data.get("call_leg_id"),
+                    "call_session_id": call_data.get("call_session_id"),
                     "status": "initiated",
                     "created_at": datetime.now().isoformat(),
                 }
@@ -137,6 +278,8 @@ class TelnyxCallServer:
                     }
                 )
 
+            except HTTPException:
+                raise
             except Exception as e:
                 self._log_error(f"Failed to create call: {str(e)}")
                 raise HTTPException(status_code=500, detail=str(e))
@@ -152,8 +295,7 @@ class TelnyxCallServer:
 
                 self._log_info(f"Ending call: {call_id}")
 
-                # End call via Telnyx API
-                self.telnyx_client.calls(call_id).update(status="completed")
+                await self._hangup_call(call_id)
 
                 # Update session status
                 if call_id in self.active_call_sessions:
@@ -172,6 +314,8 @@ class TelnyxCallServer:
                     }
                 )
 
+            except HTTPException:
+                raise
             except Exception as e:
                 self._log_error(f"Failed to end call {call_id}: {str(e)}")
                 raise HTTPException(status_code=500, detail=str(e))
@@ -192,13 +336,15 @@ class TelnyxCallServer:
                         "success": True,
                         "call_id": call_id,
                         "status": session["status"],
-                        "phone_number": session["phone_number"],
-                        "message": session["message"],
+                        "phone_number": session.get("phone_number"),
+                        "message": session.get("message"),
                         "created_at": session["created_at"],
                         "ended_at": session.get("ended_at"),
                     }
                 )
 
+            except HTTPException:
+                raise
             except Exception as e:
                 self._log_error(
                     f"Failed to get call status {call_id}: {str(e)}"
@@ -217,50 +363,28 @@ class TelnyxCallServer:
             )
 
         @self.app.post("/webhook/status")
-        @self.app.get("/webhook/status")
         async def handle_status_webhook(request: Request):
             """Handle Telnyx status webhook"""
             try:
-                # Handle both GET and POST requests
-                if request.method == "GET":
-                    # For GET requests, get parameters from query string
-                    call_id = request.query_params.get(
-                        "CallSid"
-                    ) or request.query_params.get("call_id")
-                    call_status = request.query_params.get(
-                        "CallStatus"
-                    ) or request.query_params.get("status")
-                    call_duration = request.query_params.get(
-                        "CallDuration"
-                    ) or request.query_params.get("duration")
-                else:
-                    # For POST requests, get parameters from form data
-                    form_data = await request.form()
-                    call_id = form_data.get("CallSid") or form_data.get(
-                        "call_id"
-                    )
-                    call_status = form_data.get("CallStatus") or form_data.get(
-                        "status"
-                    )
-                    call_duration = form_data.get(
-                        "CallDuration"
-                    ) or form_data.get("duration")
+                body = await request.json()
+                event_type, payload = self._parse_telnyx_event(body)
+                call_id = self._update_session_from_event(event_type, payload)
 
                 self._log_info(
-                    f"Status webhook received for call {call_id}: {call_status}"
+                    f"Status webhook received for call {call_id}: {event_type}"
                 )
 
-                # Update call session status
-                if call_id in self.active_call_sessions:
-                    self.active_call_sessions[call_id]["status"] = call_status
-
-                    if call_status == "completed":
-                        self.active_call_sessions[call_id][
-                            "ended_at"
-                        ] = datetime.now().isoformat()
+                if (
+                    event_type == "call.initiated"
+                    and payload.get("direction") == "incoming"
+                    and call_id
+                ):
+                    await self._answer_call(call_id)
 
                 return JSONResponse(content={"success": True})
 
+            except HTTPException:
+                raise
             except Exception as e:
                 self._log_error(f"Failed to handle status webhook: {str(e)}")
                 raise HTTPException(status_code=500, detail=str(e))
@@ -284,12 +408,8 @@ class TelnyxCallServer:
             webhook_url = None
 
             if self.config.telnyx_public_server_url:
-                ws_protocol = "wss" if self.config.telnyx_use_wss else "ws"
-                http_protocol = (
-                    "https" if self.config.telnyx_use_https else "http"
-                )
-                media_ws_url = f"{ws_protocol}://{self.config.telnyx_public_server_url}/media"
-                webhook_url = f"{http_protocol}://{self.config.telnyx_public_server_url}/webhook/status"
+                media_ws_url = self._media_ws_url()
+                webhook_url = self._webhook_url()
 
             return JSONResponse(
                 content={
@@ -354,7 +474,7 @@ class TelnyxCallServer:
                             audio_payload = message.get("media", {}).get(
                                 "payload", ""
                             )
-                            stream_id = message.get("streamSid", "")
+                            stream_id = message.get("stream_id", "")
 
                             if audio_payload and call_id:
                                 # Forward audio to TEN framework
@@ -372,11 +492,20 @@ class TelnyxCallServer:
 
                         elif message.get("event") == "start":
                             self._log_info(f"Media stream started: {message}")
-                            stream_id = message.get("streamSid", "")
+                            stream_id = message.get("stream_id", "")
                             start = message.get("start", {})
-                            call_id = start.get("callSid", "") or start.get(
-                                "call_id", ""
-                            )
+                            call_id = start.get("call_control_id", "")
+                            if call_id and call_id not in self.active_call_sessions:
+                                self.active_call_sessions[call_id] = {
+                                    "call_id": call_id,
+                                    "call_control_id": call_id,
+                                    "call_session_id": start.get("call_session_id"),
+                                    "phone_number": start.get("to"),
+                                    "from_number": start.get("from"),
+                                    "status": "streaming",
+                                    "created_at": datetime.now().isoformat(),
+                                }
+
                             self.active_call_sessions[call_id][
                                 "stream_id"
                             ] = stream_id
@@ -449,10 +578,12 @@ class TelnyxCallServer:
     def cleanup(self):
         """Cleanup resources"""
         self._log_info("Cleaning up Telnyx Call Server")
-        # End all active calls
         for call_id in list(self.active_call_sessions.keys()):
             try:
-                self.telnyx_client.calls(call_id).update(status="completed")
+                encoded_call_control_id = quote(call_id, safe="")
+                self._post_telnyx_sync(
+                    f"/calls/{encoded_call_control_id}/actions/hangup", {}
+                )
                 self._log_info(f"Ended call {call_id}")
             except Exception as e:
                 self._log_error(f"Failed to end call {call_id}: {str(e)}")

--- a/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/test_telnyx_call_control_events.py
+++ b/ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/test_telnyx_call_control_events.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Tests for Telnyx Call Control event handling in the SIP example.
+"""
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+
+EXTENSION_DIR = Path(__file__).parent / "ten_packages" / "extension"
+PACKAGE_DIR = EXTENSION_DIR / "main_python"
+main_python = types.ModuleType("main_python")
+main_python.__path__ = [str(PACKAGE_DIR)]
+sys.modules["main_python"] = main_python
+
+from main_python.config import TelnyxConfig
+from main_python.server import TelnyxCallServer
+
+
+def make_server():
+    return TelnyxCallServer(
+        TelnyxConfig(
+            telnyx_api_key="test-key",
+            telnyx_connection_id="connection-id",
+            telnyx_from_number="+18005550100",
+            telnyx_server_port=9000,
+            telnyx_public_server_url="example.com",
+            telnyx_use_https=True,
+            telnyx_use_wss=True,
+        )
+    )
+
+
+def test_url_builders():
+    server = make_server()
+
+    assert server._media_ws_url() == "wss://example.com/media"
+    assert server._webhook_url() == "https://example.com/webhook/status"
+    assert server._streaming_params() == {
+        "stream_url": "wss://example.com/media",
+        "stream_track": "both_tracks",
+        "stream_codec": "PCMU",
+        "stream_bidirectional_mode": "rtp",
+        "stream_bidirectional_codec": "PCMU",
+    }
+
+
+def test_parse_telnyx_webhook_event():
+    event_type, payload = TelnyxCallServer._parse_telnyx_event(
+        {
+            "data": {
+                "event_type": "call.initiated",
+                "payload": {
+                    "call_control_id": "call-control-id",
+                    "direction": "incoming",
+                    "state": "parked",
+                },
+            }
+        }
+    )
+
+    assert event_type == "call.initiated"
+    assert payload["call_control_id"] == "call-control-id"
+    assert payload["direction"] == "incoming"
+
+
+def test_update_session_from_telnyx_events():
+    server = make_server()
+
+    call_id = server._update_session_from_event(
+        "call.initiated",
+        {
+            "call_control_id": "call-control-id",
+            "call_leg_id": "call-leg-id",
+            "call_session_id": "call-session-id",
+            "from": "+18005550100",
+            "to": "+18005550101",
+            "direction": "incoming",
+            "state": "parked",
+        },
+    )
+
+    assert call_id == "call-control-id"
+    session = server.active_call_sessions["call-control-id"]
+    assert session["status"] == "parked"
+    assert session["direction"] == "incoming"
+    assert session["phone_number"] == "+18005550101"
+
+    server._update_session_from_event(
+        "call.hangup",
+        {
+            "call_control_id": "call-control-id",
+            "state": "hangup",
+        },
+    )
+
+    assert server.active_call_sessions["call-control-id"]["status"] == "completed"
+    assert "ended_at" in server.active_call_sessions["call-control-id"]
+
+
+def test_dial_payload_uses_telnyx_call_control_fields():
+    server = make_server()
+    requests = []
+
+    async def fake_post(path, payload):
+        requests.append((path, payload))
+        return {"data": {"call_control_id": "call-control-id"}}
+
+    server._post_telnyx = fake_post
+    asyncio.run(server._dial_call("+18005550101"))
+
+    path, payload = requests[0]
+    assert path == "/calls"
+    assert payload["to"] == "+18005550101"
+    assert payload["from"] == "+18005550100"
+    assert payload["connection_id"] == "connection-id"
+    assert payload["stream_url"] == "wss://example.com/media"
+    assert payload["stream_track"] == "both_tracks"
+    assert payload["stream_codec"] == "PCMU"
+    assert payload["stream_bidirectional_mode"] == "rtp"
+    assert payload["webhook_url"] == "https://example.com/webhook/status"
+    assert "answer_url" not in payload
+
+
+def test_call_control_command_paths_are_encoded():
+    server = make_server()
+    requests = []
+
+    async def fake_post(path, payload):
+        requests.append((path, payload))
+        return {"data": {"result": "ok"}}
+
+    server._post_telnyx = fake_post
+    asyncio.run(server._answer_call("v3:test/id"))
+    asyncio.run(server._hangup_call("v3:test/id"))
+
+    assert requests[0][0] == "/calls/v3%3Atest%2Fid/actions/answer"
+    assert requests[1][0] == "/calls/v3%3Atest%2Fid/actions/hangup"
+
+
+def test_cleanup_hangs_up_active_sessions():
+    server = make_server()
+    requests = []
+    server.active_call_sessions["v3:test/id"] = {
+        "call_id": "v3:test/id",
+        "status": "answered",
+    }
+
+    def fake_post_sync(path, payload):
+        requests.append((path, payload))
+        return {"data": {"result": "ok"}}
+
+    server._post_telnyx_sync = fake_post_sync
+    server.cleanup()
+
+    assert requests == [("/calls/v3%3Atest%2Fid/actions/hangup", {})]
+
+
+def test_bidirectional_media_omits_stream_id():
+    source = (PACKAGE_DIR / "extension.py").read_text()
+    send_audio_source = source.split("async def send_audio_to_telnyx", 1)[1]
+    send_audio_source = send_audio_source.split(
+        "async def _cleanup_call_after_delay", 1
+    )[0]
+
+    assert '"event": "media"' in send_audio_source
+    assert '"media": {"payload": audio_base64}' in send_audio_source
+    assert '"stream_id":' not in send_audio_source
+
+
+if __name__ == "__main__":
+    test_url_builders()
+    test_parse_telnyx_webhook_event()
+    test_update_session_from_telnyx_events()
+    test_dial_payload_uses_telnyx_call_control_fields()
+    test_call_control_command_paths_are_encoded()
+    test_cleanup_hangs_up_active_sessions()
+    test_bidirectional_media_omits_stream_id()
+    print("All Telnyx Call Control event tests passed")


### PR DESCRIPTION
## Summary
- use Telnyx Call Control REST endpoints directly for dial, answer, and hangup
- parse Telnyx webhook event payloads and update sessions from call_control_id
- set stream_codec and stream_bidirectional_codec to PCMU so inbound and outbound media match the example's mu-law audio conversion
- send bidirectional media frames in the Telnyx media shape without Twilio streamSid or extra stream_id fields
- encode Call Control command paths
- remove the unused Telnyx Python SDK dependency and align README API examples with the implemented routes
- add focused tests for Telnyx URL building, webhook parsing, session updates, dial payloads, cleanup hangup behavior, and outbound media payload shape

## Testing
- python3 ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/test_telnyx_call_control_events.py
- python3 -m py_compile ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/server.py ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/ten_packages/extension/main_python/extension.py ai_agents/agents/examples/voice-assistant-sip-telnyx/tenapp/test_telnyx_call_control_events.py
- git diff --check

## Secret scan
- scanned the PR diff for key, token, password, bearer, authorization, private key, GitHub token, Slack token, AWS key, and Telnyx key patterns
- matches were only code field names and the test placeholder test-key
