### PR TITLE
fix: vs version, rust toolchain, msg test and so on

### DIFF
--- a/.github/workflows/from_scratch.yml
+++ b/.github/workflows/from_scratch.yml
@@ -382,18 +382,43 @@ jobs:
           cd "$WORK_DIR/transcriber_demo"
 
           # Install TEN package dependencies using tman
-          tman install
+          if ! tman install; then
+            if [[ "${{ runner.os }}" != "Windows" ]]; then
+              echo "❌ ERROR: tman install failed"
+              exit 1
+            fi
+
+            # A partially published latest release may not contain Windows
+            # artifacts. Fall back to the version shipped with tman, which is
+            # published as a complete, matching package set.
+            TMAN_VERSION="$(
+              tman --version 2>&1 |
+                sed -n 's/^TEN Framework version: //p' |
+                head -n 1 |
+                tr -d '\r'
+            )"
+
+            if [ -z "$TMAN_VERSION" ]; then
+              echo "❌ ERROR: failed to determine the installed tman version"
+              exit 1
+            fi
+
+            echo "⚠ Latest package set is unavailable for Windows"
+            echo "Falling back to transcriber_demo version $TMAN_VERSION"
+
+            cd "$WORK_DIR"
+            mv transcriber_demo transcriber_demo_latest
+            tman install app "transcriber_demo@=$TMAN_VERSION"
+
+            cd "$WORK_DIR/transcriber_demo"
+            tman install
+          fi
 
           if [[ "${{ runner.os }}" != "Windows" ]]; then
             tree -I .
           fi
 
-          if [ $? -eq 0 ]; then
-            echo "✓ tman install completed successfully"
-          else
-            echo "❌ ERROR: tman install failed"
-            exit 1
-          fi
+          echo "✓ tman install completed successfully"
 
       - name: Verify ten_runtime_python package from cloud
         shell: bash

--- a/.github/workflows/from_scratch.yml
+++ b/.github/workflows/from_scratch.yml
@@ -54,9 +54,25 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup MSVC
+      - name: Locate Visual Studio 2026
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstallDir = & $vswhere `
+            -latest `
+            -products "*" `
+            -version "[18.0,19.0)" `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath |
+              Select-Object -First 1
+
+          if ([string]::IsNullOrWhiteSpace($vsInstallDir)) {
+            throw "Visual Studio 2026 with C++ tools was not found"
+          }
+
+          "VSINSTALLDIR=$($vsInstallDir.Trim())" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # This step is not necessary for the build, but it is useful for debugging.
       - name: Install tools and dependencies (macOS)

--- a/.github/workflows/from_scratch.yml
+++ b/.github/workflows/from_scratch.yml
@@ -54,6 +54,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       # This step is not necessary for the build, but it is useful for debugging.
       - name: Install tools and dependencies (macOS)
         if: runner.os == 'macOS'
@@ -416,6 +420,9 @@ jobs:
 
           if [[ "${{ runner.os }}" != "Windows" ]]; then
             tree -I .
+          else
+            # TODO: Remove this workaround after the cloud package uses VS 2026.
+            sed -i 's/vs_version=2022/vs_version=2026/g' scripts/build.py
           fi
 
           echo "✓ tman install completed successfully"
@@ -883,13 +890,12 @@ jobs:
             PYTHON_PATH=$(cygpath -u "${pythonLocation}" 2>/dev/null || echo "${pythonLocation}" | sed 's|\\|/|g' | sed 's|^\([A-Za-z]\):|/\L\1|')
             export PATH="${PYTHON_PATH}:${PYTHON_PATH}/Scripts:$PATH"
 
-            # windows-2025 runner has VS 2022, not VS 2019
-            # Patch the downloaded run_script.py to pass vs_version=2022 to tgn
+            # Patch the downloaded run_script.py to pass vs_version=2026 to tgn
             #
             # TODO: Remove this sed workaround once the cloud template
             # includes TEN_EXTRA_GN_ARGS support. After that, replace this
