### PR TITLE
fix: prevent api_key exposure in config

### DIFF
--- a/ai_agents/agents/ten_packages/extension/ezai_tw_tts_python/config.py
+++ b/ai_agents/agents/ten_packages/extension/ezai_tw_tts_python/config.py
@@ -73,6 +73,8 @@ class EZAITWTTSConfig(AsyncTTS2HttpConfig):
         # Encrypt sensitive fields in params
         if config.params and "api_key" in config.params:
             config.params["api_key"] = utils.encrypt(config.params["api_key"])
+        if config.api_key:
+            config.api_key = utils.encrypt(config.api_key)
 
         return f"{config}"
 

--- a/ai_agents/agents/ten_packages/extension/ezai_tw_tts_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/ezai_tw_tts_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "ezai_tw_tts_python",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/ezai_tw_tts_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/ezai_tw_tts_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezai_tw_tts_python"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.28.1",


### PR DESCRIPTION
## Summary
Follow-up to #2100 
fix api_key only encrypted in config.params but not in config class member

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [ ] Tests added/updated
- [x] All tests pass
- [ ] Manual testing completed

## Documentation
- [ ] Documentation updated
- [ ] Examples provided if needed