### PR TITLE
fix(playground): key chat messages by sender and timestamp

### DIFF
--- a/ai_agents/playground/src/components/Chat/MessageList.tsx
+++ b/ai_agents/playground/src/components/Chat/MessageList.tsx
@@ -20,7 +20,11 @@ export default function MessageList(props: { className?: string }) {
       className={cn("grow space-y-2 overflow-y-auto p-4", className)}
     >
       {chatItems.map((item, _index) => {
-        return <MessageItem data={item} key={item.time} />;
+        // `time` alone collides: addChatItem dedupes per userId, so a user and
+        // an agent transcript stamped in the same millisecond both get pushed.
+        // Speech-to-speech makes that routine, since the final input
+        // transcription lands as the first output transcript delta arrives.
+        return <MessageItem data={item} key={`${item.userId}-${item.time}`} />;
       })}
     </div>
   );


### PR DESCRIPTION
## Problem

The chat list throws a React key collision during normal conversation:

```
Encountered two children with the same key, `1785829362590`.
Keys should be unique so that components maintain their identity across updates.
Non-unique keys may cause children to be duplicated and/or omitted.
```

The key is a millisecond timestamp, so this is not purely cosmetic — React warns that colliding keys can drop or duplicate rendered children, meaning chat lines can visibly disappear or repeat.

## Root cause

`MessageList` keys each row by `item.time` alone:

```tsx
return <MessageItem data={item} key={item.time} />;
```

`item.time` is `text_ts`, stamped with `int(time.time() * 1000)` when the transcript is sent, and `item.userId` is the sender's `stream_id`. The `addChatItem` reducer scopes both its discard and its replace branches to a single `userId`:

```ts
const LastFinalIndex = state.chatItems.findLastIndex(
  (el) => el.userId === userId && el.isFinal
);
```

So two transcripts from *different* senders that share a millisecond are both pushed, and the list renders two children with the same key.

Two transcripts from the *same* sender can never collide — the reducer either discards the later one (`time <= LastFinalItem.time`) or replaces the pending non-final item.

Speech-to-speech graphs make the cross-sender collision routine rather than rare: the final input transcription is emitted as the first output transcript delta arrives, and the two are sent with different `stream_id`s.

## Fix

Key by sender and timestamp together, which is unique by the argument above.

## Verification

Reproduced by replaying the reducer with a user transcript (`stream_id` from session metadata) and an agent transcript (`stream_id` 100) sharing one millisecond — two items, one key. With the composite key both rows are unique, and the same-sender case still collapses to a single item, so no row is lost.

Confirmed against a running `voice_assistant_realtime` graph: the warning fired twice during ordinary conversation before the change and does not appear after it.