### PR TITLE
chore: drop unused vendor deps from four extensions

### DIFF
--- a/ai_agents/agents/ten_packages/extension/azure_mllm_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/azure_mllm_python/pyproject.toml
@@ -5,5 +5,4 @@ requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",
     "pydantic>=2.13.4",
-    "pydub==0.25.1",
 ]

--- a/ai_agents/agents/ten_packages/extension/azure_mllm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/azure_mllm_python/requirements.txt
@@ -1,3 +1,2 @@
 pydantic
-pydub==0.25.1
 aiohttp

--- a/ai_agents/agents/ten_packages/extension/gladia_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/gladia_asr_python/pyproject.toml
@@ -3,7 +3,6 @@ name = "gladia-asr-python"
 version = "0.2.2"
 requires-python = ">=3.10"
 dependencies = [
-    "deepgram-sdk==3.9.0",
     "pydantic>=2.13.4",
     "requests>=2.34.2",
     "websockets>=14.0",

--- a/ai_agents/agents/ten_packages/extension/gladia_asr_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/gladia_asr_python/requirements.txt
@@ -1,4 +1,3 @@
-deepgram-sdk==3.9.0
 websockets>=14.0
 pydantic
 requests

--- a/ai_agents/agents/ten_packages/extension/openai_mllm_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/openai_mllm_python/pyproject.toml
@@ -5,5 +5,4 @@ requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",
     "pydantic>=2.13.4",
-    "pydub==0.25.1",
 ]

--- a/ai_agents/agents/ten_packages/extension/openai_mllm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/openai_mllm_python/requirements.txt
@@ -1,3 +1,2 @@
 pydantic
-pydub==0.25.1
 aiohttp

--- a/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/pyproject.toml
@@ -5,5 +5,4 @@ requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",
     "pydantic>=2.13.4",
-    "pydub==0.25.1",
 ]

--- a/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/stepfun_mllm_python/requirements.txt
@@ -1,3 +1,2 @@
 pydantic
-pydub==0.25.1
 aiohttp


### PR DESCRIPTION
Four extensions declare a third-party dependency they never use. This removes
those declarations from both `requirements.txt` and `pyproject.toml`.

| Extension | Removed | Why |
| --- | --- | --- |
| `gladia_asr_python` | `deepgram-sdk==3.9.0` | A Gladia extension depending on Deepgram's SDK. No reference to `deepgram` anywhere in the directory, tests included. It also pulls in `httpx`, `aiohttp`, `aiofiles`, `dataclasses-json`, `aenum`, `deprecation` and `typing-extensions` for nothing. |
| `azure_mllm_python` | `pydub==0.25.1` | Declared, never imported. |
| `openai_mllm_python` | `pydub==0.25.1` | Declared, never imported. |
| `stepfun_mllm_python` | `pydub==0.25.1` | Declared, never imported. |

`glm_mllm_python` is deliberately left untouched — it is the one MLLM extension
that genuinely uses pydub (`extension.py:16`, `from pydub import AudioSegment`).
That contrast is what makes the removal criterion safe rather than a blanket sweep.

This follows the same direction as #2207, which scoped numpy to the extensions
that actually need it.

## Verification

- Searched every file type in each of the four extension directories, tests
  included. The only occurrences of the removed packages were the dependency
  declarations themselves.
- Ran an AST pass over every `.py` file in the four extensions to list
  third-party imports and check each against the remaining declared deps. This
  is the check that matters for a dependency removal, since an import can be
  satisfied only transitively by the package being dropped.
- That pass flagged one case: `gladia_asr_python` imports `typing_extensions`
  without declaring it, and `deepgram-sdk` had required `typing-extensions>=4.9.0`.
  It resolves safely — the import is in `tests/conftest.py` only, and `pydantic`
  (still declared) requires `typing-extensions>=4.14.1`.
- Installed the post-removal `requirements.txt` in a clean venv for
  `gladia_asr_python` and for `azure_mllm_python`, then executed the imports the
  code actually performs. `from typing_extensions import override` resolves
  (4.16.0, via pydantic); `aiohttp` and `pydantic` resolve. `deepgram`, `httpx`
  and `pydub` are absent, confirming the slimming takes effect.
  `openai_mllm_python` and `stepfun_mllm_python` have a post-removal
  `requirements.txt` identical to `azure_mllm_python`, so that run covers all three.

## Not verified

The repository test suite was not run — `task test-extension` needs the
`ten_agent_dev` container and Docker was unavailable on this machine. No Python
source is touched by this change; it removes four unused dependency
declarations only. Opening as a draft so the extension tests can run in CI
before this is considered ready.
