### PR TITLE
fix: avoid shell=True in run_script.py build helpers

### DIFF
--- a/ai_agents/agents/examples/voice-assistant-nodejs/tenapp/ten_packages/extension/main_nodejs/tools/run_script.py
+++ b/ai_agents/agents/examples/voice-assistant-nodejs/tenapp/ten_packages/extension/main_nodejs/tools/run_script.py
@@ -5,34 +5,39 @@
 # See the LICENSE file for more information.
 #
 import argparse
+import platform
 import subprocess
 import sys
 import os
 
+# On Windows npm ships as a batch script (`npm.cmd`). CreateProcess does not
+# apply PATHEXT resolution, so the extension has to be spelled out.
+NPM = "npm.cmd" if platform.system().lower() == "windows" else "npm"
 
-def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
-    """Run a shell command."""
+
+def run_cmd(cmd: list[str], env: dict[str, str] | None = None) -> int:
+    """Run a command without spawning a shell."""
     if env is None:
         env = os.environ.copy()
-    print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=True, env=env)
     return result.returncode
 
 
 def run_cmd_build() -> int:
     """Build the application."""
-    cmd = "npm install"
+    cmd = [NPM, "install"]
 
     rc = run_cmd(cmd)
     if rc != 0:
         return rc
 
-    cmd = "npm run standalone-install"
+    cmd = [NPM, "run", "standalone-install"]
     rc = run_cmd(cmd)
     if rc != 0:
         return rc
 
-    cmd = "npm run build"
+    cmd = [NPM, "run", "build"]
     rc = run_cmd(cmd)
     return rc
 

--- a/packages/core_apps/default_app_cpp/tools/run_script.py
+++ b/packages/core_apps/default_app_cpp/tools/run_script.py
@@ -49,40 +49,32 @@ def detect_arch() -> str:
     raise RuntimeError(f"Unsupported architecture: {machine}")
 
 
-def run_cmd(cmd: str) -> int:
-    """Run a shell command."""
-    print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True)
+def run_cmd(cmd: list[str]) -> int:
+    """Run a command without spawning a shell."""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=True)
     return result.returncode
 
 
 def run_cmd_start(os: str, _arch: str) -> int:
     """Start the application."""
     if os == "win":
-        command = "bin/default_app_cpp.exe"
+        command = ["bin/default_app_cpp.exe"]
     else:
-        command = "bin/default_app_cpp"
+        command = ["bin/default_app_cpp"]
 
     return run_cmd(command)
 
 
 def run_cmd_build(os: str, arch: str) -> int:
     """Build the application."""
-    if os == "win":
-        command = f"tgn.bat gen {os} {arch} {BUILD_TYPE}"
-    else:
-        command = f"tgn gen {os} {arch} {BUILD_TYPE}"
+    tgn = "tgn.bat" if os == "win" else "tgn"
 
-    rc = run_cmd(command)
+    rc = run_cmd([tgn, "gen", os, arch, BUILD_TYPE])
     if rc != 0:
         return rc
 
-    if os == "win":
-        command = f"tgn.bat build {os} {arch} {BUILD_TYPE}"
-    else:
-        command = f"tgn build {os} {arch} {BUILD_TYPE}"
-
-    return run_cmd(command)
+    return run_cmd([tgn, "build", os, arch, BUILD_TYPE])
 
 
 def main():

--- a/packages/core_apps/default_app_cpp/tools/run_script.py.tent
+++ b/packages/core_apps/default_app_cpp/tools/run_script.py.tent
@@ -49,40 +49,32 @@ def detect_arch() -> str:
     raise RuntimeError(f"Unsupported architecture: {machine}")
 
 
-def run_cmd(cmd: str) -> int:
-    """Run a shell command."""
-    print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True)
+def run_cmd(cmd: list[str]) -> int:
+    """Run a command without spawning a shell."""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=True)
     return result.returncode
 
 
 def run_cmd_start(os: str, _arch: str) -> int:
     """Start the application."""
     if os == "win":
