### PR TITLE
chore: bump spatius dependency to 1.0.4

### DIFF
--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "spatius_avatar_python",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
@@ -5,5 +5,5 @@ requires-python = ">=3.10"
 dependencies = [
     "agora-token-builder>=1.0.0",
     "protobuf>=5.28.3,<6",
-    "spatius[opus]==1.0.3",
+    "spatius[opus]==1.0.4",
 ]

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spatius-avatar-python"
-version = "0.2.3"
+version = "0.2.4"
 requires-python = ">=3.10"
 dependencies = [
     "agora-token-builder>=1.0.0",

--- a/ai_agents/agents/ten_packages/extension/spatius_avatar_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/spatius_avatar_python/requirements.txt
@@ -1,4 +1,4 @@
 pytest==8.3.4
 agora-token-builder>=1.0.0
-spatius[opus]==1.0.3
+spatius[opus]==1.0.4
 protobuf>=5.28.3,<6


### PR DESCRIPTION
Bump the spatius Python SDK dependency in `spatius_avatar_python` from 1.0.3 to 1.0.4.

- `requirements.txt`: `spatius[opus]==1.0.4`
- `pyproject.toml`: `spatius[opus]==1.0.4`