### PR TITLE
fix(tests): use string form for shell=True subprocess.run in nodejs test start scripts

### DIFF
--- a/tests/ten_runtime/integration/nodejs/standalone_test_nodejs_2/default_extension_nodejs/tests/bin/start.py
+++ b/tests/ten_runtime/integration/nodejs/standalone_test_nodejs_2/default_extension_nodejs/tests/bin/start.py
@@ -16,14 +16,14 @@ env = os.environ.copy()
 
 # npm install
 print("Running npm install...")
-result = subprocess.run(["npm", "install"], env=env, shell=True)
+result = subprocess.run("npm install", env=env, shell=True)
 if result.returncode != 0:
     print("npm install failed")
     sys.exit(result.returncode)
 
 # npm run build
 print("Running npm run build...")
-result = subprocess.run(["npm", "run", "build"], env=env, shell=True)
+result = subprocess.run("npm run build", env=env, shell=True)
 if result.returncode != 0:
     print("npm run build failed")
     sys.exit(result.returncode)
@@ -50,5 +50,5 @@ env["PATH"] = os.pathsep.join(dll_paths) + os.pathsep + env.get("PATH", "")
 
 # npm test
 print("Running npm test...")
-result = subprocess.run(["npm", "test"], env=env, shell=True)
+result = subprocess.run("npm test", env=env, shell=True)
 sys.exit(result.returncode)

--- a/tests/ten_runtime/integration/nodejs/standalone_test_nodejs_3/default_extension_nodejs/tests/bin/start.py
+++ b/tests/ten_runtime/integration/nodejs/standalone_test_nodejs_3/default_extension_nodejs/tests/bin/start.py
@@ -16,14 +16,14 @@ env = os.environ.copy()
 
 # npm install
 print("Running npm install...")
-result = subprocess.run(["npm", "install"], env=env, shell=True)
+result = subprocess.run("npm install", env=env, shell=True)
 if result.returncode != 0:
     print("npm install failed")
     sys.exit(result.returncode)
 
 # npm run build
 print("Running npm run build...")
-result = subprocess.run(["npm", "run", "build"], env=env, shell=True)
+result = subprocess.run("npm run build", env=env, shell=True)
 if result.returncode != 0:
     print("npm run build failed")
     sys.exit(result.returncode)


### PR DESCRIPTION
## Problem

Two Windows-only start scripts under `tests/ten_runtime/integration/nodejs/standalone_test_nodejs_{2,3}/default_extension_nodejs/tests/bin/start.py` pass a list argument together with `shell=True`:

```python
result = subprocess.run([\"npm\", \"install\"], env=env, shell=True)
```

Python's [`subprocess`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) docs discourage this combination. Concrete behavior differs by platform:

| platform | what runs | outcome |
|---|---|---|
| POSIX | `/bin/sh -c npm install` → sh with `cmd=\"npm\"` and `$0=\"install\"` | `npm` executes with no arguments — install is discarded, the step silently no-ops |
| Windows | `cmd.exe /c \"npm install\"` (via `list2cmdline`) | works — but only by accident of how Windows list2cmdline joins the list |

Same file, line 53 of `standalone_test_nodejs_3` already uses the pattern for list arguments (`subprocess.run([\"node\", \"--expose-gc\", \"build/index.js\"], env=env)` — no `shell=True`), which is what makes the `shell=True` in the other call sites read as the copy-paste anomaly.

## Fix

Switch the five affected calls to the documented string form for `shell=True`:

```python
result = subprocess.run(\"npm install\", env=env, shell=True)
```

- Windows: `list2cmdline([\"npm\",\"install\"])` already produces `\"npm install\"`, so the actual cmdline passed to `cmd.exe /c` is byte-identical — zero behavior change on the platform this script is meant to run on.
- POSIX: someone running the Python fallback from a Unix shell (e.g. a Mac dev debugging locally) now actually invokes `npm install` instead of silently no-op'ing.

## Files changed

- `tests/ten_runtime/integration/nodejs/standalone_test_nodejs_2/default_extension_nodejs/tests/bin/start.py` (3 call sites)
- `tests/ten_runtime/integration/nodejs/standalone_test_nodejs_3/default_extension_nodejs/tests/bin/start.py` (2 call sites)

## Why this shape

Not removing `shell=True` entirely because `npm` on Windows is `npm.cmd` — `CreateProcess` doesn't search `PATHEXT`, so `subprocess.run([\"npm\", \"install\"])` without a shell would fail on the target platform. String form + `shell=True` is the minimal-blast-radius fix that matches Python's own documentation.

Follows the general subprocess hardening thread in #2240.