### PR TITLE
fix(profiler): quote paths in pprof command builders to prevent shell injection

### DIFF
--- a/tools/profiler/gperftools/utils/pprof_cmd.py
+++ b/tools/profiler/gperftools/utils/pprof_cmd.py
@@ -1,27 +1,33 @@
+import shlex
+
+
 def convert_heap_to_text_cmd(bin, heapFile, textFile):
     # run cmd: google-pprof --text bin heapFile > textFile
-    return "google-pprof --text " + bin + " " + heapFile + " > " + textFile
+    return (
+        f"google-pprof --text {shlex.quote(bin)} {shlex.quote(heapFile)}"
+        f" > {shlex.quote(textFile)}"
+    )
 
 
 def convert_heap_to_raw_cmd(bin, heapFile, rawFile):
     # run cmd: google-pprof --raw bin heapFile > rawFile
-    return "google-pprof --raw " + bin + " " + heapFile + " > " + rawFile
+    return (
+        f"google-pprof --raw {shlex.quote(bin)} {shlex.quote(heapFile)}"
+        f" > {shlex.quote(rawFile)}"
+    )
 
 
 def convert_raw_to_text_cmd(rawFile, textFile):
     # run cmd: google-pprof --text rawFile > textFile
-    return "google-pprof --text " + rawFile + " > " + textFile
+    return (
+        f"google-pprof --text {shlex.quote(rawFile)} > {shlex.quote(textFile)}"
+    )
 
 
 def compare_heaps_cmd(baseRawFile, rawFile, outputType, outputFile):
-    # run cmd: google-pprof --base baseRawFile rawFile --text > outputFile
+    # run cmd: google-pprof --base baseRawFile rawFile --<outputType> > outputFile
     return (
-        "google-pprof --base "
-        + baseRawFile
-        + " "
-        + rawFile
-        + " --"
-        + outputType
-        + " > "
-        + outputFile
+        f"google-pprof --base {shlex.quote(baseRawFile)}"
+        f" {shlex.quote(rawFile)} --{shlex.quote(outputType)}"
+        f" > {shlex.quote(outputFile)}"
     )

--- a/tools/profiler/pprof/utils/pprof_cmd.py
+++ b/tools/profiler/pprof/utils/pprof_cmd.py
@@ -1,8 +1,16 @@
+import shlex
+
+
 def convert_heap_to_text_cmd(heapFile, textFile):
     # run cmd: go tool pprof -text ${heapFile} > ${textFile}
-    return f"go tool pprof -text {heapFile} > {textFile}"
+    return (
+        f"go tool pprof -text {shlex.quote(heapFile)}"
+        f" > {shlex.quote(textFile)}"
+    )
 
 
 def show_heap_in_browser_cmd(port, heapFile):
     # run cmd: go tool pprof -http=:${port} ${heapFile}
-    return f"go tool pprof -http=:{port} {heapFile}"
+    return (
+        f"go tool pprof -http=:{shlex.quote(str(port))} {shlex.quote(heapFile)}"
+    )


### PR DESCRIPTION
## Problem

`tools/profiler/gperftools/utils/pprof_cmd.py` and `tools/profiler/pprof/utils/pprof_cmd.py` build shell command strings by concatenating caller-supplied file paths directly into the string. The resulting string is then executed by four dumper / comparer scripts via `subprocess.run(cmd, shell=True)`:

- `tools/profiler/gperftools/dump_heap_files_to_raw.py:38`
- `tools/profiler/gperftools/dump_raw_files_to_text.py:37`
- `tools/profiler/gperftools/compare_heaps.py:25`
- `tools/profiler/pprof/dump_heap_files_to_text.py:37`

If any of `bin`, `heapFile`, `rawFile`, `textFile`, `outputFile`, `port`, or `outputType` contains shell metacharacters, the shell interprets them rather than passing them to `google-pprof` / `go tool pprof`. All six builders have this issue.

This mirrors the concern addressed in #2240 (`shell=True` in `run_script.py`), one layer up.

## Verification

Drove the real `pprof_cmd` modules against a `true`-substituted binary so the shell parses+evaluates argv without needing `google-pprof` / `go` installed. Payload: `'; touch /tmp/PPROF_PWNED_MARKER; #` passed as `heapFile`.

| builder                          | before          | after         |
|----------------------------------|-----------------|---------------|
| `gperf.convert_heap_to_text_cmd` | injection ran   | blocked       |
| `gperf.convert_heap_to_raw_cmd`  | injection ran   | blocked       |
| `gperf.convert_raw_to_text_cmd`  | injection ran   | blocked       |
| `gperf.compare_heaps_cmd`        | injection ran   | blocked       |
| `go.convert_heap_to_text_cmd`    | injection ran   | blocked       |
| `go.show_heap_in_browser_cmd`    | injection ran   | blocked       |

Benign paths produce byte-for-byte identical commands (`shlex.quote` is a no-op on shell-safe strings), so no caller behavior changes:

```
convert_heap_to_raw_cmd('./mybin', 'heap.out', 'o.raw')
→ google-pprof --raw ./mybin heap.out > o.raw
```

## Why this shape

Two possible fixes:

1. **`shlex.quote` at the string-building layer** (this PR) — preserves `str` return type, keeps the `>` redirection in the string, no changes to the four downstream callers.
2. **Return `list[str]` argv + move redirection into Python** — deeper hardening (removes `shell=True` entirely, matching #2240), but touches four caller files and changes their `" & ".join(...)` parallel-execution pattern.

I picked (1) because the parallel-execution pattern (`" & ".join(cmds)` in the dumpers) has its own semantics worth preserving in a separate change — reviewer can decide independently whether to accept (2) as a follow-up. Happy to extend this PR to option (2) if preferred.

## Files changed

- `tools/profiler/gperftools/utils/pprof_cmd.py` (4 builders quoted)
- `tools/profiler/pprof/utils/pprof_cmd.py` (2 builders quoted, `port` cast + quoted)