### PR TITLE
fix(tman): accept --user-token and --config-file after the subcommand

### DIFF
--- a/core/src/ten_manager/src/cmd/cmd_completion.rs
+++ b/core/src/ten_manager/src/cmd/cmd_completion.rs
@@ -90,14 +90,23 @@ fn create_command_for_completion() -> Command {
                 .help("Print version information and check for updates")
                 .action(clap::ArgAction::SetTrue),
         )
+        // Keep `global` in sync with `cmd_line.rs` so the generated shell
+        // completions offer these options after a subcommand name as well.
         .arg(
             Arg::new("CONFIG_FILE")
                 .long("config-file")
                 .short('c')
                 .help("The location of config.json")
+                .global(true)
                 .default_value(None),
         )
-        .arg(Arg::new("USER_TOKEN").long("user-token").help("The user token").default_value(None))
+        .arg(
+            Arg::new("USER_TOKEN")
+                .long("user-token")
+                .help("The user token")
+                .global(true)
+                .default_value(None),
+        )
         .arg(
             Arg::new("VERBOSE")
                 .long("verbose")
@@ -116,6 +125,7 @@ fn create_command_for_completion() -> Command {
             Arg::new("ADMIN_TOKEN")
                 .long("admin-token")
                 .help("The administration token")
+                .global(true)
                 .default_value(None)
                 .hide(true),
         )

--- a/core/src/ten_manager/src/cmd_line.rs
+++ b/core/src/ten_manager/src/cmd_line.rs
@@ -63,14 +63,26 @@ fn create_cmd() -> clap::ArgMatches {
                 .help("Print version information and check for updates")
                 .action(clap::ArgAction::SetTrue),
         )
+        // The three options below configure how tman talks to a registry, so
+        // they are needed by subcommands such as `publish`. They are marked
+        // `global` so that they are accepted after the subcommand name too
+        // (`tman publish --user-token ...`) and are listed in the subcommand's
+        // own `--help` output.
         .arg(
             Arg::new("CONFIG_FILE")
                 .long("config-file")
                 .short('c')
                 .help("The location of config.json")
+                .global(true)
                 .default_value(None),
         )
-        .arg(Arg::new("USER_TOKEN").long("user-token").help("The user token").default_value(None))
+        .arg(
+            Arg::new("USER_TOKEN")
+                .long("user-token")
+                .help("The user token")
+                .global(true)
+                .default_value(None),
+        )
         .arg(
             Arg::new("VERBOSE")
                 .long("verbose")
@@ -97,6 +109,7 @@ fn create_cmd() -> clap::ArgMatches {
             Arg::new("ADMIN_TOKEN")
                 .long("admin-token")
                 .help("The administration token")
+                .global(true)
                 .default_value(None)
                 .hide(true),
         )


### PR DESCRIPTION
## Problem

`tman publish -h` advertises no options at all, and passing the token the way
you would expect fails:

```
$ tman publish -h
Publish a package

Usage: tman publish

Options:
  -h, --help  Print help

Switch to the base directory of the TEN package you want to publish, then simply run 'tman publish' directly in that directory.

$ tman publish --user-token SECRET
error: unexpected argument '--user-token' found
```

`--user-token` is not missing — it is declared as a top-level argument in
`cmd_line.rs` and wired into `TmanConfig` in `parse_cmd()`. What is missing is
`.global(true)`, so clap only accepts it *before* the subcommand
(`tman --user-token SECRET publish`) and never lists it in a subcommand's help.
That is what #226 is reporting: from `tman publish -h` there is no way to
discover that the option exists.

## Fix

Mark the three registry-facing options `global` so clap propagates them into
subcommands: `--user-token`, `--config-file`, and (still hidden) `--admin-token`.

`parse_cmd()` is unchanged — clap propagates global values back up into the
top-level `ArgMatches` that it already reads from, so both argument orders end
up in the same `TmanConfig` field.

`cmd_completion.rs` carries a duplicated copy of the top-level command tree
(its own comment says it "should match the structure in cmd_line.rs"), so the
same three options are updated there in step; otherwise generated shell
completions would disagree with the real CLI.

## Verification

`cargo check -p ten_manager --bin tman` passes, and `rustfmt --check` is clean
on both changed files.

For the CLI behaviour I extracted the exact argument definitions from
`cmd_line.rs` and the real `publish` subcommand from `cmd_publish.rs` into a
standalone clap 4.5 harness and rendered help through the real parse path
(`try_get_matches_from(["tman", "publish", "--help"])`), toggling only
`.global(true)`:

**Before (`origin/main`)**

```
$ tman publish -h
Publish a package

Usage: tman publish

Options:
  -h, --help  Print help

$ tman publish --user-token SECRET
  error: unexpected argument '--user-token' found

$ tman --user-token SECRET publish
  OK -> parse_cmd() reads USER_TOKEN = Some("SECRET")
```

**After (this PR)**

```
$ tman publish -h
Publish a package

Usage: tman publish [OPTIONS]

Options:
  -c, --config-file <CONFIG_FILE>  The location of config.json
      --user-token <USER_TOKEN>    The user token
  -h, --help                       Print help

$ tman publish --user-token SECRET
  OK -> parse_cmd() reads USER_TOKEN = Some("SECRET")

$ tman --user-token SECRET publish
  OK -> parse_cmd() reads USER_TOKEN = Some("SECRET")
```

The pre-existing form keeps working, so this is additive. `--admin-token`
remains hidden from help as before.

I could not link the real `tman` binary locally — it needs
`libten_utils_static` from the GN/ninja C build — which is why the CLI evidence
comes from the extracted harness rather than the shipped binary. Happy to
attach output from a full build if you would like it confirmed that way.

## Notes for reviewers

- `--verbose`, `--yes` and `--tracing` have the same shape and are also rejected
  after a subcommand today. I left them alone to keep this PR scoped to #226 —
  say the word and I will include them.
- `create_command_for_completion()` in `cmd_completion.rs` is also missing the
  `--tracing` argument that `cmd_line.rs` has. That drift predates this PR, so I
  did not touch it here.

Closes #226