-        command = "bin/{{package_name}}.exe"
+        command = ["bin/{{package_name}}.exe"]
     else:
-        command = "bin/{{package_name}}"
+        command = ["bin/{{package_name}}"]
 
     return run_cmd(command)
 
 
 def run_cmd_build(os: str, arch: str) -> int:
     """Build the application."""
-    if os == "win":
-        command = f"tgn.bat gen {os} {arch} {BUILD_TYPE}"
-    else:
-        command = f"tgn gen {os} {arch} {BUILD_TYPE}"
+    tgn = "tgn.bat" if os == "win" else "tgn"
 
-    rc = run_cmd(command)
+    rc = run_cmd([tgn, "gen", os, arch, BUILD_TYPE])
     if rc != 0:
         return rc
 
-    if os == "win":
-        command = f"tgn.bat build {os} {arch} {BUILD_TYPE}"
-    else:
-        command = f"tgn build {os} {arch} {BUILD_TYPE}"
-
-    return run_cmd(command)
+    return run_cmd([tgn, "build", os, arch, BUILD_TYPE])
 
 
 def main():

--- a/packages/core_extensions/default_extension_cpp/tools/run_script.py
+++ b/packages/core_extensions/default_extension_cpp/tools/run_script.py
@@ -76,9 +76,14 @@ def run_cmd_test(os_str: str, _arch: str) -> int:
 def run_cmd_build(os: str, arch: str) -> int:
     """Build the application."""
     # Allow extra GN args via environment variable (e.g. vs_version=2022)
-    extra_gn_args = shlex.split(os_module.environ.get("TEN_EXTRA_GN_ARGS", ""))
+    extra_gn_args = os_module.environ.get("TEN_EXTRA_GN_ARGS", "")
 
     tgn = "tgn.bat" if os == "win" else "tgn"
+
+    # Kept as a single string so extra args can be appended to it in place
+    # (CI does this to add vs_version=2022); shlex.split then turns it back
+    # into separate arguments.
+    gn_args = "ten_enable_standalone_test=true"
 
     command = [
         tgn,
@@ -87,8 +92,8 @@ def run_cmd_build(os: str, arch: str) -> int:
         arch,
         BUILD_TYPE,
         "--",
-        "ten_enable_standalone_test=true",
-        *extra_gn_args,
+        *shlex.split(gn_args),
+        *shlex.split(extra_gn_args),
     ]
 
     rc = run_cmd(command)

--- a/packages/core_extensions/default_extension_cpp/tools/run_script.py
+++ b/packages/core_extensions/default_extension_cpp/tools/run_script.py
@@ -6,6 +6,7 @@
 #
 import argparse
 import platform
+import shlex
 import subprocess
 import sys
 import os as os_module
@@ -48,12 +49,12 @@ def detect_arch() -> str:
     raise RuntimeError(f"Unsupported architecture: {machine}")
 
 
-def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
-    """Run a shell command."""
+def run_cmd(cmd: list[str], env: dict[str, str] | None = None) -> int:
+    """Run a command without spawning a shell."""
     if env is None:
         env = os_module.environ.copy()
-    print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=True, env=env)
     return result.returncode
 
 
@@ -65,9 +66,9 @@ def run_cmd_test(os_str: str, _arch: str) -> int:
         env["PATH"] = (
             env["PATH"] + ";" + ".ten/app/ten_packages/system/ten_runtime/lib"
         )
-        command = "bin/default_extension_cpp_test.exe"
+        command = ["bin/default_extension_cpp_test.exe"]
     else:
-        command = "bin/default_extension_cpp_test"
+        command = ["bin/default_extension_cpp_test"]
 
     return run_cmd(command, env)
 
