### PR TITLE
fix: reap zombie worker processes in containerized environments

### DIFF
--- a/ai_agents/server/internal/worker_linux.go
+++ b/ai_agents/server/internal/worker_linux.go
@@ -9,11 +9,35 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
+
+// init registers a SIGCHLD handler to reap zombie child processes.
+//
+// TEN workers are spawned via tman, which forks a [main] subprocess.
+// When tman receives SIGKILL during stop(), it has no chance to wait()
+// for [main]. [main] becomes an orphan, re-parented to the api process
+// (PID 1 in the container). Without this handler, those orphans
+// accumulate as zombies.
+func init() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGCHLD)
+	go func() {
+		for range c {
+			for {
+				var wstatus syscall.WaitStatus
+				pid, err := syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
+				if pid <= 0 || err != nil {
+					break
+				}
+			}
+		}
+	}()
+}
 
 // Function to check if a PID is in the correct process group
 func isInProcessGroup(pid, pgid int) bool {


### PR DESCRIPTION
## Problem

In containerized environments without a proper init system (PID 1), TEN Agent Server spawns [main] worker processes via `tman run start`. When the worker is stopped, `tman` exits without calling `wait()` on its child [main], leaving zombie processes that accumulate over time.

## Root Cause

The server starts `tman` with `Setpgid: true`, then kills the process group via `syscall.Kill(-pid, SIGKILL)`. `tman` is terminated before it can reap its child [main], so the kernel re-parents the child to PID 1. In a container, PID 1 is the Go server itself, which does not call `waitpid()` on child processes outside its own `cmd.Wait()` goroutine.

## Fix

Register a `SIGCHLD` handler in `worker_linux.go` that calls `waitpid(-1, WNOHANG)` in a loop to reap any zombie children re-parented to PID 1.

## Verification

- Built on Linux (Docker): `go build ./...` passes
- Deployed and tested on live environment: voice sessions start and stop correctly, zombie process count remains zero after multiple sessions

## Related

This is a standard Linux pattern for init-less containers. The handler is placed in `worker_linux.go` (`linux || darwin` build tag) since it relies on `syscall.SIGCHLD` and `syscall.Wait4`.
