### PR TITLE
fix: reconnect xai asr after finalize

### DIFF
--- a/ai_agents/agents/integration_tests/asr_guarder/README.md
+++ b/ai_agents/agents/integration_tests/asr_guarder/README.md
@@ -68,6 +68,7 @@ task asr-guarder-test EXTENSION=oracle_asr_python -- -k test_connection_timing
 | `test_connection_timing` | Verifies ASR extension establishes connection and processes audio |
 | `test_asr_result` | Validates ASR result fields, language detection, and ID consistency across multiple sends |
 | `test_asr_finalize` | Tests `asr_finalize` signal handling and `asr_finalize_end` response |
+| `test_same_session_finalize_reconnect` | Repeats audio -> finalize twice in one session and requires a second non-empty result |
 | `test_reconnection` | Tests reconnection mechanism with invalid credentials |
 | `test_vendor_error` | Validates vendor error detection and error message format |
 | `test_multi_language` | Tests English and Chinese language processing |

--- a/ai_agents/agents/integration_tests/asr_guarder/tests/test_same_session_finalize_reconnect.py
+++ b/ai_agents/agents/integration_tests/asr_guarder/tests/test_same_session_finalize_reconnect.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+
+from typing import Any
+from typing_extensions import override
+from ten_runtime import (
+    AsyncExtensionTester,
+    AsyncTenEnvTester,
+    Data,
+    AudioFrame,
+    TenError,
+    TenErrorCode,
+)
+import asyncio
+import json
+import os
+
+
+AUDIO_CHUNK_SIZE = 320
+FRAME_INTERVAL_MS = 10
+RESULT_WAIT_TIMEOUT_SECS = 15
+FINALIZE_WAIT_TIMEOUT_SECS = 10
+
+CONFIG_FILE = "property_en.json"
+SESSION_ID = "test_same_session_finalize_reconnect_session_123"
+EXPECTED_LANGUAGE = "en-US"
+
+
+class SameSessionFinalizeReconnectTester(AsyncExtensionTester):
+    """Validate that one session survives multiple finalize cycles."""
+
+    def __init__(
+        self,
+        audio_file_path: str,
+        session_id: str = SESSION_ID,
+        expected_language: str = EXPECTED_LANGUAGE,
+    ):
+        super().__init__()
+        print("=" * 80)
+        print("🧪 TEST CASE: Same Session Finalize Reconnect Test")
+        print("=" * 80)
+        print(
+            "📋 Test Description: Validate that ASR keeps working after finalize in the same session"
+        )
+        print("🎯 Test Objectives:")
+        print("   - Send audio in one session")
+        print("   - Finalize and receive final result + finalize_end")
+        print("   - Send audio again in the same session")
+        print("   - Finalize again and require another non-empty final result")
+        print("=" * 80)
+
+        self.audio_file_path = audio_file_path
+        self.session_id = session_id
+        self.expected_language = expected_language
+
+        self.current_cycle = 0
+        self.current_finalize_id: str | None = None
+        self.current_cycle_final_text: str | None = None
+
+        self.result_event = asyncio.Event()
+        self.finalize_end_event = asyncio.Event()
+        self.cycle_results: list[dict[str, Any]] = []
+
+    def _stop_test_with_error(
+        self, ten_env: AsyncTenEnvTester, error_message: str
+    ) -> None:
+        ten_env.stop_test(
+            TenError.create(TenErrorCode.ErrorCodeGeneric, error_message)
+        )
+
+    def _create_audio_frame(self, data: bytes, session_id: str) -> AudioFrame:
+        audio_frame = AudioFrame.create("pcm_frame")
+        metadata = {"session_id": session_id}
+        audio_frame.set_property_from_json("metadata", json.dumps(metadata))
+        audio_frame.alloc_buf(len(data))
+        buf = audio_frame.lock_buf()
+        buf[:] = data
+        audio_frame.unlock_buf(buf)
+        return audio_frame
+
+    async def _send_audio_file(self, ten_env: AsyncTenEnvTester) -> None:
+        ten_env.log_info(
+            f"Sending audio file for cycle {self.current_cycle}: {self.audio_file_path}"
+        )
+        with open(self.audio_file_path, "rb") as audio_file:
+            while True:
+                chunk = audio_file.read(AUDIO_CHUNK_SIZE)
+                if not chunk:
+                    break
+                audio_frame = self._create_audio_frame(chunk, self.session_id)
+                await ten_env.send_audio_frame(audio_frame)
+                await asyncio.sleep(FRAME_INTERVAL_MS / 1000)
+
+    async def _send_finalize_signal(self, ten_env: AsyncTenEnvTester) -> None:
+        self.current_finalize_id = (
+            f"finalize_{self.session_id}_{self.current_cycle}_"
+            f"{int(asyncio.get_event_loop().time())}"
+        )
+        finalize_data = {
+            "finalize_id": self.current_finalize_id,
+            "metadata": {"session_id": self.session_id},
+        }
+        finalize_data_obj = Data.create("asr_finalize")
+        finalize_data_obj.set_property_from_json(
+            None, json.dumps(finalize_data)
+        )
+        await ten_env.send_data(finalize_data_obj)
+        ten_env.log_info(
+            f"✅ asr_finalize sent for cycle {self.current_cycle}: {self.current_finalize_id}"
+        )
+
+    async def _run_cycle(self, ten_env: AsyncTenEnvTester, cycle: int) -> None:
+        self.current_cycle = cycle
+        self.current_cycle_final_text = None
+        self.current_finalize_id = None
+        self.result_event.clear()
+        self.finalize_end_event.clear()
+
+        ten_env.log_info(f"=== Starting cycle {cycle} in session {self.session_id} ===")
+        await self._send_audio_file(ten_env)
+        await asyncio.sleep(1.5)
+        await self._send_finalize_signal(ten_env)
+
+        try:
+            await asyncio.wait_for(
+                self.result_event.wait(), timeout=RESULT_WAIT_TIMEOUT_SECS
+            )
+        except asyncio.TimeoutError:
+            self._stop_test_with_error(
+                ten_env,
+                f"Timed out waiting for final ASR result in cycle {cycle}",
+            )
+            return
+
+        try:
+            await asyncio.wait_for(
+                self.finalize_end_event.wait(),
+                timeout=FINALIZE_WAIT_TIMEOUT_SECS,
+            )
+        except asyncio.TimeoutError:
+            self._stop_test_with_error(
+                ten_env,
+                f"Timed out waiting for asr_finalize_end in cycle {cycle}",
+            )
+            return
+
+    def _validate_required_fields(
+        self, ten_env: AsyncTenEnvTester, json_data: dict[str, Any]
+    ) -> bool:
+        required_fields = [
+            "id",
+            "text",
+            "final",
+            "start_ms",
+            "duration_ms",
+            "language",
+        ]
+        missing_fields = [
+            field for field in required_fields if field not in json_data
+        ]
+        if missing_fields:
+            self._stop_test_with_error(
+                ten_env, f"Missing required fields: {missing_fields}"
+            )
+            return False
+        return True
+
+    def _validate_final_result(
+        self, ten_env: AsyncTenEnvTester, json_data: dict[str, Any]
+    ) -> bool:
+        language = json_data.get("language", "")
+        if language != self.expected_language:
+            self._stop_test_with_error(
+                ten_env,
+                f"Language mismatch, expected: {self.expected_language}, actual: {language}",
+            )
+            return False
+
+        metadata = json_data.get("metadata")
+        if (
+            not isinstance(metadata, dict)
+            or metadata.get("session_id") != self.session_id
+        ):
+            self._stop_test_with_error(
+                ten_env,
+                f"session_id mismatch, expected: {self.session_id}, actual: {metadata}",
+            )
+            return False
+
+        text = str(json_data.get("text", ""))
+        if not text.strip():
+            self._stop_test_with_error(
+                ten_env,
+                f"Cycle {self.current_cycle} produced empty final transcription",
+            )
+            return False
+
+        return True
+
+    @override
+    async def on_start(self, ten_env: AsyncTenEnvTester) -> None:
+        await self._run_cycle(ten_env, cycle=1)
+        # Give single-utterance vendors a short window to reopen cleanly.
+        await asyncio.sleep(1.0)
+        await self._run_cycle(ten_env, cycle=2)
+
+        if len(self.cycle_results) != 2:
+            self._stop_test_with_error(
+                ten_env,
+                f"Expected 2 successful cycles, got {len(self.cycle_results)}",
+            )
+            return
+
+        ten_env.log_info(
+            "✅ Same-session finalize reconnect test passed with 2 non-empty final results"
+        )
+        ten_env.stop_test()
+
+    @override
+    async def on_data(self, ten_env: AsyncTenEnvTester, data: Data) -> None:
+        name = data.get_name()
+
+        if name == "asr_finalize_end":
+            json_str, _ = data.get_property_to_json(None)
+            finalize_end_data: dict[str, Any] = json.loads(json_str)
+            finalize_id = finalize_end_data.get("finalize_id")
+            metadata = finalize_end_data.get("metadata")
+
+            if finalize_id != self.current_finalize_id:
+                self._stop_test_with_error(
+                    ten_env,
+                    f"Unexpected finalize_end id in cycle {self.current_cycle}: "
+                    f"expected {self.current_finalize_id}, got {finalize_id}",
+                )
+                return
+
+            if (
+                not isinstance(metadata, dict)
+                or metadata.get("session_id") != self.session_id
+            ):
+                self._stop_test_with_error(
+                    ten_env,
+                    f"Unexpected finalize_end metadata in cycle {self.current_cycle}: {metadata}",
+                )
+                return
+
+            ten_env.log_info(
+                f"✅ finalize_end received for cycle {self.current_cycle}: {finalize_id}"
+            )
+            self.finalize_end_event.set()
+            return
+
+        if name != "asr_result":
+            ten_env.log_info(f"Received non-ASR data: {name}")
+            return
+
+        json_str, _ = data.get_property_to_json(None)
+        json_data: dict[str, Any] = json.loads(json_str)
+        if not self._validate_required_fields(ten_env, json_data):
+            return
+
+        is_final = bool(json_data.get("final", False))
+        text = str(json_data.get("text", ""))
+        ten_env.log_info(
+            f"Received ASR result in cycle {self.current_cycle} - "
+            f"final: {is_final}, text: {text!r}"
+        )
+
+        if not is_final:
+            return
+        if self.result_event.is_set():
+            ten_env.log_info(
+                f"Ignoring additional final result in cycle {self.current_cycle}"
+            )
+            return
+        if not self._validate_final_result(ten_env, json_data):
+            return
+
+        self.current_cycle_final_text = text
+        self.cycle_results.append(
+            {
+                "cycle": self.current_cycle,
+                "id": json_data.get("id"),
+                "text": text,
+            }
+        )
+        ten_env.log_info(
+            f"✅ Final ASR result received in cycle {self.current_cycle}: {text!r}"
+        )
+        self.result_event.set()
+
+    @override
+    async def on_stop(self, ten_env: AsyncTenEnvTester) -> None:
+        ten_env.log_info("Test stopped")
+
+
+def test_same_session_finalize_reconnect(
+    extension_name: str, config_dir: str
+) -> None:
+    audio_file_path = os.path.join(
+        os.path.dirname(__file__), "test_data/16k_en_us.pcm"
+    )
+    config_file_path = os.path.join(config_dir, CONFIG_FILE)
+    if not os.path.exists(config_file_path):
+        raise FileNotFoundError(f"Config file not found: {config_file_path}")
+
+    with open(config_file_path, "r") as f:
+        config: dict[str, Any] = json.load(f)
+
+    print(f"Using test configuration: {config}")
+    print(f"Audio file path: {audio_file_path}")
+    print(
+        f"Expected results: language='{EXPECTED_LANGUAGE}', session_id='{SESSION_ID}'"
+    )
+
+    tester = SameSessionFinalizeReconnectTester(
+        audio_file_path=audio_file_path,
+        session_id=SESSION_ID,
+        expected_language=EXPECTED_LANGUAGE,
+    )
+    tester.set_test_mode_single(extension_name, json.dumps(config))
+    error = tester.run()
+
+    assert (
+        error is None
+    ), f"Test failed: {error.error_message() if error else 'Unknown error'}"

