### PR TITLE
feat: scope numpy deps to extensions that need them

### DIFF
--- a/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/aliyun_asr_bigmodel_python/pyproject.toml
@@ -1,8 +1,5 @@
 [project]
 name = "aliyun-asr-bigmodel-python"
-version = "0.2.6"
+version = "0.2.7"
 requires-python = ">=3.10"
-dependencies = [
-    "dashscope>=1.26.0",
-    "pydantic>=2.13.4",
-]
+dependencies = ["dashscope>=1.26.0", "pydantic>=2.13.4"]

--- a/ai_agents/agents/ten_packages/extension/azure_mllm_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/azure_mllm_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "azure_mllm_python",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/azure_mllm_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/azure_mllm_python/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "azure-mllm-python"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",
-    "numpy==1.26.4",
     "pydantic>=2.13.4",
     "pydub==0.25.1",
 ]

--- a/ai_agents/agents/ten_packages/extension/azure_mllm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/azure_mllm_python/requirements.txt
@@ -1,4 +1,3 @@
 pydantic
-numpy==1.26.4
 pydub==0.25.1
 aiohttp

--- a/ai_agents/agents/ten_packages/extension/bedrock_llm_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/bedrock_llm_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "bedrock_llm_python",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/bedrock_llm_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/bedrock_llm_python/pyproject.toml
@@ -1,9 +1,8 @@
 [project]
 name = "bedrock-llm-python"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
     "boto3>=1.43.37",
-    "numpy>=2.2.6",
     "python-dotenv>=1.2.2",
 ]

--- a/ai_agents/agents/ten_packages/extension/bedrock_llm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/bedrock_llm_python/requirements.txt
@@ -1,3 +1,2 @@
 boto3
-numpy
 python-dotenv

--- a/ai_agents/agents/ten_packages/extension/generic_video_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/generic_video_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "generic_video_python",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/generic_video_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/generic_video_python/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "generic-video-python"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.10"
 dependencies = [
     "agora-token-builder>=1.0.0",
-    "numpy>=2.2.6",
     "requests>=2.32.3",
     "scipy>=1.15.3",
     "websockets>=15.0.1",

--- a/ai_agents/agents/ten_packages/extension/generic_video_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/generic_video_python/requirements.txt
@@ -2,4 +2,3 @@ agora-token-builder>=1.0.0
 requests>=2.32.3
 websockets>=15.0.1
 scipy
-numpy

--- a/ai_agents/agents/ten_packages/extension/glm_mllm_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/glm_mllm_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "glm_mllm_python",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/glm_mllm_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/glm_mllm_python/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "glm-mllm-python"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",
-    "numpy==1.26.4",
     "pydantic>=2.13.4",
     "pydub==0.25.1",
 ]

--- a/ai_agents/agents/ten_packages/extension/glm_mllm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/glm_mllm_python/requirements.txt
@@ -1,4 +1,3 @@
 pydantic
-numpy==1.26.4
 pydub==0.25.1
 aiohttp

--- a/ai_agents/agents/ten_packages/extension/grok_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/grok_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "grok_python",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/grok_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/grok_python/pyproject.toml
@@ -1,9 +1,8 @@
 [project]
 name = "grok-python"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=2.2.6",
     "openai>=2.44.0",
     "pillow>=12.2.0",
     "requests[socks]>=2.34.2",

--- a/ai_agents/agents/ten_packages/extension/grok_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/grok_python/requirements.txt
@@ -1,4 +1,3 @@
 openai
-numpy
 requests[socks]
 pillow

--- a/ai_agents/agents/ten_packages/extension/openai_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/openai_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "openai_asr_python",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "display_name": {
     "locales": {
       "en-US": {

--- a/ai_agents/agents/ten_packages/extension/openai_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/openai_asr_python/pyproject.toml
@@ -1,8 +1,9 @@
 [project]
 name = "openai-asr-python"
-version = "0.3.2"
+version = "0.3.3"
 requires-python = ">=3.10"
 dependencies = [
+    "numpy>=1.24.0",
     "openai>=1.99.3",
     "pydantic>=2.13.4",
     "samplerate==0.1.0",

--- a/ai_agents/agents/ten_packages/extension/openai_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/openai_asr_python/requirements.txt
@@ -2,6 +2,7 @@ typing_extensions
 pytest
 websockets>=14.0
 openai>=1.99.3
+numpy>=1.24.0
 pydantic
 # the latest version need cmake and C++ 14 or above compiler
 samplerate==0.1.0

--- a/ai_agents/agents/ten_packages/extension/openai_llm2_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/openai_llm2_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "openai_llm2_python",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/openai_llm2_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/openai_llm2_python/pyproject.toml
@@ -1,9 +1,8 @@
 [project]
 name = "openai-llm2-python"
-version = "0.2.2"
+version = "0.2.3"
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=2.2.6",
     "openai>=2.44.0",
     "pillow>=12.2.0",
     "requests[socks]>=2.34.2",

--- a/ai_agents/agents/ten_packages/extension/openai_llm2_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/openai_llm2_python/requirements.txt
@@ -1,4 +1,3 @@
 openai
-numpy
 requests[socks]
 pillow

--- a/ai_agents/agents/ten_packages/extension/openai_mllm_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/openai_mllm_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "openai_mllm_python",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/openai_mllm_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/openai_mllm_python/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "openai-mllm-python"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",
-    "numpy==1.26.4",
     "pydantic>=2.13.4",
     "pydub==0.25.1",
 ]

--- a/ai_agents/agents/ten_packages/extension/openai_mllm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/openai_mllm_python/requirements.txt
@@ -1,4 +1,3 @@
 pydantic
-numpy==1.26.4
 pydub==0.25.1
 aiohttp

--- a/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "stepfun_mllm_python",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "stepfun-mllm-python"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",
-    "numpy==1.26.4",
     "pydantic>=2.13.4",
     "pydub==0.25.1",
 ]

--- a/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/requirements.txt
@@ -1,4 +1,3 @@
 pydantic
-numpy==1.26.4
 pydub==0.25.1
 aiohttp

--- a/ai_agents/agents/ten_packages/extension/ten_vad_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/ten_vad_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "ten_vad_python",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/ten_vad_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/ten_vad_python/pyproject.toml
@@ -1,8 +1,9 @@
 [project]
 name = "ten-vad-python"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
+    "numpy>=1.24.0",
     "ten-vad",
 ]
 

--- a/ai_agents/agents/ten_packages/extension/ten_vad_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/ten_vad_python/requirements.txt
@@ -1,1 +1,2 @@
+numpy>=1.24.0
 git+https://github.com/TEN-framework/ten-vad.git


### PR DESCRIPTION
Remove numpy from Python extension packages that do not import it and add explicit numpy requirements to `openai_asr_python` and `ten_vad_python`, where it is actually needed.