### PR TITLE
fix: align spatius avatar eof and runtime compatibility

### DIFF
--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/AVATAR_BASE_README.md
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/AVATAR_BASE_README.md
@@ -9,7 +9,7 @@
 - ✅ Built-in audio queue and processing loop
 - ✅ Sample rate validation
 - ✅ Error handling and logging
-- ✅ Command handling (flush, tts_audio_end)
+- ✅ Command handling (flush, drain)
 - ✅ Optional audio dumping for debugging
 
 ---
@@ -85,7 +85,7 @@ async def send_audio_to_avatar(self, audio_data: bytes) -> None:
 ### 6. `send_eof_to_avatar() -> None`
 **Purpose:** Signal end of audio stream.
 **Called:** Automatically when:
-- `tts_audio_end` event arrives with `reason=1` (TTS completion)
+- `drain` command is received
 
 ```python
 async def send_eof_to_avatar(self) -> None:
@@ -218,7 +218,7 @@ The base class handles the complete lifecycle automatically:
 
 4. Commands (automatic)
    └─> flush command → interrupt_avatar()
-   └─> tts_audio_end event → send_eof_to_avatar()
+   └─> drain command → send_eof_to_avatar()
 
 5. on_stop()
    └─> Stop audio processing loop
@@ -283,10 +283,10 @@ When a `flush` command is received:
 2. `interrupt_avatar()` is called
 3. `flush` command is forwarded
 
-### TTS Audio End Event
-When `tts_audio_end` event arrives with `reason=1`:
-1. `send_eof_to_avatar()` is called automatically
-2. Signals that TTS generation is complete
+### Drain Command
+When a `drain` command is received:
+1. `send_eof_to_avatar()` is queued behind pending audio
+2. Signals that TTS playback audio has drained
 
 ---
 

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/AVATAR_BASE_README.zh.md
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/AVATAR_BASE_README.zh.md
@@ -9,7 +9,7 @@
 - ✅ 内置音频队列和处理循环
 - ✅ 采样率验证
 - ✅ 错误处理和日志记录
-- ✅ 命令处理（flush、tts_audio_end）
+- ✅ 命令处理（flush、drain）
 - ✅ 可选的音频转储功能用于调试
 
 ---
@@ -85,7 +85,7 @@ async def send_audio_to_avatar(self, audio_data: bytes) -> None:
 ### 6. `send_eof_to_avatar() -> None`
 **用途：** 发送音频流结束信号。
 **调用时机：** 自动调用，当：
-- 收到 `tts_audio_end` 事件且 `reason=1`（TTS 完成）
+- 收到 `drain` 命令
 
 ```python
 async def send_eof_to_avatar(self) -> None:
@@ -218,7 +218,7 @@ class MyAvatarExtension(AsyncAvatarBaseExtension):
 
 4. 命令处理（自动）
    └─> flush 命令 → interrupt_avatar()
-   └─> tts_audio_end 事件 → send_eof_to_avatar()
+   └─> drain 命令 → send_eof_to_avatar()
 
 5. on_stop()
    └─> 停止音频处理循环
@@ -283,10 +283,10 @@ class MyAvatarExtension(AsyncAvatarBaseExtension):
 2. 调用 `interrupt_avatar()`
 3. 转发 `flush` 命令
 
-### TTS Audio End 事件
-收到 `tts_audio_end` 事件且 `reason=1` 时：
-1. 自动调用 `send_eof_to_avatar()`
-2. 表示 TTS 生成完成
+### Drain 命令
+收到 `drain` 命令时：
+1. 将 `send_eof_to_avatar()` 排到待处理音频之后执行
+2. 表示 TTS 播放音频已经 drain 完成
 
 ---
 

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/avatar_base.py
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/avatar_base.py
@@ -62,7 +62,7 @@ That's it! The base class handles everything else:
 - Audio processing loop
 - Sample rate validation
 - Audio dumping (if enabled)