--- a/ai_agents/agents/ten_packages/extension/xai_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/xai_asr_python/extension.py
@@ -402,9 +402,29 @@ class XAIASRExtension(AsyncASRBaseExtension, XAIASRRecognitionCallback):
         if self._stop_requested:
             return
         if self._close_expected:
+            # xAI STT is a single-utterance protocol: the server closes the
+            # socket after each transcript.done. Subsequent turns need a
+            # fresh connection. Schedule a clean reconnect (not the
+            # backoff path — this is a planned cycle, not a failure).
+            # The base class buffers audio frames in the meantime and
+            # flushes them from on_open.
             self._close_expected = False
+            asyncio.create_task(self._reconnect_after_finalize())
             return
         await self._handle_reconnect()
+
+    async def _reconnect_after_finalize(self) -> None:
+        if self._stop_requested:
+            return
+        try:
+            await self._connect_recognition()
+        except Exception as e:
+            self.ten_env.log_warn(
+                f"xAI STT post-finalize reconnect failed: {e}; "
+                f"falling back to reconnect manager backoff",
+                category=LOG_CATEGORY_VENDOR,
+            )
+            await self._handle_reconnect()
 
     async def _handle_reconnect(self) -> None:
         if not self.reconnect_manager:

--- a/ai_agents/agents/ten_packages/extension/xai_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/xai_asr_python/extension.py
@@ -46,11 +46,13 @@ class XAIASRExtension(AsyncASRBaseExtension, XAIASRRecognitionCallback):
         self.reconnect_manager: ReconnectManager | None = None
         self._stop_requested = False
         self._close_expected = False
