### PR TITLE
feat(spatius): enable opus by default for spatius avatar

### DIFF
--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/extension.py
@@ -12,9 +12,17 @@ from agora_token_builder import RtcTokenBuilder
 from ten_runtime import AsyncTenEnv
 from ten_ai_base.config import BaseConfig
 from ten_ai_base.utils import encrypt
-from spatius import new_avatar_session, AgoraEgressConfig
+from spatius import (
+    AgoraEgressConfig,
+    AudioFormat,
+    OggOpusEncoderConfig,
+    new_avatar_session,
+)
 
 from .avatar_base import AsyncAvatarBaseExtension
+
+DEFAULT_AUDIO_FORMAT = AudioFormat.OGG_OPUS.value
+SUPPORTED_OPUS_SAMPLE_RATES = {8000, 12000, 16000, 24000, 48000}
 
 
 class SpatiusParams(TypedDict, total=False):
@@ -31,6 +39,7 @@ class SpatiusParams(TypedDict, total=False):
     region: str
     sample_rate: int | str
     session_expire_minutes: int | str
+    audio_format: str
 
 
 @dataclass
@@ -50,6 +59,7 @@ class SpatiusConfig(BaseConfig):
     region: str = ""
     sample_rate: int = 24000
     session_expire_minutes: int = 30
+    audio_format: str = DEFAULT_AUDIO_FORMAT
 
     channel: str = ""
     params: SpatiusParams = field(default_factory=dict)
@@ -97,6 +107,9 @@ class SpatiusConfig(BaseConfig):
                 self.params["session_expire_minutes"]
             )
 
+        if "audio_format" in self.params:
+            self.audio_format = self.params["audio_format"]
+
     def validate_params(self) -> None:
         """Validate required configuration parameters."""
         required_fields = {
@@ -128,6 +141,28 @@ class SpatiusConfig(BaseConfig):
 
         if self.sample_rate <= 0:
             raise ValueError("sample_rate must be greater than 0")
+
+        try:
+            self.audio_format = AudioFormat(self.audio_format).value
+        except ValueError as exc:
+            allowed = ", ".join(
+                audio_format.value for audio_format in AudioFormat
+            )
+            raise ValueError(
+                f"params.audio_format must be one of: {allowed}"
+            ) from exc
+
+        if (
+            self.audio_format == AudioFormat.OGG_OPUS.value
+            and self.sample_rate not in SUPPORTED_OPUS_SAMPLE_RATES
+        ):
+            supported_rates = ", ".join(
+                str(rate) for rate in sorted(SUPPORTED_OPUS_SAMPLE_RATES)
+            )
+            raise ValueError(
+                "Ogg Opus encoding supports sample rates: "
+                f"{supported_rates} Hz; got {self.sample_rate} Hz"
+            )
 
         if self.session_expire_minutes <= 0:
             raise ValueError("session_expire_minutes must be greater than 0")
@@ -215,6 +250,7 @@ class SpatiusAvatarExtension(AsyncAvatarBaseExtension):
                 f"agora_appcert={self._masked_agora_appcert()}, "
                 f"agora_channel={self.config.agora_channel}, "
                 f"sample_rate={self.config.sample_rate}, "
+                f"audio_format={self.config.audio_format}, "
                 "session_expire_minutes="
                 f"{self.config.session_expire_minutes}"
             )
@@ -275,6 +311,8 @@ class SpatiusAvatarExtension(AsyncAvatarBaseExtension):
             "expire_at": datetime.now(timezone.utc)
             + timedelta(minutes=self.config.session_expire_minutes),
             "sample_rate": self.config.sample_rate,
+            "audio_format": AudioFormat(self.config.audio_format),
+            "ogg_opus_encoder": self._ogg_opus_encoder_config(),
             "agora_egress": agora_egress,
             "transport_frames": self._on_frame_received,
             "on_error": self._on_error,
@@ -294,6 +332,12 @@ class SpatiusAvatarExtension(AsyncAvatarBaseExtension):
         ten_env.log_info(
             f"[Spatius] Connected successfully (connection_id={connection_id})"
         )
+
+    def _ogg_opus_encoder_config(self) -> OggOpusEncoderConfig | None:
+        """Return encoder config when Opus audio is enabled."""
+        if self.config.audio_format != AudioFormat.OGG_OPUS.value:
+            return None
+        return OggOpusEncoderConfig()
 
     async def disconnect_from_avatar(self, ten_env: AsyncTenEnv) -> None:
         """Disconnect from Spatius avatar service."""

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
@@ -86,6 +86,9 @@
             },
             "session_expire_minutes": {
               "type": "int32"
+            },
+            "audio_format": {
+              "type": "string"
             }
           }
         }

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "spatius_avatar_python",
-  "version": "0.1.5",
+  "version": "0.2.1",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "spatius_avatar_python",
-  "version": "0.2.0",
+  "version": "0.1.5",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/property.json
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/property.json
@@ -18,6 +18,7 @@
         "agora_channel": "",
         "region": "",
         "sample_rate": 24000,
-        "session_expire_minutes": 30
+        "session_expire_minutes": 30,
+        "audio_format": "ogg_opus"
     }
 }

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
@@ -5,5 +5,5 @@ requires-python = ">=3.10"
 dependencies = [
     "agora-token-builder>=1.0.0",
     "protobuf>=5.28.3,<6",
-    "spatius==1.0.2",
+    "spatius[opus]==1.0.2",
 ]

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
@@ -5,5 +5,5 @@ requires-python = ">=3.10"
 dependencies = [
     "agora-token-builder>=1.0.0",
     "protobuf>=5.28.3,<6",
-    "spatius[opus]==1.0.2",
+    "spatius[opus]==1.0.3",
 ]

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spatius-avatar-python"
-version = "0.1.4"
+version = "0.1.5"
 requires-python = ">=3.10"
 dependencies = [
     "agora-token-builder>=1.0.0",

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spatius-avatar-python"
-version = "0.1.5"
+version = "0.2.1"
 requires-python = ">=3.10"
 dependencies = [
     "agora-token-builder>=1.0.0",

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/requirements.txt
@@ -1,4 +1,4 @@
 pytest==8.3.4
 agora-token-builder>=1.0.0
-spatius==1.0.2
+spatius[opus]==1.0.2
 protobuf>=5.28.3,<6

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/requirements.txt
@@ -1,4 +1,4 @@
 pytest==8.3.4
 agora-token-builder>=1.0.0
-spatius[opus]==1.0.2
+spatius[opus]==1.0.3
 protobuf>=5.28.3,<6


### PR DESCRIPTION
## Summary
- default the TEN Spatius avatar extension to Ogg Opus audio
- add params.audio_format so users can opt back to pcm_s16le
- wire Spatius SDK AudioFormat and OggOpusEncoderConfig through session creation
- depend on spatius[opus]

## Validation
- python3 -m compileall extension.py
- parsed manifest.json and property.json with python3 json loader