-- Command handling (flush)
+- Command handling (flush, drain)
 - Lifecycle management
 - Error handling
 
@@ -72,14 +72,13 @@ Lifecycle (Automatic):
 2. on_start() → calls connect_to_avatar() → starts audio loop
 3. Audio arrives → sample rate checked → queued → calls send_audio_to_avatar()
 4. flush command → calls interrupt_avatar()
-5. tts_audio_end event → calls send_eof_to_avatar()
+5. drain command → calls send_eof_to_avatar()
 6. on_stop() → calls disconnect_from_avatar() → cleanup
 
 You don't need to override on_init/on_start/on_stop!
 """
 
 import asyncio
-import json
 from abc import ABC, abstractmethod
 from typing import Any
 import os
@@ -103,6 +102,7 @@ from ten_ai_base.message import ErrorMessage, ModuleType
 
 # Avatar-specific constants
 MODULE_TYPE_AVATAR = "avatar"
+CMD_IN_DRAIN = "drain"
 
 
 class AsyncAvatarBaseExtension(AsyncExtension, ABC):
@@ -225,9 +225,7 @@ class AsyncAvatarBaseExtension(AsyncExtension, ABC):
         """
         [REQUIRED] Signal end of audio stream.
 
-        Called automatically in two scenarios:
-        1. When drain command is received (manual trigger)
-        2. When tts_audio_end event arrives
+        Called automatically when drain command is received.
 
         Example:
             async def send_eof_to_avatar(self) -> None:
@@ -373,6 +371,13 @@ class AsyncAvatarBaseExtension(AsyncExtension, ABC):
             await self._handle_flush(ten_env)
             await ten_env.send_cmd(Cmd.create(CMD_OUT_FLUSH))
 
+        elif cmd_name == CMD_IN_DRAIN:
+            ten_env.log_info(
+                f"KEYPOINT [on_cmd:{CMD_IN_DRAIN}]",
+                category=LOG_CATEGORY_KEY_POINT,
+            )
+            await self._handle_drain(ten_env)
+
         cmd_result = CmdResult.create(StatusCode.OK, cmd)
         await ten_env.return_result(cmd_result)
         ten_env.log_info(f"{self.LOG_PREFIX} on_cmd completed: {cmd_name}")
@@ -381,25 +386,6 @@ class AsyncAvatarBaseExtension(AsyncExtension, ABC):
         """Handle incoming data events."""
         data_name = data.get_name()
         ten_env.log_info(f"{self.LOG_PREFIX} on_data received: {data_name}")
-
-        if data_name == "tts_audio_end":
-            json_str, _ = data.get_property_to_json(None)
-            reason = None
-            request_id = "unknown"
-            if json_str:
-                payload = json.loads(json_str)
-                reason = payload.get("reason")
-                request_id = payload.get("request_id", "unknown")
-            ten_env.log_info(
-                f"{self.LOG_PREFIX} tts_audio_end: "
-                f"reason={reason}, request_id={request_id}"
-            )
-
-            ten_env.log_info(
-                f"{self.LOG_PREFIX} TTS audio ended "
-                f"(request_id={request_id}), sending EOF"
-            )
-            await self._on_tts_audio_end(ten_env)
 
     # ========================================================================
     # AUDIO HANDLING - Managed by base class
@@ -514,8 +500,8 @@ class AsyncAvatarBaseExtension(AsyncExtension, ABC):
         except Exception as e:
             ten_env.log_error(f"{self.LOG_PREFIX} Error interrupting: {e}")
 