+        self._finalize_reconnect_task: asyncio.Task | None = None
         self.connection_start_timestamp = 0
         self._init_failed = False
 
     @override
     async def on_deinit(self, ten_env: AsyncTenEnv) -> None:
+        self._cancel_finalize_reconnect_task()
         await super().on_deinit(ten_env)
         if self.audio_dumper:
             await self.audio_dumper.stop()
@@ -214,6 +216,7 @@ class XAIASRExtension(AsyncASRBaseExtension, XAIASRRecognitionCallback):
     @override
     async def stop_connection(self) -> None:
         self._stop_requested = True
+        self._cancel_finalize_reconnect_task()
         if self.recognition:
             await self.recognition.close()
             self.recognition = None
@@ -409,9 +412,30 @@ class XAIASRExtension(AsyncASRBaseExtension, XAIASRRecognitionCallback):
             # The base class buffers audio frames in the meantime and
             # flushes them from on_open.
             self._close_expected = False
-            asyncio.create_task(self._reconnect_after_finalize())
+            self._schedule_finalize_reconnect()
             return
         await self._handle_reconnect()
+
+    def _schedule_finalize_reconnect(self) -> None:
+        self._cancel_finalize_reconnect_task()
+        self._finalize_reconnect_task = asyncio.create_task(
+            self._reconnect_after_finalize()
+        )
+        self._finalize_reconnect_task.add_done_callback(
+            self._clear_finalize_reconnect_task
+        )
+
+    def _cancel_finalize_reconnect_task(self) -> None:
+        if (
+            self._finalize_reconnect_task
+            and not self._finalize_reconnect_task.done()
+        ):
+            self._finalize_reconnect_task.cancel()
+        self._finalize_reconnect_task = None
+
+    def _clear_finalize_reconnect_task(self, task: asyncio.Task) -> None:
+        if self._finalize_reconnect_task is task:
+            self._finalize_reconnect_task = None
 
     async def _reconnect_after_finalize(self) -> None:
         if self._stop_requested:

