### PR TITLE
fix: apply pre-flatten passes to imported subgraphs

### DIFF
--- a/core/src/ten_rust/src/graph/mod.rs
+++ b/core/src/ten_rust/src/graph/mod.rs
@@ -526,6 +526,39 @@ impl Graph {
         Ok(Some(new_graph))
     }
 
+    /// Applies the passes that must run before subgraph flattening:
+    ///
+    /// 1. Expand `names` arrays into individual `name` items.
+    /// 2. Replace selector references with the nodes they match.
+    /// 3. Convert reversed connections (`source`) to forward connections
+    ///    (`dest`).
+    ///
+    /// `flatten_subgraphs` relies on all three having already run - it expects
+    /// `name` to be `Some`, `names` to be `None`, and every node to be an
+    /// extension node. Any graph handed to it, including one imported through
+    /// `import_uri`, has to go through here first.
+    ///
+    /// Returns `Ok(None)` if none of the passes changed anything.
+    pub fn apply_pre_flatten_passes(&self) -> Result<Option<Graph>> {
+        let mut processing_graph = self;
+
+        let expanded_names_graph = processing_graph.expand_names_to_individual_items()?;
+        processing_graph = expanded_names_graph.as_ref().unwrap_or(processing_graph);
+
+        let flattened_selector_graph = processing_graph.flatten_selectors()?;
+        processing_graph = flattened_selector_graph.as_ref().unwrap_or(processing_graph);
+
+        let reversed_graph =
+            processing_graph.convert_reversed_connections_to_forward_connections()?;
+        processing_graph = reversed_graph.as_ref().unwrap_or(processing_graph);
+
+        if std::ptr::eq(processing_graph, self) {
+            return Ok(None);
+        }
+
+        Ok(Some(processing_graph.clone()))
+    }
+
     /// Convenience method for flattening a graph instance without preserving
     /// exposed info. This is the main public API for flattening graphs.
     ///