@@ -75,29 +76,26 @@ def run_cmd_test(os_str: str, _arch: str) -> int:
 def run_cmd_build(os: str, arch: str) -> int:
     """Build the application."""
     # Allow extra GN args via environment variable (e.g. vs_version=2022)
-    extra_gn_args = os_module.environ.get("TEN_EXTRA_GN_ARGS", "")
+    extra_gn_args = shlex.split(os_module.environ.get("TEN_EXTRA_GN_ARGS", ""))
 
-    if os == "win":
-        command = (
-            f"tgn.bat gen {os} {arch} {BUILD_TYPE} "
-            f"-- ten_enable_standalone_test=true {extra_gn_args}"
-        )
-    else:
-        command = (
-            f"tgn gen {os} {arch} {BUILD_TYPE} "
-            f"-- ten_enable_standalone_test=true {extra_gn_args}"
-        )
+    tgn = "tgn.bat" if os == "win" else "tgn"
+
+    command = [
+        tgn,
+        "gen",
+        os,
+        arch,
+        BUILD_TYPE,
+        "--",
+        "ten_enable_standalone_test=true",
+        *extra_gn_args,
+    ]
 
     rc = run_cmd(command)
     if rc != 0:
         return rc
 
-    if os == "win":
-        command = f"tgn.bat build {os} {arch} {BUILD_TYPE}"
-    else:
-        command = f"tgn build {os} {arch} {BUILD_TYPE}"
-
-    return run_cmd(command)
+    return run_cmd([tgn, "build", os, arch, BUILD_TYPE])
 
 
 def main():

--- a/packages/core_extensions/default_extension_cpp/tools/run_script.py.tent
+++ b/packages/core_extensions/default_extension_cpp/tools/run_script.py.tent
@@ -49,12 +49,12 @@ def detect_arch() -> str:
     raise RuntimeError(f"Unsupported architecture: {machine}")
 
 
-def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
-    """Run a shell command."""
+def run_cmd(cmd: list[str], env: dict[str, str] | None = None) -> int:
+    """Run a command without spawning a shell."""
     if env is None:
         env = os.environ.copy()
-    print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=True, env=env)
     return result.returncode
 
 
@@ -66,36 +66,32 @@ def run_cmd_test(os_str: str, _arch: str) -> int:
         env["PATH"] = (
             env["PATH"] + ";" + ".ten/app/ten_packages/system/ten_runtime/lib"
         )
-        command = "bin/{{package_name}}_test.exe"
+        command = ["bin/{{package_name}}_test.exe"]
     else:
-        command = "bin/{{package_name}}_test"
+        command = ["bin/{{package_name}}_test"]
 
     return run_cmd(command, env)
 
 
 def run_cmd_build(os: str, arch: str) -> int:
     """Build the application."""
-    if os == "win":
-        command = (
-            f"tgn.bat gen {os} {arch} {BUILD_TYPE} "
-            "-- ten_enable_standalone_test=true"
-        )
-    else:
-        command = (
-            f"tgn gen {os} {arch} {BUILD_TYPE} "
-            "-- ten_enable_standalone_test=true"
-        )
+    tgn = "tgn.bat" if os == "win" else "tgn"
 
-    rc = run_cmd(command)
+    rc = run_cmd(
+        [
+            tgn,
+            "gen",
+            os,
+            arch,
+            BUILD_TYPE,
+            "--",
+            "ten_enable_standalone_test=true",
+        ]
+    )
     if rc != 0:
         return rc
 
-    if os == "win":
-        command = f"tgn.bat build {os} {arch} {BUILD_TYPE}"
-    else:
-        command = f"tgn build {os} {arch} {BUILD_TYPE}"
-
-    return run_cmd(command)
+    return run_cmd([tgn, "build", os, arch, BUILD_TYPE])
 
 
 def main():

--- a/packages/core_extensions/default_extension_cpp/tools/run_script.py.tent
+++ b/packages/core_extensions/default_extension_cpp/tools/run_script.py.tent
@@ -7,6 +7,7 @@
 
 import argparse
 import platform