--- a/ai_agents/agents/ten_packages/extension/xai_asr_python/tests/test_reconnect.py
+++ b/ai_agents/agents/ten_packages/extension/xai_asr_python/tests/test_reconnect.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from ten_ai_base.message import ModuleErrorCode
 
@@ -157,6 +157,135 @@ def test_stop_connection_cancels_pending_finalize_reconnect_task():
         assert extension.recognition is None
         assert extension._finalize_reconnect_task is None
         assert task.cancelled()
+
+    asyncio.run(_run())
+
+
+def test_stop_connection_cancels_inflight_connect_recognition():
+    """Race coverage: stop_connection() is called while a finalize-reconnect
+    task is mid-flight inside _connect_recognition() (recognition partially
+    created, recognition.start() still awaiting). Verify the in-flight task is
+    cancelled cleanly — recognition ends up None, no second reconnect is
+    attempted, and the cancelled task leaks no exception."""
+
+    async def _run():
+        extension = XAIASRExtension("xai_asr_python")
+        extension.ten_env = MagicMock()
+        extension.reconnect_manager = MagicMock()
+        extension.send_asr_error = AsyncMock()
+
+        recognition = MagicMock()
+        recognition.close = AsyncMock()
+
+        connect_started = asyncio.Event()
+        connect_calls = 0
+
+        async def inflight_connect():
+            nonlocal connect_calls
+            connect_calls += 1
+            # Mimic _connect_recognition having partially created the
+            # recognition object before recognition.start() returns.
+            extension.recognition = recognition
+            connect_started.set()
+            # Block here as if awaiting recognition.start(); only a cancel
+            # should ever unblock this.
+            await asyncio.Event().wait()
+
+        extension._connect_recognition = inflight_connect
+
+        # State right after the vendor closed the socket post-finalize.
+        extension._stop_requested = False
+        extension._close_expected = True
+        extension.recognition = MagicMock()
+
+        await extension.on_close()
+        task = extension._finalize_reconnect_task
+        assert task is not None
+
+        # Let the reconnect task actually reach the in-flight await point.
+        await connect_started.wait()
+        assert extension.recognition is recognition
+
+        # Now race a stop in while the connect is still suspended.
+        await extension.stop_connection()
+
+        # The cancelled task must settle without leaking an exception.
+        result = await asyncio.gather(task, return_exceptions=True)
+        assert task.cancelled()
+        assert isinstance(result[0], asyncio.CancelledError)
+
+        assert extension._stop_requested is True
+        assert extension.recognition is None
+        recognition.close.assert_awaited_once()
+        assert extension._finalize_reconnect_task is None
+        # No second reconnect: connect ran exactly once and the backoff
+        # error path was never entered.
+        assert connect_calls == 1
+        extension.send_asr_error.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_stop_connection_cancels_real_connect_recognition_at_start():
+    """Same race as above, but drives the *real* _connect_recognition body so
+    we exercise the production line that assigns self.recognition before
+    recognition.start() returns. recognition.start() is held open; a
+    concurrent stop_connection() must cancel cleanly, close the half-started
+    recognition, and leave no second reconnect or leaked exception."""
+
+    async def _run():
+        extension = XAIASRExtension("xai_asr_python")
+        extension.ten_env = MagicMock()
+        extension.reconnect_manager = MagicMock()
+        extension.send_asr_error = AsyncMock()
+        extension.audio_timeline = MagicMock()
+
+        extension.config = MagicMock()
+        extension.config.params = {"api_key": "test-key"}
+
+        start_entered = asyncio.Event()
+
+        recognition_instance = MagicMock()
+        recognition_instance.is_connected.return_value = False
+        recognition_instance.close = AsyncMock()
+
+        async def blocking_start(timeout=None):
+            # We are now mid recognition.start(); self.recognition has already
+            # been assigned by the real _connect_recognition.
+            start_entered.set()
+            await asyncio.Event().wait()
+
+        recognition_instance.start = AsyncMock(side_effect=blocking_start)
+
+        extension._stop_requested = False
+        extension._close_expected = True
+        extension.recognition = None
+
+        with patch(
+            "xai_asr_python.extension.XAIASRRecognition",
+            return_value=recognition_instance,
+        ) as recognition_cls:
+            extension._schedule_finalize_reconnect()
+            task = extension._finalize_reconnect_task
+            assert task is not None
+
+            # Let the real _connect_recognition run up to recognition.start().
+            await start_entered.wait()
+            assert extension.recognition is recognition_instance
+
+            await extension.stop_connection()
+
+            result = await asyncio.gather(task, return_exceptions=True)
+            assert task.cancelled()
+            assert isinstance(result[0], asyncio.CancelledError)
+
+            assert extension._stop_requested is True
+            assert extension.recognition is None
+            recognition_instance.close.assert_awaited_once()
+            assert extension._finalize_reconnect_task is None
+            # Exactly one recognition was constructed: no second reconnect.
+            assert recognition_cls.call_count == 1
+            extension.send_asr_error.assert_not_awaited()
 
     asyncio.run(_run())
 

