### PR TITLE
feat(aliyun_asr): support dashscope 1.26.0+

### DIFF
--- a/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/extension.py
@@ -77,7 +77,10 @@ class AliyunRecognitionCallback(RecognitionCallback):
 
     def on_event(self, result: RecognitionResult) -> None:
         """Recognition result event callback"""
-        self.ten_env.log_info(f"Aliyun ASR result event: {result}")
+        # Avoid str(result): dashscope >=1.26.0 __str__ expects API response headers.
+        self.ten_env.log_info(
+            f"Aliyun ASR result event: {result.get_sentence()}"
+        )
         asyncio.run_coroutine_threadsafe(
             self.extension.on_asr_event(result), self.loop
         )
@@ -286,12 +289,11 @@ class AliyunASRBigmodelExtension(AsyncASRBaseExtension):
     async def on_asr_event(self, result: RecognitionResult) -> None:
         """Handle recognition result event callback"""
         try:
+            sentence = result.get_sentence()
             self.ten_env.log_debug(
-                f"vendor_result: on_event: {result}",
+                f"vendor_result: on_event: {sentence}",
                 category=LOG_CATEGORY_VENDOR,
             )
-
-            sentence = result.get_sentence()
             if (
                 isinstance(sentence, dict)
                 and "text" in sentence

--- a/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "aliyun_asr_bigmodel_python",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/pyproject.toml
@@ -3,6 +3,6 @@ name = "aliyun-asr-bigmodel-python"
 version = "0.2.6"
 requires-python = ">=3.10"
 dependencies = [
-    "dashscope==1.24.1",
+    "dashscope>=1.26.0",
     "pydantic>=2.13.4",
 ]

--- a/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/requirements.txt
@@ -1,2 +1,2 @@
-dashscope==1.24.1
+dashscope>=1.26.0
 pydantic

--- a/ai_agents/agents/ten_packages/extension/xai_asr_python/tests/test_params.py
+++ b/ai_agents/agents/ten_packages/extension/xai_asr_python/tests/test_params.py
@@ -51,7 +51,7 @@ def test_language_normalization():
 def test_start_connection_missing_api_key_emits_fatal_error():
     async def _run():
         extension = XAIASRExtension("xai_asr_python")
-        extension.ten_env = MagicMock()
+        extension.ten_env = AsyncMock()
         extension.config = XAIASRConfig(params={"api_key": ""})
         extension.send_asr_error = AsyncMock()
 


### PR DESCRIPTION
Avoid logging `RecognitionResult` directly because newer dashscope versions expect response headers in `__str__`.

Log the sentence payload instead and bump the extension version to 0.2.7.