### PR TITLE
feat(mcp): add stdio transport to mcp_client_python

### DIFF
--- a/ai_agents/agents/ten_packages/extension/mcp_client_python/README.md
+++ b/ai_agents/agents/ten_packages/extension/mcp_client_python/README.md
@@ -1,29 +1,55 @@
 # mcp_client_python
 
-<!-- brief introduction for the extension -->
+Connects the agent to an [MCP](https://modelcontextprotocol.io/) server and
+exposes every tool the server advertises as an LLM tool, so the LLM extension
+can call them like any other tool.
 
 ## Features
 
-<!-- main features introduction -->
+- Registers all tools reported by the MCP server through `tool_register`
+- Forwards `tool_call` to the server and returns the result to the LLM
+- Two transports:
+  - **stdio** — launches a local MCP server as a subprocess (`command`)
+  - **SSE** — connects to a remote MCP server over HTTP (`url`)
 
-- xxx feature
+## Configuration
+
+| Property  | Type   | Description |
+| --------- | ------ | ----------- |
+| `command` | string | Command line of a local MCP server, launched and spoken to over stdio. Takes precedence over `url`. |
+| `url`     | string | SSE endpoint of a remote MCP server. |
+
+One of the two is required. If neither is set, the extension logs an error and
+registers no tools.
+
+### stdio (local server)
+
+```json
+{
+  "command": "npx -y @modelcontextprotocol/server-filesystem /data"
+}
+```
+
+The command line is split with `shlex.split`, so ordinary shell quoting works:
+
+```json
+{
+  "command": "python -m my_server --root '/data/my files'"
+}
+```
+
+The server runs as a child process of the extension and is shut down together
+with it.
+
+### SSE (remote server)
+
+```json
+{
+  "url": "https://example.com/sse"
+}
+```
 
 ## API
 
-Refer to `api` definition in [manifest.json] and default values in [property.json](property.json).
-
-<!-- Additional API.md can be referred to if extra introduction needed -->
-
-## Development
-
-### Build
-
-<!-- build dependencies and steps -->
-
-### Unit test
-
-<!-- how to do unit test for the extension -->
-
-## Misc
-
-<!-- others if applicable -->
+Refer to the `api` definition in [manifest.json](manifest.json) and the
+default values in [property.json](property.json).

--- a/ai_agents/agents/ten_packages/extension/mcp_client_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/mcp_client_python/extension.py
@@ -13,9 +13,11 @@ from ten_ai_base.types import (
 )
 from ten_ai_base.llm_tool import AsyncLLMToolBaseExtension
 from dataclasses import dataclass
+import shlex
 
-from mcp import ClientSession
+from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
+from mcp.client.stdio import stdio_client
 
 CMD_TOOL_REGISTER = "tool_register"
 CMD_TOOL_CALL = "tool_call"
@@ -30,7 +32,13 @@ TOOL_CALLBACK = "callback"
 
 @dataclass
 class MCPClientConfig(BaseConfig):
+    # SSE endpoint of a remote MCP server.
     url: str = ""
+
+    # Command line of a local MCP server to launch and talk to over stdio,
+    # e.g. "npx -y @modelcontextprotocol/server-filesystem /data".
+    # Takes precedence over `url` when both are set.
+    command: str = ""
 
 
 class MCPClientExtension(AsyncLLMToolBaseExtension):
@@ -47,13 +55,47 @@ class MCPClientExtension(AsyncLLMToolBaseExtension):
     async def on_init(self, ten_env: AsyncTenEnv) -> None:
         ten_env.log_debug("on_init")
 
+    def _create_transport(self, ten_env: AsyncTenEnv):
+        """Create the MCP transport selected by the configuration.
+
+        `command` launches a local server and talks to it over stdio,
+        `url` connects to a remote server over SSE. Returns None when
+        neither is configured.
+        """
+        if self.config.command:
+            argv = shlex.split(self.config.command)
+            if not argv:
+                ten_env.log_error(
+                    "`command` is set but contains no executable"
+                )
+                return None
+
+            ten_env.log_info(f"Starting MCP server over stdio: {argv}")
+            return stdio_client(
+                StdioServerParameters(command=argv[0], args=argv[1:])
+            )
+
+        if self.config.url:
+            ten_env.log_info(
+                f"Connecting to MCP server over SSE: {self.config.url}"
+            )
+            return sse_client(url=self.config.url)
+
+        ten_env.log_error(
+            "No MCP server configured. Set `command` for a local server "
+            "over stdio, or `url` for a remote one over SSE."
+        )
+        return None
+
     async def on_start(self, ten_env: AsyncTenEnv) -> None:
         ten_env.log_debug("on_start")
 
         self.config = await MCPClientConfig.create_async(ten_env=ten_env)
         ten_env.log_info(f"config: {self.config}")
-        if self.config.url:
-            self._streams_context = sse_client(url=self.config.url)
+
+        transport = self._create_transport(ten_env)
+        if transport is not None:
+            self._streams_context = transport
             # pylint: disable=no-member
             streams = await self._streams_context.__aenter__()
             # pylint: enable=no-member

--- a/ai_agents/agents/ten_packages/extension/mcp_client_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/mcp_client_python/manifest.json
@@ -23,6 +23,9 @@
       "properties": {
         "url": {
           "type": "string"
+        },
+        "command": {
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
## Problem

`mcp_client_python` can only reach MCP servers over SSE. `on_start` calls `sse_client(url=...)` directly, so a server that speaks stdio cannot be used at all — even though stdio is how most MCP servers are distributed and run (`npx -y @modelcontextprotocol/server-filesystem /data`, `uvx some-mcp-server`, a local script).

There is also no feedback when the extension is misconfigured: with `url` empty, `on_start` skips the whole connection block and the extension registers no tools, silently.

## Change

Add a `command` property holding the command line of a local MCP server:

```json
{
  "command": "npx -y @modelcontextprotocol/server-filesystem /data"
}
```

Transport selection moves into `_create_transport`:

- `command` set → `shlex.split` it and launch through `stdio_client`
- otherwise `url` set → `sse_client` as before
- neither → log an error and register no tools

`shlex.split` means ordinary shell quoting works for paths with spaces.

Both transports yield a two-element stream tuple, so `ClientSession(*streams)` and the existing `on_stop` teardown are unchanged. SSE behaviour is untouched.

The README was still the unedited template (`- xxx feature`); it now documents both transports and the two properties.

## Verification

Against a real MCP server launched over stdio, using the same construction as `_create_transport`:

- `shlex.split` parses a quoted path correctly
- `stdio_client` yields 2 streams, so `ClientSession(*streams)` is right for this transport too
- the session initializes and `list_tools()` returns the server's tools

## Not included

Streamable HTTP is the other transport worth having, but the SDK renamed it between major versions (`streamablehttp_client` in 1.x, `streamable_http_client` in 2.0), so it needs a version compatibility decision. Happy to follow up in a separate PR once there is a preference on how this extension should pin `mcp` — the current `mcp>=1.2.1` has no upper bound and 2.0 is already out.
