### PR TITLE
feat: allow newer websockets versions across Python extensions

### DIFF
--- a/ai_agents/agents/ten_packages/extension/assemblyai_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/assemblyai_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "assemblyai_asr_python",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/assemblyai_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/assemblyai_asr_python/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "assemblyai-asr-python"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.13.4",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/assemblyai_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/assemblyai_asr_python/requirements.txt
@@ -1,2 +1,2 @@
-websockets~=14.0
+websockets>=14.0
 pydantic

--- a/ai_agents/agents/ten_packages/extension/azure_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/azure_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "azure_asr_python",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/azure_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/azure_asr_python/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "azure-asr-python"
-version = "0.2.12"
+version = "0.2.13"
 requires-python = ">=3.10"
 dependencies = [
     "aiofiles>=25.1.0",
     "azure-cognitiveservices-speech==1.45.0",
     "pydantic>=2.13.4",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/azure_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/azure_asr_python/requirements.txt
@@ -1,4 +1,4 @@
 azure-cognitiveservices-speech==1.45.0
-websockets~=14.0
+websockets>=14.0
 pydantic
 aiofiles

--- a/ai_agents/agents/ten_packages/extension/bytedance_asr/bytedance_asr.py
+++ b/ai_agents/agents/ten_packages/extension/bytedance_asr/bytedance_asr.py
@@ -6,7 +6,7 @@ Bytedance ASR WebSocket Client
 Requires Python 3.9 or later for modern typing features.
 
 Dependencies:
-    websockets~=14.0
+    websockets>=14.0
     pydantic
 """
 

--- a/ai_agents/agents/ten_packages/extension/bytedance_asr/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/bytedance_asr/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "bytedance_asr",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/bytedance_asr/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/bytedance_asr/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "bytedance-asr"
-version = "0.2.5"
+version = "0.2.6"
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.13.4",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/bytedance_asr/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/bytedance_asr/requirements.txt
@@ -1,2 +1,2 @@
-websockets~=14.0
+websockets>=14.0
 pydantic

--- a/ai_agents/agents/ten_packages/extension/bytedance_llm_based_asr/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/bytedance_llm_based_asr/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "bytedance_llm_based_asr",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/bytedance_llm_based_asr/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/bytedance_llm_based_asr/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "bytedance-llm-based-asr"
-version = "0.4.4"
+version = "0.4.5"
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.13.4",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/bytedance_llm_based_asr/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/bytedance_llm_based_asr/requirements.txt
@@ -1,2 +1,2 @@
-websockets~=14.0
+websockets>=14.0
 pydantic

--- a/ai_agents/agents/ten_packages/extension/bytedance_tts_duplex/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/bytedance_tts_duplex/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "bytedance_tts_duplex",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/bytedance_tts_duplex/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/bytedance_tts_duplex/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "bytedance-tts-duplex"
-version = "0.4.1"
+version = "0.4.2"
 requires-python = ">=3.10"
 dependencies = [
     "fastrand>=3.1.0",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/bytedance_tts_duplex/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/bytedance_tts_duplex/requirements.txt
@@ -1,2 +1,2 @@
-websockets~=14.0
+websockets>=14.0
 fastrand

--- a/ai_agents/agents/ten_packages/extension/elevenlabs_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/elevenlabs_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "elevenlabs_asr_python",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/elevenlabs_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/elevenlabs_asr_python/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "elevenlabs-asr-python"
-version = "0.2.2"
+version = "0.2.3"
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.13.4",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/elevenlabs_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/elevenlabs_asr_python/requirements.txt
@@ -1,2 +1,2 @@
-websockets~=14.0
+websockets>=14.0
 pydantic

--- a/ai_agents/agents/ten_packages/extension/ezai_asr/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/ezai_asr/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "ezai_asr",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/ezai_asr/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/ezai_asr/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ezai-asr"
-version = "0.1.2"
+version = "0.1.3"
 requires-python = ">=3.10"
 dependencies = [
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/ezai_asr/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/ezai_asr/requirements.txt
@@ -1,2 +1,2 @@
 pytest==8.3.4
-websockets~=14.0
+websockets>=14.0

--- a/ai_agents/agents/ten_packages/extension/fashionai/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/fashionai/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "fashionai",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/fashionai/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/fashionai/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fashionai"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/fashionai/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/fashionai/requirements.txt
@@ -1,1 +1,1 @@
-websockets~=14.0
+websockets>=14.0

--- a/ai_agents/agents/ten_packages/extension/gladia_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/gladia_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "gladia_asr_python",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/gladia_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/gladia_asr_python/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "gladia-asr-python"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
     "deepgram-sdk==3.9.0",
     "pydantic>=2.13.4",
     "requests>=2.34.2",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/gladia_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/gladia_asr_python/requirements.txt
@@ -1,4 +1,4 @@
 deepgram-sdk==3.9.0
-websockets~=14.0
+websockets>=14.0
 pydantic
 requests

--- a/ai_agents/agents/ten_packages/extension/gradium_tts_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/gradium_tts_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "gradium_tts_python",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/gradium_tts_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/gradium_tts_python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gradium-tts-python"
-version = "0.1.2"
+version = "0.1.3"
 requires-python = ">=3.10"
 dependencies = [
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/gradium_tts_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/gradium_tts_python/requirements.txt
@@ -1,1 +1,1 @@
-websockets~=14.0
+websockets>=14.0

--- a/ai_agents/agents/ten_packages/extension/minimax_tts_websocket_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/minimax_tts_websocket_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "minimax_tts_websocket_python",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "display_name": {
     "locales": {
       "en-US": {

--- a/ai_agents/agents/ten_packages/extension/minimax_tts_websocket_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/minimax_tts_websocket_python/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "minimax-tts-websocket-python"
-version = "0.4.1"
+version = "0.4.2"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",
     "pydantic>=2.13.4",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/minimax_tts_websocket_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/minimax_tts_websocket_python/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp
 pydantic
-websockets~=14.0
+websockets>=14.0

--- a/ai_agents/agents/ten_packages/extension/murf_tts_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/murf_tts_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "murf_tts_python",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/murf_tts_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/murf_tts_python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "murf-tts-python"
-version = "0.1.2"
+version = "0.1.3"
 requires-python = ">=3.10"
 dependencies = [
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/murf_tts_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/murf_tts_python/requirements.txt
@@ -1,1 +1,1 @@
-websockets~=14.0
+websockets>=14.0

--- a/ai_agents/agents/ten_packages/extension/neuphonic_tts/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/neuphonic_tts/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "neuphonic_tts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/neuphonic_tts/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/neuphonic_tts/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "neuphonic-tts"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
     "pyneuphonic~=1.8.0",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/neuphonic_tts/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/neuphonic_tts/requirements.txt
@@ -1,2 +1,2 @@
 pyneuphonic~=1.8.0
-websockets~=14.0
+websockets>=14.0

--- a/ai_agents/agents/ten_packages/extension/rime_tts/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/rime_tts/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "rime_tts",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/rime_tts/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/rime_tts/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rime-tts"
-version = "0.4.6"
+version = "0.4.7"
 requires-python = ">=3.10"
 dependencies = [
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/rime_tts/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/rime_tts/requirements.txt
@@ -1,1 +1,1 @@
-websockets~=14.0
+websockets>=14.0

--- a/ai_agents/agents/ten_packages/extension/sarvam_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/sarvam_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "sarvam_asr_python",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/sarvam_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/sarvam_asr_python/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "sarvam-asr-python"
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",
     "numpy>=2.2.6",
     "pydantic>=2.13.4",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/sarvam_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/sarvam_asr_python/requirements.txt
@@ -1,4 +1,4 @@
 aiohttp
 numpy
 pydantic
-websockets~=14.0
+websockets>=14.0

--- a/ai_agents/agents/ten_packages/extension/stepfun_tts_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/stepfun_tts_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "stepfun_tts_python",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/stepfun_tts_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/stepfun_tts_python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "stepfun-tts-python"
-version = "0.4.3"
+version = "0.4.4"
 requires-python = ">=3.10"
 dependencies = [
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/stepfun_tts_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/stepfun_tts_python/requirements.txt
@@ -1,1 +1,1 @@
-websockets~=14.0
+websockets>=14.0

--- a/ai_agents/agents/ten_packages/extension/tencent_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/tencent_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "tencent_asr_python",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "display_name": {
     "locales": {
       "en-US": {

--- a/ai_agents/agents/ten_packages/extension/tencent_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/tencent_asr_python/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "tencent-asr-python"
-version = "0.2.13"
+version = "0.2.14"
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.13.4",
     "typing-extensions>=4.15.0",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/tencent_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/tencent_asr_python/requirements.txt
@@ -1,4 +1,4 @@
 typing_extensions
 pytest==8.3.4
-websockets~=14.0
+websockets>=14.0
 pydantic

--- a/ai_agents/agents/ten_packages/extension/vibevoice_tts_websocket_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/vibevoice_tts_websocket_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "vibevoice_tts_websocket_python",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/vibevoice_tts_websocket_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/vibevoice_tts_websocket_python/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "vibevoice-tts-websocket-python"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.13.4",
-    "websockets~=14.0",
+    "websockets>=14.0",
 ]

--- a/ai_agents/agents/ten_packages/extension/vibevoice_tts_websocket_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/vibevoice_tts_websocket_python/requirements.txt
@@ -1,2 +1,2 @@
 pydantic
-websockets~=14.0
+websockets>=14.0


### PR DESCRIPTION
Replace `websockets~=14.0` with `websockets>=14.0` in the affected extension `pyproject.toml` and `requirements.txt` files so websocket-based ASR and TTS packages can install newer compatible releases.