--- a/ai_agents/agents/ten_packages/extension/xai_asr_python/tests/test_reconnect.py
+++ b/ai_agents/agents/ten_packages/extension/xai_asr_python/tests/test_reconnect.py
@@ -53,6 +53,82 @@ def test_reconnect_counter_resets_after_success():
     assert manager.attempts == 0
 
 
+def test_on_close_expected_after_finalize_reconnects_fresh_socket():
+    """Regression: xAI STT is a single-utterance protocol — the server
+    closes the socket after transcript.done. Previously on_close returned
+    early when _close_expected was True, leaving recognition=None and
+    dropping every subsequent turn. Verify on_close now schedules a
+    fresh _connect_recognition() so the next utterance can be captured.
+    """
+
+    async def _run():
+        extension = XAIASRExtension("xai_asr_python")
+        extension.ten_env = MagicMock()
+        extension.reconnect_manager = MagicMock()
+        extension._connect_recognition = AsyncMock()
+        extension.send_asr_error = AsyncMock()
+
+        # State right after finalize() ran and the vendor closed the socket.
+        extension._stop_requested = False
+        extension._close_expected = True
+        extension.recognition = MagicMock()
+
+        await extension.on_close()
+        # The reconnect is scheduled as a task; wait for it to complete.
+        pending = [
+            t for t in asyncio.all_tasks() if t is not asyncio.current_task()
+        ]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+        # _close_expected reset, recognition cleared, fresh connect attempted.
+        assert extension._close_expected is False
+        assert extension.recognition is None
+        extension._connect_recognition.assert_awaited_once()
+        # The backoff reconnect path was NOT used — this is a planned cycle.
+        extension.send_asr_error.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_on_close_expected_falls_back_to_backoff_if_reconnect_fails():
+    """If the planned reconnect after finalize raises, the extension
+    should fall back to the bounded reconnect-manager backoff path
+    instead of silently leaving the session dead."""
+
+    async def _run():
+        extension = XAIASRExtension("xai_asr_python")
+        extension.ten_env = MagicMock()
+        extension.reconnect_manager = ReconnectManager(
+            base_delay=0,
+            max_delay=0,
+            max_attempts=2,
+            logger=MagicMock(),
+        )
+        extension.send_asr_error = AsyncMock()
+        extension._connect_recognition = AsyncMock(
+            side_effect=RuntimeError("xai down")
+        )
+
+        extension._stop_requested = False
+        extension._close_expected = True
+        extension.recognition = MagicMock()
+
+        await extension.on_close()
+        pending = [
+            t for t in asyncio.all_tasks() if t is not asyncio.current_task()
+        ]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+        # First attempt is the planned reconnect; on failure the backoff
+        # path runs max_attempts=2 times.
+        assert extension._connect_recognition.await_count >= 3
+        assert extension.send_asr_error.await_count >= 1
+
+    asyncio.run(_run())
+
+
 def test_on_close_retries_until_retry_ceiling():
     async def _run():
         extension = XAIASRExtension("xai_asr_python")