-            # sed line with: export TEN_EXTRA_GN_ARGS="vs_version=2022"
-            sed -i 's/ten_enable_standalone_test=true/ten_enable_standalone_test=true vs_version=2022/' "$WORK_DIR/test_ext_cpp/tools/run_script.py"
+            # sed line with: export TEN_EXTRA_GN_ARGS="vs_version=2026"
+            sed -i 's/ten_enable_standalone_test=true/ten_enable_standalone_test=true vs_version=2026/' "$WORK_DIR/test_ext_cpp/tools/run_script.py"
           else
             WORK_DIR="/tmp"
             TEST_BIN="bin/test_ext_cpp_test"

--- a/.github/workflows/from_scratch.yml
+++ b/.github/workflows/from_scratch.yml
@@ -54,26 +54,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Locate Visual Studio 2026
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsInstallDir = & $vswhere `
-            -latest `
-            -products "*" `
-            -version "[18.0,19.0)" `
-            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-            -property installationPath |
-              Select-Object -First 1
-
-          if ([string]::IsNullOrWhiteSpace($vsInstallDir)) {
-            throw "Visual Studio 2026 with C++ tools was not found"
-          }
-
-          "VSINSTALLDIR=$($vsInstallDir.Trim())" |
-            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
       # This step is not necessary for the build, but it is useful for debugging.
       - name: Install tools and dependencies (macOS)
         if: runner.os == 'macOS'
@@ -267,6 +247,10 @@ jobs:
           echo "================================================"
           echo "Installing tgn build system for C++ extensions"
           echo "================================================"
+
+          TGN_VERSION="$(git rev-parse HEAD:core/ten_gn)"
+          export TGN_VERSION
+          echo "Using tgn revision: $TGN_VERSION"
 
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             # On Windows, install to a temporary directory

--- a/.github/workflows/from_scratch.yml
+++ b/.github/workflows/from_scratch.yml
@@ -194,17 +194,15 @@ jobs:
             echo "Installing tman via winget..."
             winget install TEN-framework.tman --disable-interactivity --accept-source-agreements --accept-package-agreements
 
-            # winget modifies the system/user PATH, but GitHub Actions steps
-            # inherit the PATH snapshot from job start. Re-read the current
-            # Machine+User PATH and add any new entries to GITHUB_PATH so
-            # subsequent steps can find tman.
-            NEW_PATH=$(powershell.exe -NoProfile -Command \
-              "[System.Environment]::GetEnvironmentVariable('PATH','Machine') + ';' + [System.Environment]::GetEnvironmentVariable('PATH','User')")
-            echo "$NEW_PATH" | tr ';' '\n' | while IFS= read -r p; do
-              if [ -n "$p" ] && ! echo "$PATH" | tr ':' '\n' | grep -qxF "$p"; then
-                echo "$p" >> $GITHUB_PATH
-              fi
-            done
+            # Add only winget's link directory. Re-importing the complete
+            # Machine+User PATH can move the WindowsApps WSL shim ahead of
+            # Git Bash in later steps.
+            TMAN_DIR="$(
+              powershell.exe -NoProfile -Command \
+                "[System.IO.Path]::Combine([System.Environment]::GetFolderPath('LocalApplicationData'), 'Microsoft', 'WinGet', 'Links')" |
+                tr -d '\r'
+            )"
+            echo "$TMAN_DIR" >> "$GITHUB_PATH"
           else
             echo "❌ ERROR: Unsupported OS: ${{ runner.os }}"
             exit 1

--- a/.github/workflows/from_scratch.yml
+++ b/.github/workflows/from_scratch.yml
@@ -230,6 +230,23 @@ jobs:
           echo "  Version: $(tman --version 2>&1 || tman -v 2>&1)"
           echo "  Location: $(which tman)"
 
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            TMAN_VERSION="$(
+              tman --version 2>&1 |
+                sed -n 's/^TEN Framework version: //p' |
+                head -n 1 |
+                tr -d '\r'
+            )"
+
+            if [ -z "$TMAN_VERSION" ]; then
+              echo "ERROR: failed to determine the installed tman version"
+              exit 1
+            fi
+
+            echo "TMAN_VERSION=$TMAN_VERSION" >> "$GITHUB_ENV"
+            echo "TMAN_TEMPLATE_SUFFIX=@=$TMAN_VERSION" >> "$GITHUB_ENV"
+          fi
+
           # Display Python version being used
           echo ""
           echo "Python configuration:"
