### PR TITLE
feat(tts): report per-request metrics

### DIFF
--- a/ai_agents/agents/ten_packages/extension/bytedance_tts_duplex/extension.py
+++ b/ai_agents/agents/ten_packages/extension/bytedance_tts_duplex/extension.py
@@ -5,6 +5,7 @@
 #
 import asyncio
 import os
+import time
 import traceback
 from datetime import datetime
 from typing import Dict, Tuple, Union
@@ -468,6 +469,12 @@ class BytedanceTTSDuplexExtension(AsyncTTS2BaseExtension):
             if t.text.strip() != "":
                 # Billing: output characters
                 self.metrics_add_output_characters(len(t.text))
+                await self.send_tts_request_metrics(
+                    request_id=t.request_id,
+                    request_time_ms=int(time.time() * 1000),
+                    output_characters=len(t.text),
+                    request_final=t.text_input_end,
+                )
                 await self.client.send_text(t.text)
                 # after handling first non-empty message, mark flag false
                 self.is_first_message_of_request = False

--- a/ai_agents/agents/ten_packages/extension/openai_tts2_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/openai_tts2_python/extension.py
@@ -3,12 +3,12 @@
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file for more information.
 #
+from ten_ai_base import utils
 from ten_ai_base.tts2_http import (
     AsyncTTS2HttpExtension,
     AsyncTTS2HttpConfig,
     AsyncTTS2HttpClient,
 )
-from ten_ai_base import utils
 from ten_runtime import AsyncTenEnv
 
 from .config import OpenAITTSConfig

--- a/ai_agents/agents/ten_packages/extension/openai_tts2_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/openai_tts2_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "openai_tts2_python",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/openai_tts2_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/openai_tts2_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-tts2-python"
-version = "0.6.9"
+version = "0.6.10"
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.28.1",

--- a/ai_agents/agents/ten_packages/extension/rime_tts/extension.py
+++ b/ai_agents/agents/ten_packages/extension/rime_tts/extension.py
@@ -6,6 +6,7 @@
 import asyncio
 from datetime import datetime
 import os
+import time
 import traceback
 
 from ten_ai_base.helper import PCMWriter
@@ -391,6 +392,13 @@ class RimeTTSExtension(AsyncTTS2BaseExtension):
             self.sent_tts = True
             # Track character metrics
             self.metrics_add_output_characters(len(t.text))
+            if t.text:
+                await self.send_tts_request_metrics(
+                    request_id=t.request_id,
+                    request_time_ms=int(time.time() * 1000),
+                    output_characters=len(t.text),
+                    request_final=t.text_input_end,
+                )
             await self.client.send_text(t)
             if t.text_input_end:
                 self.current_request_finished = True


### PR DESCRIPTION
## Summary

- report each Bytedance duplex and Rime WebSocket text send through the common TTS request metrics API
- let OpenAI TTS inherit request reporting from the HTTP base implementation
- bump openai_tts2_python from 0.6.9 to 0.6.10

## Dependency

- Requires TEN-framework/ten_ai_base#116

## Testing

- Bytedance duplex `tests/test_params.py` (1 passed)
- Rime `tests/test_params.py` (1 passed)
- OpenAI TTS `tests/test_params.py` (8 passed)
- modified Python files compile successfully