@@ -534,19 +567,9 @@ impl Graph {
     pub async fn flatten_graph(&self, current_base_dir: Option<&str>) -> Result<Option<Graph>> {
         let mut processing_graph = self;
 
-        // Step 1: Expand names arrays to individual name items
-        let expanded_names_graph = processing_graph.expand_names_to_individual_items()?;
-        processing_graph = expanded_names_graph.as_ref().unwrap_or(processing_graph);
-
-        // Step 2: Match nodes according to selector rules and replace them in
-        // connections
-        let flattened_selector_graph = processing_graph.flatten_selectors()?;
-        processing_graph = flattened_selector_graph.as_ref().unwrap_or(processing_graph);
-
-        // Step 3: Convert reversed connections to forward connections if needed
-        let reversed_graph =
-            processing_graph.convert_reversed_connections_to_forward_connections()?;
-        processing_graph = reversed_graph.as_ref().unwrap_or(processing_graph);
+        // Steps 1-3: names expansion, selector resolution, reversed connections.
+        let pre_flattened_graph = processing_graph.apply_pre_flatten_passes()?;
+        processing_graph = pre_flattened_graph.as_ref().unwrap_or(processing_graph);
 
         // Step 4: Flatten subgraphs
         let flattened = Self::flatten_subgraphs(processing_graph, current_base_dir, false)

--- a/core/src/ten_rust/src/graph/subgraph/flatten.rs
+++ b/core/src/ten_rust/src/graph/subgraph/flatten.rs
@@ -534,6 +534,15 @@ impl Graph {
         let mut new_base_dir: Option<String> = None;
         let subgraph = load_graph_from_uri(import_uri, current_base_dir, &mut new_base_dir).await?;
 
+        // `load_graph_from_uri` only deserializes the file, so an imported
+        // subgraph has not been through the pre-flatten passes yet. Run them
+        // here, otherwise `names`, selectors and reversed connections written
+        // inside the subgraph reach the flattening logic unlowered.
+        let pre_flattened_subgraph = subgraph.apply_pre_flatten_passes().map_err(|e| {
+            anyhow::anyhow!("Failed to process subgraph '{}': {}", subgraph_node.name, e)
+        })?;
+        let subgraph = pre_flattened_subgraph.unwrap_or(subgraph);
+
         Self::process_loaded_subgraph(
             subgraph_node,
             &subgraph,

--- a/core/src/ten_rust/tests/test_case/graph/subgraph.rs
+++ b/core/src/ten_rust/tests/test_case/graph/subgraph.rs
@@ -1339,4 +1339,171 @@ mod tests {
         assert_eq!(expanded_property.name, "config_b");
         assert!(expanded_property.subgraph.is_none());
     }
+
+    /// Builds a main graph whose only node imports `subgraph_path`.
+    fn main_graph_importing(subgraph_path: &str) -> Graph {
+        Graph {
+            nodes: vec![GraphNode::new_subgraph_node(
+                "sg".to_string(),
+                None,
+                GraphResource { import_uri: format!("file://{subgraph_path}") },
+            )],
+            connections: None,
+            exposed_messages: None,
+            exposed_properties: None,
+        }
+    }
+
+    /// A reversed connection (`source`) written inside an imported subgraph
+    /// must be converted to a forward connection, with the subgraph name
+    /// prefix applied, just like one written in the main graph.
+    #[tokio::test]
+    async fn test_flatten_subgraph_with_reversed_connection() {
+        let temp_dir = tempdir().unwrap();
+        let subgraph_file_path = temp_dir.path().join("subgraph_reversed.json");
+
+        // Inside the subgraph: ext_a --hello--> ext_b, written in reverse form.
+        fs::write(
+            &subgraph_file_path,
+            r#"{
+              "nodes": [
+                {"type": "extension", "name": "ext_a", "addon": "addon_a"},
+                {"type": "extension", "name": "ext_b", "addon": "addon_b"}
+              ],
+              "connections": [
+                {
+                  "extension": "ext_b",
+                  "cmd": [{"name": "hello", "source": [{"extension": "ext_a"}]}]
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        let main_graph = main_graph_importing(subgraph_file_path.to_str().unwrap());
+        let flattened = main_graph.flatten_graph(None).await.unwrap().unwrap();
+
+        let connections = flattened.connections.as_ref().unwrap();
+
+        // No reversed connection may survive flattening.
+        assert!(
+            connections
+                .iter()
+                .flat_map(|conn| conn.cmd.iter().flatten())
+                .all(|flow| flow.source.is_empty()),
+            "reversed connection inside the subgraph was not converted: {connections:?}"
+        );
+
+        // It must have become sg_ext_a --hello--> sg_ext_b.
+        let forward = connections
+            .iter()
+            .find(|conn| conn.loc.extension.as_deref() == Some("sg_ext_a"))
+            .expect("no forward connection originating from sg_ext_a");
+
+        let flow = forward
+            .cmd
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|flow| flow.name.as_deref() == Some("hello"))
+            .expect("no 'hello' cmd flow");
+
+        assert_eq!(flow.dest.len(), 1);
+        assert_eq!(flow.dest[0].loc.extension.as_deref(), Some("sg_ext_b"));
+    }
+
+    /// A `names` array written inside an imported subgraph must be expanded
+    /// into individual `name` items.
+    #[tokio::test]
+    async fn test_flatten_subgraph_with_names_array() {
+        let temp_dir = tempdir().unwrap();
+        let subgraph_file_path = temp_dir.path().join("subgraph_names.json");
+
+        fs::write(
+            &subgraph_file_path,
+            r#"{
+              "nodes": [
+                {"type": "extension", "name": "ext_a", "addon": "addon_a"},
+                {"type": "extension", "name": "ext_b", "addon": "addon_b"}
+              ],
+              "connections": [
+                {
+                  "extension": "ext_a",
+                  "cmd": [{"names": ["hello", "world"], "dest": [{"extension": "ext_b"}]}]
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        let main_graph = main_graph_importing(subgraph_file_path.to_str().unwrap());
+        let flattened = main_graph.flatten_graph(None).await.unwrap().unwrap();
+
+        let connections = flattened.connections.as_ref().unwrap();
+        let flows: Vec<_> = connections.iter().flat_map(|conn| conn.cmd.iter().flatten()).collect();
+
+        assert!(
+            flows.iter().all(|flow| flow.names.is_none()),
+            "'names' inside the subgraph was not expanded: {flows:?}"
+        );
+
+        let mut names: Vec<&str> = flows.iter().filter_map(|flow| flow.name.as_deref()).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["hello", "world"]);
+
+        for flow in &flows {
+            assert_eq!(flow.dest.len(), 1);
+            assert_eq!(flow.dest[0].loc.extension.as_deref(), Some("sg_ext_b"));
+        }
+    }
+
+    /// A selector node written inside an imported subgraph must be resolved to
+    /// the nodes it matches and removed, instead of reaching the flattening
+    /// logic and panicking as a non-extension node.
+    #[tokio::test]
+    async fn test_flatten_subgraph_with_selector() {
+        let temp_dir = tempdir().unwrap();
+        let subgraph_file_path = temp_dir.path().join("subgraph_selector.json");
+
+        fs::write(
+            &subgraph_file_path,
+            r#"{
+              "nodes": [
+                {"type": "extension", "name": "ext_a", "addon": "addon_a"},
+                {"type": "extension", "name": "ext_b", "addon": "addon_b"},
+                {
+                  "type": "selector",
+                  "name": "targets",
+                  "filter": {"field": "name", "operator": "exact", "value": "ext_b"}
+                }
+              ],
+              "connections": [
+                {
+                  "extension": "ext_a",
+                  "cmd": [{"name": "hello", "dest": [{"selector": "targets"}]}]
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        let main_graph = main_graph_importing(subgraph_file_path.to_str().unwrap());
+        let flattened = main_graph.flatten_graph(None).await.unwrap().unwrap();
+
+        // The selector node must not survive into the flattened graph.
+        assert!(flattened.nodes.iter().all(|node| node.get_type() == GraphNodeType::Extension));
+        assert_eq!(flattened.nodes.len(), 2);
+
+        let connections = flattened.connections.as_ref().unwrap();
+        let flow = connections
+            .iter()
+            .find(|conn| conn.loc.extension.as_deref() == Some("sg_ext_a"))
+            .and_then(|conn| conn.cmd.as_ref())
+            .and_then(|flows| flows.iter().find(|flow| flow.name.as_deref() == Some("hello")))
+            .expect("no 'hello' cmd flow from sg_ext_a");
+
+        assert_eq!(flow.dest.len(), 1);
+        assert_eq!(flow.dest[0].loc.extension.as_deref(), Some("sg_ext_b"));
+        assert!(flow.dest[0].loc.selector.is_none());
+    }
 }


### PR DESCRIPTION
## Problem

`Graph::flatten_graph` runs four passes over a graph:

1. `expand_names_to_individual_items` — `names: [...]` into individual `name` items
2. `flatten_selectors` — selector references into the nodes they match
3. `convert_reversed_connections_to_forward_connections` — `source` into `dest`
4. `flatten_subgraphs` — inline imported subgraphs, prefixing names with the subgraph name

Passes 1-3 were only ever applied to the top-level graph. `process_subgraph_node` loads an imported subgraph with `load_graph_from_uri`, which only deserializes the file, and hands it straight to pass 4. A subgraph that uses `names`, a `selector` node, or a reversed `source` connection therefore reaches the flattening logic unlowered, even though that logic assumes all three passes have already run.

## Reproduction

`sub.json` — inside the subgraph, `ext_a` sends `hello` to `ext_b`, written in reverse form:

```json
{
  "nodes": [
    {"type": "extension", "name": "ext_a", "addon": "addon_a"},
    {"type": "extension", "name": "ext_b", "addon": "addon_b"}
  ],
  "connections": [
    {"extension": "ext_b", "cmd": [{"name": "hello", "source": [{"extension": "ext_a"}]}]}
  ]
}
```

Main graph:

```json
{"nodes": [{"type": "subgraph", "name": "sg", "graph": {"import_uri": "file://.../sub.json"}}]}
```

Expected after flattening: `sg_ext_a --hello--> sg_ext_b`.

Actual on `main`:

```json
{
  "nodes": [
    {"type": "extension", "name": "sg_ext_a", "addon": "addon_a"},
    {"type": "extension", "name": "sg_ext_b", "addon": "addon_b"}
  ],
  "connections": [
    {"extension": "sg_ext_b", "cmd": [{"name": "hello", "source": [{"extension": "ext_a"}]}]}
  ]
}
```

The connection is still in reverse form, and its `source` still names `ext_a` while the node has been renamed to `sg_ext_a`. It now points at an extension that does not exist, and nothing reports an error.

## Impact per feature

| Written inside an imported subgraph | Result on `main` |
| --- | --- |
| `source` (reversed connection) | Silently produces a connection referencing a non-existent extension. No error, message never delivered. |
| `names: [...]` | Reaches flattening unexpanded, where `name` is expected to be `Some` and `names` to be `None`. |
| `selector` node | Panics: `Unexpected non-extension node in flattened subgraph` (`subgraph/flatten.rs:493`). |

The `selector` case is the most visible one: this code path is reachable from the tman designer HTTP backend and from the C runtime through `ten_rust_graph_validate_complete_flatten`, so a malformed-but-plausible subgraph file takes down the process instead of returning an error.

## Fix

Extract passes 1-3 into `Graph::apply_pre_flatten_passes` and run them on a subgraph immediately after it is loaded, so an imported subgraph goes through the same lowering as the top-level graph. `flatten_graph` now calls the same helper, so there is a single definition of what has to happen before flattening.

The other `load_graph_from_uri` caller (`GraphContent::validate_and_complete_and_flatten`) already reaches these passes through `flatten_graph` and needed no change.

## Tests

Three tests added to `tests/test_case/graph/subgraph.rs`, one per feature:

- `test_flatten_subgraph_with_reversed_connection`
- `test_flatten_subgraph_with_names_array`
- `test_flatten_subgraph_with_selector`

Verified they fail on `main` and pass with this change:

```
# without the fix
test test_flatten_subgraph_with_names_array ... FAILED
test test_flatten_subgraph_with_reversed_connection ... FAILED
test test_flatten_subgraph_with_selector ... FAILED     # panics at flatten.rs:493
test result: FAILED. 9 passed; 3 failed

# with the fix
test result: ok. 12 passed; 0 failed
```

The rest of the graph suite is unaffected — `graph::reverse` (14), `graph::flatten_integration` (4), `graph::names_expansion` (6), `graph::selector` (2), `graph::exposed_message` (10), `graph::graph_info` (5), `graph::import_uri` (6) all still pass.

## Possible follow-up

`validate_and_complete` is also never run on an imported subgraph, so the app-URI rules are not enforced there. I left that out of this PR because it changes which graphs are accepted rather than fixing a mis-compilation. Happy to send a separate PR if you would like that tightened too.