@@ -395,18 +412,6 @@ jobs:
             # A partially published latest release may not contain Windows
             # artifacts. Fall back to the version shipped with tman, which is
             # published as a complete, matching package set.
-            TMAN_VERSION="$(
-              tman --version 2>&1 |
-                sed -n 's/^TEN Framework version: //p' |
-                head -n 1 |
-                tr -d '\r'
-            )"
-
-            if [ -z "$TMAN_VERSION" ]; then
-              echo "❌ ERROR: failed to determine the installed tman version"
-              exit 1
-            fi
-
             echo "⚠ Latest package set is unavailable for Windows"
             echo "Falling back to transcriber_demo version $TMAN_VERSION"
 
@@ -838,7 +843,7 @@ jobs:
           cd "$WORK_DIR"
 
           # Create a C++ extension using the default template
-          tman create extension test_ext_cpp --template default_extension_cpp
+          tman create extension test_ext_cpp --template "default_extension_cpp${TMAN_TEMPLATE_SUFFIX}"
 
           if [ ! -d "test_ext_cpp" ]; then
             echo "❌ ERROR: test_ext_cpp extension was not created"
@@ -977,7 +982,7 @@ jobs:
           cd "$WORK_DIR"
 
           # Create a Go extension using the default template
-          tman create extension test_ext_go --template default_extension_go --template-data class_name_prefix=Test
+          tman create extension test_ext_go --template "default_extension_go${TMAN_TEMPLATE_SUFFIX}" --template-data class_name_prefix=Test
 
           if [ ! -d "test_ext_go" ]; then
             echo "❌ ERROR: test_ext_go extension was not created"
@@ -1064,7 +1069,7 @@ jobs:
           cd "$WORK_DIR"
 
           # Create a Python extension using the default async template
-          tman create extension test_ext_python --template default_async_extension_python --template-data class_name_prefix=Test
+          tman create extension test_ext_python --template "default_async_extension_python${TMAN_TEMPLATE_SUFFIX}" --template-data class_name_prefix=Test
 
           if [ ! -d "test_ext_python" ]; then
             echo "❌ ERROR: test_ext_python extension was not created"
@@ -1186,7 +1191,7 @@ jobs:
           cd "$WORK_DIR"
 
           # Create a Node.js extension using the default template
-          tman create extension test_ext_nodejs --template default_extension_nodejs --template-data class_name_prefix=Test
+          tman create extension test_ext_nodejs --template "default_extension_nodejs${TMAN_TEMPLATE_SUFFIX}" --template-data class_name_prefix=Test
 
           if [ ! -d "test_ext_nodejs" ]; then
             echo "❌ ERROR: test_ext_nodejs extension was not created"

