### PR TITLE
fix: ezai asr error when a speech segment has no transcript

### DIFF
--- a/ai_agents/agents/ten_packages/extension/ezai_asr_python/recognition.py
+++ b/ai_agents/agents/ten_packages/extension/ezai_asr_python/recognition.py
@@ -72,7 +72,19 @@ class DeepgramASRRecognition:
         self.websocket = None
         self.is_started = False
         self._message_task = None
-        self.prev_result = {}
+        self.prev_result = {
+            "type": "EmptyResults",
+            "channel_index": [0],
+            "start": 0.01,
+            "duration": 0.01,
+            "is_final": False,
+            "speech_final": False,
+            "channel": {
+                "alternatives": [
+                    {"transcript": "", "confidence": 0, "words": []}
+                ]
+            },
+        }
         self.segment_start_offset = 0
 
     async def _keepalive_loop(self):
@@ -120,7 +132,9 @@ class DeepgramASRRecognition:
 
                 elif message_type == "UtteranceEnd":
                     msg_data_end = self.prev_result
-                    if not msg_data_end["is_final"]:
+                    if msg_data_end.get("type") == "EmptyResults":
+                        msg_data_end["type"] = "Results"
+                    elif not msg_data_end["is_final"]:
                         msg_data_end["is_final"] = True
                         msg_data_end["speech_final"] = True
                     else:

--- a/ai_agents/agents/ten_packages/extension/ezai_asr_python/tests/configs/property_en.json
+++ b/ai_agents/agents/ten_packages/extension/ezai_asr_python/tests/configs/property_en.json
@@ -1,7 +1,7 @@
 {
   "params": {
     "key": "${env:EZAI_API_KEY}",
-    "url": "ws://3090trainer:8000//v1/listen",
+    "url": "wss://qwlk.ezai-k8s.freeddns.org/v1/listen",
     "model": "nova-3",
     "sample_rate": 16000
   }


### PR DESCRIPTION

## Summary
<img width="500" alt="image" src="https://github.com/user-attachments/assets/98c11e06-b3ef-493f-9a0f-2e137c9a83f6" />


Maintainer report an bug in extension when a possible speech segment detected by ASR but no transcript.

Since it's easier to ignore in client-side, fixed by init `self.prev_result` to a empty item, 
when a speech segment ( `type == "SpeechStarted"`) exists but no transcript, return that empty item

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [ ] Tests added/updated
- [x] All tests pass
- [ ] Manual testing completed

## Documentation
- [ ] Documentation updated
- [ ] Examples provided if needed