-    async def _on_tts_audio_end(self, ten_env: AsyncTenEnv) -> None:
-        """Handle tts_audio_end event."""
+    async def _handle_drain(self, ten_env: AsyncTenEnv) -> None:
+        """Handle drain command."""
         if not self._audio_processing_enabled:
             ten_env.log_info(
                 f"{self.LOG_PREFIX} Audio processing disabled, skipping EOF"

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/extension.py
@@ -11,6 +11,7 @@ from typing import TypedDict
 from agora_token_builder import RtcTokenBuilder
 from ten_runtime import AsyncTenEnv
 from ten_ai_base.config import BaseConfig
+from ten_ai_base.utils import encrypt
 from spatius import new_avatar_session, AgoraEgressConfig
 
 from .avatar_base import AsyncAvatarBaseExtension
@@ -225,25 +226,23 @@ class SpatiusAvatarExtension(AsyncAvatarBaseExtension):
 
     def _masked_api_key(self) -> str:
         """Return a redacted Spatius API key for logs."""
-        if len(self.config.spatius_api_key) <= 4:
-            return "(short)"
-        return f"***{self.config.spatius_api_key[-4:]}"
+        return self._encrypt_config_value(self.config.spatius_api_key)
 
     def _masked_agora_token(self) -> str:
         """Return a redacted Agora token for logs."""
         if not self.config.agora_token:
             return "(generated from app cert)"
-        if len(self.config.agora_token) <= 4:
-            return "(short)"
-        return f"***{self.config.agora_token[-4:]}"
+        return self._encrypt_config_value(self.config.agora_token)
 
     def _masked_agora_appcert(self) -> str:
         """Return a redacted Agora app certificate for logs."""
-        if not self.config.agora_appcert:
+        return self._encrypt_config_value(self.config.agora_appcert)
+
+    @staticmethod
+    def _encrypt_config_value(value: str) -> str:
+        if not value:
             return "(empty)"
-        if len(self.config.agora_appcert) <= 4:
-            return "(short)"
-        return f"***{self.config.agora_appcert[-4:]}"
+        return encrypt(value)
 
     def _region(self) -> str:
         """Return the configured Spatius region."""

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "spatius_avatar_python",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": [
     {
       "type": "system",
@@ -95,14 +95,12 @@
         "name": "pcm_frame"
       }
     ],
-    "data_in": [
-      {
-        "name": "tts_audio_end"
-      }
-    ],
     "cmd_in": [
       {
         "name": "flush"
+      },
+      {
+        "name": "drain"
       }
     ]
   },

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/requirements.txt
@@ -1,4 +1,4 @@
 pytest==8.3.4
 agora-token-builder>=1.0.0
-spatius==1.0.1
-protobuf>=6.31.1
+spatius==1.0.2
+protobuf>=5.28.3,<6


### PR DESCRIPTION
## Summary
- switch Spatius avatar EOF handling from tts_audio_end data to the drain command
- update the Spatius avatar manifest to accept drain and stop declaring tts_audio_end input
- bump spatius_avatar_python to 0.1.3 and update local avatar base docs
- update Spatius SDK dependency to spatius==1.0.2 and constrain protobuf to >=5.28.3,<6 for TEN runtime compatibility
- use ten_ai_base.utils.encrypt for Spatius API key, Agora token, and Agora app certificate in config logs

## Tests
- uvx --from black black --check --line-length 80 ai_agents/agents/ten_packages/extension/spatius_avatar_python/avatar_base.py ai_agents/agents/ten_packages/extension/spatius_avatar_python/extension.py
- python3 -m py_compile ai_agents/agents/ten_packages/extension/spatius_avatar_python/avatar_base.py ai_agents/agents/ten_packages/extension/spatius_avatar_python/extension.py
- python3 -m venv /private/tmp/spatius-ten-req-venv && /private/tmp/spatius-ten-req-venv/bin/python -m pip install -q -r ai_agents/agents/ten_packages/extension/spatius_avatar_python/requirements.txt && /private/tmp/spatius-ten-req-venv/bin/python - <<'PY'
import google.protobuf
import spatius
from spatius.proto.generated import message_pb2
print('protobuf', google.protobuf.__version__)
print('spatius', spatius.__name__)
print('message', message_pb2.Message.DESCRIPTOR.full_name)
PY

Note: full container task check was not run because ten_agent_dev is not running locally.