--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     needs: call-check-pr-status
     if: ${{ needs.call-check-pr-status.outputs.should_continue == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         compiler: [gcc, clang]

--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -189,6 +189,11 @@ jobs:
 
             rustc --version
             cargo --version
+
+            # Linking the Rust/ASan ten_manager test artifacts in parallel can
+            # exhaust the GitHub runner disk. Keep Cargo sequential while GN
+            # still serializes the outer build actions.
+            export CARGO_BUILD_JOBS=1
           fi
 
           df -h .

--- a/.github/workflows/linux_ubuntu2204.yml
+++ b/.github/workflows/linux_ubuntu2204.yml
@@ -55,6 +55,24 @@ jobs:
           echo "ref_name=${{ github.ref_name }}"
           echo "ref_type=${{ github.ref_type }}"
 
+      # Jobs have observed two root filesystem sizes: 72G and about 145G. The 72G root filesystem can run out of
+      # space during the build. A somewhat hacky workaround is to move build output to a separate /mnt disk, but
+      # inspect the disk logs first to confirm the runner layout and whether /mnt is visible inside the container.
+      # Ref: https://agents.stackoverflow.com/tils/f9501577-9ffb-4a4e-b7cc-b9202620c338?tag=ci-cd&sort=newest&page=1
+      # "The GitHub Actions documentation guarantees only 14 GB of free disk for private repositories and doesn't
+      # document the dual-disk configuration."
+      - name: Inspect runner disk layout
+        run: |
+          echo "=== Filesystem usage ==="
+          df -h
+
+          echo "=== Block devices ==="
+          if command -v lsblk >/dev/null 2>&1; then
+            lsblk -o NAME,SIZE,FSTYPE,MOUNTPOINTS
+          else
+            echo "lsblk is not available"
+          fi
+
       - name: Check PR status before matrix execution
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/mac_arm64.yml
+++ b/.github/workflows/mac_arm64.yml
@@ -32,6 +32,9 @@ jobs:
     needs: call-check-pr-status
     if: ${{ needs.call-check-pr-status.outputs.should_continue == 'true' }}
     runs-on: macos-latest
+    # Override crate-local nightly toolchains for reproducible macOS builds.
+    env:
+      RUSTUP_TOOLCHAIN: stable
     strategy:
       matrix:
         build_type: [debug, release]

--- a/.github/workflows/mac_x64.yml
+++ b/.github/workflows/mac_x64.yml
@@ -32,6 +32,9 @@ jobs:
     needs: call-check-pr-status
     if: ${{ needs.call-check-pr-status.outputs.should_continue == 'true' }}
     runs-on: macos-15-intel
+    # Override crate-local nightly toolchains for reproducible macOS builds.
+    env:
+      RUSTUP_TOOLCHAIN: stable
     strategy:
       matrix:
         build_type: [debug, release]

--- a/.github/workflows/tman_full_mac_arm64.yml
+++ b/.github/workflows/tman_full_mac_arm64.yml
@@ -26,6 +26,9 @@ jobs:
     needs: call-check-pr-status
     if: ${{ needs.call-check-pr-status.outputs.should_continue == 'true' }}
     runs-on: macos-latest
+    # Override crate-local nightly toolchains for reproducible macOS builds.
+    env:
+      RUSTUP_TOOLCHAIN: stable
     strategy:
       matrix:
         build_type: [release]

--- a/.github/workflows/tman_full_mac_x64.yml
+++ b/.github/workflows/tman_full_mac_x64.yml
@@ -26,6 +26,9 @@ jobs:
     needs: call-check-pr-status
     if: ${{ needs.call-check-pr-status.outputs.should_continue == 'true' }}
     runs-on: macos-15-intel
+    # Override crate-local nightly toolchains for reproducible macOS builds.
+    env:
+      RUSTUP_TOOLCHAIN: stable
     strategy:
       matrix:
         build_type: [release]

--- a/.github/workflows/tman_full_mac_x64.yml
+++ b/.github/workflows/tman_full_mac_x64.yml
@@ -185,11 +185,28 @@ jobs:
         env:
           PLAYWRIGHT_RUNTIME: "macos"
         run: |
+          log_port_usage() {
+            local port="$1"
+            echo "TCP socket usage for local port ${port}:"
+            lsof -nP -iTCP:"${port}" || true
+            netstat -anv -p tcp | grep -E "[.:]${port}[[:space:]]" || true
+          }
+
+          # Port 49483 may already be in use on the runner. Log its usage, then
+          # ask macOS for a currently unused port for this CI run.
+          log_port_usage 49483
+          TMAN_PORT=$(python3 -c \
+            'import socket; s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1])')
+          TMAN_URL="http://127.0.0.1:${TMAN_PORT}"
+          echo "Selected local port ${TMAN_PORT} for tman designer"
+          log_port_usage "${TMAN_PORT}"
+
           # Start the tman designer backend
           cd ${GITHUB_WORKSPACE}/out/mac/x64/ten_manager/bin
-          ./tman --verbose designer &
+          ./tman --verbose designer --ip 127.0.0.1 --port "${TMAN_PORT}" &
           TMAN_PID=$!
-          echo "Started tman designer with PID $TMAN_PID"
+          trap 'kill "${TMAN_PID}" 2>/dev/null || true' EXIT
+          echo "Started tman designer with PID ${TMAN_PID} at ${TMAN_URL}"
 
           # Start the frontend preview server
           cd ${GITHUB_WORKSPACE}/core/src/ten_manager/designer_frontend
@@ -199,36 +216,38 @@ jobs:
 
           # Wait for the server to be available (max 30 seconds)
           echo "Waiting for server to be available..."
-          timeout=30
-          while [ $timeout -gt 0 ]; do
-            if curl -s http://127.0.0.1:49483/ > /dev/null; then
+          server_ready=false
+          for attempt in {1..30}; do
+            if ! kill -0 "${TMAN_PID}" 2>/dev/null; then
+              echo "tman designer exited before becoming ready"
+              log_port_usage "${TMAN_PORT}"
+              wait "${TMAN_PID}" || true
+              exit 1
+            fi
+
+            if curl --fail --silent "${TMAN_URL}/" > /dev/null; then
               echo "Server is up and running!"
+              server_ready=true
               break
             fi
-            echo "Server not ready yet, waiting... ($timeout seconds left)"
+
+            echo "Server not ready yet, waiting... (${attempt}/30)"
             sleep 1
-            timeout=$((timeout-1))
           done
 
-          if [ $timeout -eq 0 ]; then
+          if [ "${server_ready}" != true ]; then
             echo "Timed out waiting for server to start"
             echo "Checking if tman designer is running:"
-            ps -p $TMAN_PID || true
+            ps -p "${TMAN_PID}" || true
             # echo "Checking if preview server is running:"
             # ps -p $PREVIEW_PID || true
             exit 1
           fi
 
+          log_port_usage "${TMAN_PORT}"
+
           # Run the tests
-          npx playwright test
-          TEST_EXIT_CODE=$?
-
-          # Cleanup background processes
-          kill $TMAN_PID || true
-          # kill $PREVIEW_PID || true
-
-          # Return the test exit code
-          exit $TEST_EXIT_CODE
+          PLAYWRIGHT_BASE_URL="${TMAN_URL}" npx playwright test
 
       - name: Upload tests relevant artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tman_full_win_x64.yml
+++ b/.github/workflows/tman_full_win_x64.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Build
         run: |
           $ENV:PATH += ";$PWD/core/ten_gn"
-          tgn gen win x64 ${{ matrix.build_type }} -- vs_version=2022 log_level=1 enable_serialized_actions=true  ten_rust_enable_gen_cargo_config=false ten_enable_cargo_clean=true ten_enable_python_binding=false ten_enable_go_binding=false ten_enable_nodejs_binding=false ten_enable_rust_incremental_build=false ten_manager_enable_frontend=true ten_enable_ten_rust=true ten_enable_ten_manager=true
+          tgn gen win x64 ${{ matrix.build_type }} -- vs_version=2026 log_level=1 enable_serialized_actions=true  ten_rust_enable_gen_cargo_config=false ten_enable_cargo_clean=true ten_enable_python_binding=false ten_enable_go_binding=false ten_enable_nodejs_binding=false ten_enable_rust_incremental_build=false ten_manager_enable_frontend=true ten_enable_ten_rust=true ten_enable_ten_manager=true
           tgn build:ten_manager_package win x64 ${{ matrix.build_type }}
 
       - name: Package assets

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -269,7 +269,7 @@ jobs:
           } else {
             $buildArgs += "is_mingw=false" # msvc
             $buildArgs += "is_clang=true" # choose to use clang-cl.exe instead of cl.exe, the latter does not work yet
-            $buildArgs += "vs_version=2022"
+            $buildArgs += "vs_version=2026"
             $buildArgs += "ten_enable_nodejs_binding=true"
           }
           $buildArgs += "log_level=1"

--- a/core/src/ten_manager/designer_frontend/tests/e2e/overview.spec.ts
+++ b/core/src/ten_manager/designer_frontend/tests/e2e/overview.spec.ts
@@ -6,9 +6,9 @@
 //
 import { expect, test } from "@playwright/test";
 
-const BASE_URL = process.env.CI
-  ? "http://127.0.0.1:49483"
-  : "http://127.0.0.1:4173";
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL ??
+  (process.env.CI ? "http://127.0.0.1:49483" : "http://127.0.0.1:4173");
 
 console.log(`Using base URL: ${BASE_URL}`);
 

--- a/packages/core_extensions/default_extension_cpp/tools/run_script.py
+++ b/packages/core_extensions/default_extension_cpp/tools/run_script.py
@@ -74,7 +74,7 @@ def run_cmd_test(os_str: str, _arch: str) -> int:
 
 def run_cmd_build(os: str, arch: str) -> int:
     """Build the application."""
-    # Allow extra GN args via environment variable (e.g. vs_version=2022)
+    # Allow extra GN args via environment variable (e.g. vs_version=2026)
     extra_gn_args = os_module.environ.get("TEN_EXTRA_GN_ARGS", "")
 
     if os == "win":

--- a/packages/example_apps/transcriber_demo/scripts/build.py
+++ b/packages/example_apps/transcriber_demo/scripts/build.py
@@ -546,7 +546,6 @@ def build_cxx_extensions(
                     "--",
                     "is_clang=false",
                     "enable_sanitizer=false",
-                    "vs_version=2022",
                 ]
             )
         elif os_type == "win":
