### PR TITLE
fix(deps): pin websockets/aiohttp in requirements.txt to match pyproject.toml

### DIFF
--- a/ai_agents/agents/ten_packages/extension/azure_mllm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/azure_mllm_python/requirements.txt
@@ -1,3 +1,3 @@
 pydantic
 pydub==0.25.1
-aiohttp
+aiohttp>=3.14.1

--- a/ai_agents/agents/ten_packages/extension/xfyun_asr_bigmodel_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/xfyun_asr_bigmodel_python/requirements.txt
@@ -1,2 +1,2 @@
-websockets
+websockets>=16.0
 pydantic

--- a/ai_agents/agents/ten_packages/extension/xfyun_asr_dialect_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/xfyun_asr_dialect_python/requirements.txt
@@ -1,2 +1,2 @@
-websockets
+websockets>=16.0
 pydantic

--- a/ai_agents/agents/ten_packages/extension/xfyun_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/xfyun_asr_python/requirements.txt
@@ -1,2 +1,2 @@
-websockets
+websockets>=16.0
 pydantic


### PR DESCRIPTION
## Problem

Four extensions declare a bare package name in `requirements.txt` while their `pyproject.toml` specifies a minimum version. `pip install -r requirements.txt` may resolve an older release that the extension's code does not run on, breaking reproducibility between the two install paths.

| extension                      | requirements.txt | pyproject.toml       |
|--------------------------------|------------------|----------------------|
| `xfyun_asr_bigmodel_python`    | `websockets`     | `websockets>=16.0`   |
| `xfyun_asr_dialect_python`     | `websockets`     | `websockets>=16.0`   |
| `xfyun_asr_python`             | `websockets`     | `websockets>=16.0`   |
| `azure_mllm_python`            | `aiohttp`        | `aiohttp>=3.14.1`    |

## Fix

Update each `requirements.txt` to carry the same floor its sibling `pyproject.toml` declares.

## Verification

```
$ for e in xfyun_asr_bigmodel_python xfyun_asr_dialect_python xfyun_asr_python; do
    grep websockets ai_agents/agents/ten_packages/extension/$e/{requirements.txt,pyproject.toml}
  done
$ grep aiohttp ai_agents/agents/ten_packages/extension/azure_mllm_python/{requirements.txt,pyproject.toml}
```
Both files in each pair now report the same floor.

## Why this shape

Matches the pattern established by #2232 (ezai_asr_python) — align the two install manifests rather than pick a different floor. Happy to raise the floors further (e.g. websockets>=16.0 → newer) if the maintainers prefer, but this PR sticks to the version the code was written against.

## Files changed

- `ai_agents/agents/ten_packages/extension/xfyun_asr_bigmodel_python/requirements.txt`
- `ai_agents/agents/ten_packages/extension/xfyun_asr_dialect_python/requirements.txt`
- `ai_agents/agents/ten_packages/extension/xfyun_asr_python/requirements.txt`
- `ai_agents/agents/ten_packages/extension/azure_mllm_python/requirements.txt`