--- a/ai_agents/agents/ten_packages/extension/xai_asr_python/tests/test_reconnect.py
+++ b/ai_agents/agents/ten_packages/extension/xai_asr_python/tests/test_reconnect.py
@@ -74,6 +74,7 @@ def test_on_close_expected_after_finalize_reconnects_fresh_socket():
         extension.recognition = MagicMock()
 
         await extension.on_close()
+        assert extension._finalize_reconnect_task is not None
         # The reconnect is scheduled as a task; wait for it to complete.
         pending = [
             t for t in asyncio.all_tasks() if t is not asyncio.current_task()
@@ -84,6 +85,7 @@ def test_on_close_expected_after_finalize_reconnects_fresh_socket():
         # _close_expected reset, recognition cleared, fresh connect attempted.
         assert extension._close_expected is False
         assert extension.recognition is None
+        assert extension._finalize_reconnect_task is None
         extension._connect_recognition.assert_awaited_once()
         # The backoff reconnect path was NOT used — this is a planned cycle.
         extension.send_asr_error.assert_not_awaited()
@@ -115,6 +117,7 @@ def test_on_close_expected_falls_back_to_backoff_if_reconnect_fails():
         extension.recognition = MagicMock()
 
         await extension.on_close()
+        assert extension._finalize_reconnect_task is not None
         pending = [
             t for t in asyncio.all_tasks() if t is not asyncio.current_task()
         ]
@@ -123,8 +126,37 @@ def test_on_close_expected_falls_back_to_backoff_if_reconnect_fails():
 
         # First attempt is the planned reconnect; on failure the backoff
         # path runs max_attempts=2 times.
+        assert extension._finalize_reconnect_task is None
         assert extension._connect_recognition.await_count >= 3
         assert extension.send_asr_error.await_count >= 1
+
+    asyncio.run(_run())
+
+
+def test_stop_connection_cancels_pending_finalize_reconnect_task():
+    async def _run():
+        extension = XAIASRExtension("xai_asr_python")
+        extension.ten_env = MagicMock()
+        recognition = MagicMock()
+        recognition.close = AsyncMock()
+        extension.recognition = recognition
+
+        blocker = asyncio.Event()
+
+        async def pending_reconnect():
+            await blocker.wait()
+
+        task = asyncio.create_task(pending_reconnect())
+        extension._finalize_reconnect_task = task
+
+        await extension.stop_connection()
+        await asyncio.gather(task, return_exceptions=True)
+
+        assert extension._stop_requested is True
+        recognition.close.assert_awaited_once()
+        assert extension.recognition is None
+        assert extension._finalize_reconnect_task is None
+        assert task.cancelled()
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary

xAI STT is a **single-utterance** protocol: the server closes the websocket after each `transcript.done`. Previously, on a finalize-induced close, `on_close()` consumed the `_close_expected` flag and returned **without reconnecting**, leaving `recognition = None`. Every subsequent turn's audio then hit the base class, which only *buffers* frames when disconnected and never reconnects — so the second utterance in a session was silently dropped. This is the "first turn works, dead after that" symptom seen in the `voice_assistant_xai_grok` graph.

## Changes

- **`extension.py`** — on the planned-close path, schedule `_reconnect_after_finalize()` to open a fresh connection (bypassing the failure-backoff path, since this is a planned cycle, not an error), with a fallback to the reconnect-manager backoff if the clean reconnect throws. Buffered frames flush from `on_open`. A fresh `XAIASRRecognition` per utterance also avoids reusing a stale `done_event`/`done_payload`.
- The reconnect task is tracked via `self._finalize_reconnect_task` and cancelled on `stop_connection()` / `on_deinit()`, so an in-flight reconnect is cleanly aborted on shutdown.

## Tests

- `tests/test_reconnect.py` — unit tests (mock-based): planned reconnect on finalize-close, fallback to backoff on failure, and cancellation of a pending reconnect on `stop_connection`.
- `integration_tests/asr_guarder/test_same_session_finalize_reconnect.py` — guarder test that runs two audio→finalize cycles in one session and requires a second non-empty final result.