+import shlex
 import subprocess
 import sys
 import os
@@ -77,16 +78,13 @@ def run_cmd_build(os: str, arch: str) -> int:
     """Build the application."""
     tgn = "tgn.bat" if os == "win" else "tgn"
 
+    # Kept as a single string so extra args can be appended to it in place
+    # (CI does this to add vs_version=2022); shlex.split then turns it back
+    # into separate arguments.
+    gn_args = "ten_enable_standalone_test=true"
+
     rc = run_cmd(
-        [
-            tgn,
-            "gen",
-            os,
-            arch,
-            BUILD_TYPE,
-            "--",
-            "ten_enable_standalone_test=true",
-        ]
+        [tgn, "gen", os, arch, BUILD_TYPE, "--", *shlex.split(gn_args)]
     )
     if rc != 0:
         return rc

--- a/packages/core_extensions/default_extension_nodejs/tools/run_script.py
+++ b/packages/core_extensions/default_extension_nodejs/tools/run_script.py
@@ -5,34 +5,39 @@
 # See the LICENSE file for more information.
 #
 import argparse
+import platform
 import subprocess
 import sys
 import os
 
+# On Windows npm ships as a batch script (`npm.cmd`). CreateProcess does not
+# apply PATHEXT resolution, so the extension has to be spelled out.
+NPM = "npm.cmd" if platform.system().lower() == "windows" else "npm"
 
-def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
-    """Run a shell command."""
+
+def run_cmd(cmd: list[str], env: dict[str, str] | None = None) -> int:
+    """Run a command without spawning a shell."""
     if env is None:
         env = os.environ.copy()
-    print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=True, env=env)
     return result.returncode
 
 
 def run_cmd_build() -> int:
     """Build the application."""
-    cmd = "npm install"
+    cmd = [NPM, "install"]
 
     rc = run_cmd(cmd)
     if rc != 0:
         return rc
 
-    cmd = "npm run standalone-install"
+    cmd = [NPM, "run", "standalone-install"]
     rc = run_cmd(cmd)
     if rc != 0:
         return rc
 
-    cmd = "npm run build"
+    cmd = [NPM, "run", "build"]
     rc = run_cmd(cmd)
     return rc
 

--- a/packages/example_apps/transcriber_demo/ten_packages/extension/vtt_nodejs/tools/run_script.py
+++ b/packages/example_apps/transcriber_demo/ten_packages/extension/vtt_nodejs/tools/run_script.py
@@ -5,34 +5,39 @@
 # See the LICENSE file for more information.
 #
 import argparse
+import platform
 import subprocess
 import sys
 import os
 
+# On Windows npm ships as a batch script (`npm.cmd`). CreateProcess does not
+# apply PATHEXT resolution, so the extension has to be spelled out.
+NPM = "npm.cmd" if platform.system().lower() == "windows" else "npm"
 
-def run_cmd(cmd: str, env: dict[str, str] | None = None) -> int:
-    """Run a shell command."""
+
+def run_cmd(cmd: list[str], env: dict[str, str] | None = None) -> int:
+    """Run a command without spawning a shell."""
     if env is None:
         env = os.environ.copy()
-    print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, check=True, env=env)
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=True, env=env)
     return result.returncode
 
 
 def run_cmd_build() -> int:
     """Build the application."""
-    cmd = "npm install"
+    cmd = [NPM, "install"]
 
     rc = run_cmd(cmd)
     if rc != 0:
         return rc
 
-    cmd = "npm run standalone-install"
+    cmd = [NPM, "run", "standalone-install"]
     rc = run_cmd(cmd)
     if rc != 0:
         return rc
 
-    cmd = "npm run build"
+    cmd = [NPM, "run", "build"]
     rc = run_cmd(cmd)
     return rc
 


### PR DESCRIPTION
Closes #2107

## Problem