@@ -556,7 +555,7 @@ def build_cxx_extensions(
                     "is_mingw=false",
                     "is_clang=true",
                     "enable_sanitizer=false",
-                    "vs_version=2022",
+                    "vs_version=2026",
                 ]
             )
 

--- a/tests/ten_runtime/smoke/sync_stop_before_deinit/BUILD.gn
+++ b/tests/ten_runtime/smoke/sync_stop_before_deinit/BUILD.gn
@@ -8,7 +8,15 @@ import("//build/ten_runtime/glob.gni")
 import("//build/ten_runtime/ten.gni")
 
 ten_runtime_glob("sync_stop_before_deinit") {
-  file_list = all_native_files
+  file_list = [ "basic.cc" ]
+
+  # This test relies on Rust graph processing to turn exposed_messages into a
+  # ten:graph_proxy node and routing connections. Without Rust, on_stop_notify
+  # has no destination ("Failed to find destination") and the test times out.
+  if (ten_enable_ten_rust) {
+    file_list += [ "msg_during_on_stop.cc" ]
+  }
+
   deps = [
     "//third_party/msgpack:msgpackc",
     "//third_party/nlohmann_json",


### PR DESCRIPTION
1. **visual studio selection**: check env var VSINSTALLDIR first, and then go for VS 2026 (instead of 2022)
2. **skip test**:  test **msg_during_on_stop** requires Rust, so it should be skipped when rust is not enabled (details commented in Codes)
3. **macOS Rust toolchain**: force the use of Rust stable so crate-local rust-toolchain.toml files cannot switch the build to nightly and trigger **compiler ICE.**
4. **macOS Designer tests**: use a dynamically selected loopback port for the tman Designer instead of the fixed port 49483, in order to avoid port-conflict failures. _(Not sure what triggers this problem)_
5. **Windows PATH**: add only the WinGet links directory after installing tman. Re-importing the complete Windows PATH could place the WindowsApps WSL bash.exe ahead of Git Bash and break subsequent workflow steps. _(Not sure which commit triggers this problem)_
6. **Linux runner disk space**: Pin Linux builds to Ubuntu 22.04 and add log.

Fix errors triggered by failed releases:
1. **Windows packages**: handle incomplete latest Windows package releases by falling back to the package version matching the installed tman.

chore:
1. **ten_gn version**: Use the recorded pointer in the repository, instead of pinned to main (as default in install_tgn.ps1). 
2. **GN arguments output**: Validate the complete gn args --list --short output before writing tgn_args.txt, preventing GN failure from overwriting the file.