### PR TITLE
docs(dev): collapse per-language extension guides into <details> switches

### DIFF
--- a/docs/development/how_to_develop_with_ext.cn.md
+++ b/docs/development/how_to_develop_with_ext.cn.md
@@ -35,7 +35,12 @@ TEN Framework version: <version>
 
 ---
 
-## C++ 扩展开发
+## 按语言浏览开发指南
+
+点击下方语言展开完整开发指南。默认全部收起，方便您专注于自己需要的语言。
+
+<details>
+<summary><strong>C++ 扩展开发</strong></summary>
 
 C++ 扩展适用于对性能要求极高的应用场景，如实时音视频处理、高频数据计算、底层系统操作等。
 
@@ -246,9 +251,10 @@ gdb ./bin/my_example_ext_cpp_test
 (gdb) bt  # 查看完整的函数调用栈
 ```
 
----
+</details>
 
-## Go 扩展开发
+<details>
+<summary><strong>Go 扩展开发</strong></summary>
 
 Go 扩展在高性能和开发效率之间提供了很好的平衡，特别适合构建网络服务、并发处理、微服务架构等应用场景。
 
@@ -418,9 +424,10 @@ use (
 }
 ```
 
----
+</details>
 
-## Python 扩展开发
+<details>
+<summary><strong>Python 扩展开发</strong></summary>
 
 Python 扩展具有最高的开发效率，特别适合快速原型开发、AI/ML 应用集成、复杂业务逻辑实现等场景。
 
@@ -593,9 +600,10 @@ def test_basic():
 }
 ```
 
----
+</details>
 
-## Node.js 扩展开发
+<details>
+<summary><strong>Node.js 扩展开发</strong></summary>
 
 Node.js 扩展提供了现代 JavaScript/TypeScript 开发体验，特别适合 Web 应用集成、快速原型开发、前端技术栈扩展等场景。得益于 Node.js 的异步特性和丰富的生态系统，开发者可以轻松构建高效的实时应用。
 
@@ -1037,6 +1045,8 @@ async onCmd(tenEnv: TenEnv, cmd: Cmd): Promise<void> {
   }
 }
 ```
+
+</details>
 
 ---
 

--- a/docs/development/how_to_develop_with_ext.md
+++ b/docs/development/how_to_develop_with_ext.md
@@ -35,7 +35,12 @@ Regardless of which programming language you use, TEN extension development foll
 
 ---
 
-## C++ Extension Development
+## Language-specific Development Guides
+
+Click a language below to expand its full guide. Sections default to collapsed so you can focus on the language you need.
+
+<details>
+<summary><strong>C++ Extension Development</strong></summary>
 
 C++ extensions are suitable for application scenarios with extremely high performance requirements, such as real-time audio and video processing, high-frequency data computation, low-level system operations, etc.
 
@@ -246,9 +251,10 @@ gdb ./bin/my_example_ext_cpp_test
 (gdb) bt  # View complete function call stack
 ```
 
----
+</details>
 
-## Go Extension Development
+<details>
+<summary><strong>Go Extension Development</strong></summary>
 
 Go extensions provide a good balance between high performance and development efficiency, particularly suitable for building network services, concurrent processing, microservice architecture and other application scenarios.
 
@@ -418,9 +424,10 @@ Make sure the official Go extension is installed, then use the following debug c
 }
 ```
 
----
+</details>
 
-## Python Extension Development
+<details>
+<summary><strong>Python Extension Development</strong></summary>
 
 Python extensions have the highest development efficiency, particularly suitable for rapid prototyping, AI/ML application integration, complex business logic implementation and other scenarios.
 
@@ -593,9 +600,10 @@ Make sure you have installed the Python extension and debugpy debugger, use the 
 }
 ```
 
----
+</details>
 
-## Node.js Extension Development
+<details>
+<summary><strong>Node.js Extension Development</strong></summary>
 
 Node.js extensions provide a modern JavaScript/TypeScript development experience, particularly suitable for Web application integration, rapid prototyping, frontend technology stack extensions and other scenarios. Thanks to Node.js's async characteristics and rich ecosystem, developers can easily build efficient real-time applications.
 
@@ -1037,6 +1045,8 @@ async onCmd(tenEnv: TenEnv, cmd: Cmd): Promise<void> {
   }
 }
 ```
+
+</details>
 
 ---
 


### PR DESCRIPTION
Closes #1994.

## Problem

The extension development guide (`docs/development/how_to_develop_with_ext.md` and its `.cn.md` counterpart) tiled all four language sections (C++, Go, Python, Node.js) on one page. A reader looking only for Python still had to scroll past ~200 lines of C++ and ~170 lines of Go before reaching the guide they wanted. The Chinese version is the same shape and had the same problem.

The issue asks for switch-like behavior instead of tiling.

## Fix

Wrap each language section in a collapsible `<details><summary>` block. Readers now see a compact list of four language guides and expand the one they need.

```
## Language-specific Development Guides

Click a language below to expand its full guide.

<details>
<summary><strong>C++ Extension Development</strong></summary>

...C++ content unchanged...

</details>

<details>
<summary><strong>Go Extension Development</strong></summary>

...Go content unchanged...

</details>

...Python...
...Node.js...
```

Same shape in both `how_to_develop_with_ext.md` and `how_to_develop_with_ext.cn.md`.

## Why this shape

- **Matches an existing convention** — `docs/getting-started/websocket-voice-assistant-quick-start.md` already uses `<details><summary><strong>` for its Troubleshooting section (five blocks). Reusing that pattern rather than inventing something.
- **Framework-neutral** — plain HTML `<details>` renders on GitHub and on any Fumadocs / MDX / static-site renderer without additional imports. No `import { Tabs }` shim required.
- **Zero content edits** — the inner content of each language section (including the `###` subheadings that generate TOC anchors) is untouched. Diff is boundaries only.

## Verification

```
$ grep -c '^<details>' docs/development/how_to_develop_with_ext.md    #  4
$ grep -c '^</details>' docs/development/how_to_develop_with_ext.md   #  4
$ grep -c '^<details>' docs/development/how_to_develop_with_ext.cn.md #  4
$ grep -c '^</details>' docs/development/how_to_develop_with_ext.cn.md #  4
```

Both files preserve their inner `###` subheading structure (`Create Project`, `Run Tests`, etc.) so any TOC generator or deep-link that pointed at those anchors still resolves.

## Files changed

- `docs/development/how_to_develop_with_ext.md` (+24 −7)
- `docs/development/how_to_develop_with_ext.cn.md` (+24 −7)

## Alternatives considered

- **MDX `<Tabs>` component** — would need to convert the file to `.mdx` and add an import; larger blast radius and framework-specific. Happy to switch if the maintainers prefer tabs and can point me at the right component import path.
- **Splitting into four files (per language)** — cleaner but changes URLs and breaks any external links currently pointing at `#c-extension-development` etc.