`run_script.py` ran every build/start/test command through `subprocess.run(..., shell=True)`.

For most call sites the commands are hardcoded literals, so this was hygiene rather than an exploitable bug. But in `default_extension_cpp` the `TEN_EXTRA_GN_ARGS` environment variable was interpolated directly into the shell string:

```python
extra_gn_args = os_module.environ.get("TEN_EXTRA_GN_ARGS", "")
command = (
    f"tgn gen {os} {arch} {BUILD_TYPE} "
    f"-- ten_enable_standalone_test=true {extra_gn_args}"
)
result = subprocess.run(command, shell=True, check=True, env=env)
```

Anything in that variable was executed as shell code rather than passed as an argument.

## Scope

The issue reported one file, but the same pattern existed in seven. Two of them are the `.tent` templates that `tman` uses to scaffold new C++ apps and extensions, so every newly generated project inherited it — fixing only the reported file would have let the pattern keep reproducing.

- `packages/core_apps/default_app_cpp/tools/run_script.py` (+ `.tent`)
- `packages/core_extensions/default_extension_cpp/tools/run_script.py` (+ `.tent`)
- `packages/core_extensions/default_extension_nodejs/tools/run_script.py`
- `packages/example_apps/transcriber_demo/ten_packages/extension/vtt_nodejs/tools/run_script.py`
- `ai_agents/agents/examples/voice-assistant-nodejs/tenapp/ten_packages/extension/main_nodejs/tools/run_script.py`

## Change

`run_cmd` now takes a `list[str]` and runs without a shell. `TEN_EXTRA_GN_ARGS` is split with `shlex.split`, so multi-word and quoted GN args still work while shell metacharacters stay inert.

Two cross-platform details preserved:

- **npm on Windows** is spelled `npm.cmd`. `CreateProcess` does not apply `PATHEXT` resolution, so a bare `npm` with `shell=False` would fail — this keeps `tman_full_win_x64` working.
- **`tgn.bat` vs `tgn`** branching is unchanged. `CreateProcess` does execute `.bat`/`.cmd` directly, so these still run with `shell=False`.

## Verification

Rather than only inspecting the diff, I stubbed `npm`/`tgn` and the built binaries onto `PATH`, executed each script for real, and asserted the exact argv produced. 22/22 checks pass:

- All three `npm` invocations, both `tgn gen`/`tgn build` paths, and the `start`/`test` subcommands produce the expected argv.
- `TEN_EXTRA_GN_ARGS='vs_version=2022 label="a b"'` splits into `vs_version=2022` and `label=a b`.
- Both `.tent` templates render (`{{package_name}}` substituted) and execute correctly.

Injection test with `TEN_EXTRA_GN_ARGS='; touch PWNED'`:

- **Control** — the pre-fix code from `main` created the `PWNED` file, confirming the injection was real.
- **After** — no file is created; the payload arrives as three inert argv tokens `";"`, `"touch"`, `"PWNED"`.

Formatting checked with `black --line-length 79` (the convention 4 of the 5 files already followed). One pre-existing deviation in `default_app_cpp` sits in an untouched block and was deliberately left alone to avoid unrelated diff noise.

## Threat model (scoping this honestly)

To avoid overstating severity:

- In the file the issue names (`main_nodejs/tools/run_script.py`) the three commands are hardcoded literals with no external input flowing in, so `shell=True` there was **not exploitable** — it is a static-analysis finding, not a live vulnerability.
- `TEN_EXTRA_GN_ARGS` is the only genuine injection sink, and `grep` shows nothing in this repo ever sets it (it appears only in a TODO comment in `from_scratch.yml`). An attacker who can set your build environment variables generally has easier options already.

So this PR is best read as **hardening and stopping the pattern from propagating through the templates**, not as a fix for an actively exploitable bug. No runtime behaviour changes: the argv reaching `npm`/`tgn` is identical, which the argv suite asserts.