### PR TITLE
docs: add version bump and guarder evidence to extension pr checklist

### DIFF
--- a/docs/ai/L1/L2/extension_development.md
+++ b/docs/ai/L1/L2/extension_development.md
@@ -769,6 +769,12 @@ class MyBridge(AsyncExtension):
 
 ## Pre-Submission Checklist
 
+- [ ] Version bumped in BOTH `manifest.json` and `pyproject.toml` — any
+      change to an existing extension needs at least a patch bump;
+      reviewers request this on every PR that misses it
+- [ ] Guarder test result attached to the PR as a comment (screenshot
+      or pasted terminal output of the final pytest summary) —
+      reviewers ask for this on every ASR/TTS extension PR
 - [ ] `addon.py` decorator name matches `manifest.json` `name` field
 - [ ] All abstract methods implemented (vendor, request_tts/send_audio, etc.)
 - [ ] Config validation raises ValueError for missing required params

--- a/docs/ai/L1/L2/extension_development.md
+++ b/docs/ai/L1/L2/extension_development.md
@@ -772,9 +772,10 @@ class MyBridge(AsyncExtension):
 - [ ] Version bumped in BOTH `manifest.json` and `pyproject.toml` — any
       change to an existing extension needs at least a patch bump;
       reviewers request this on every PR that misses it
-- [ ] Guarder test result attached to the PR as a comment (screenshot
-      or pasted terminal output of the final pytest summary) —
-      reviewers ask for this on every ASR/TTS extension PR
+- [ ] Screenshot of the guarder test result attached as a PR comment
+      (run with `-v` so per-test results are visible; an image is what
+      reviewers expect, not just pasted text) — requested on every
+      ASR/TTS extension PR
 - [ ] `addon.py` decorator name matches `manifest.json` `name` field
 - [ ] All abstract methods implemented (vendor, request_tts/send_audio, etc.)
 - [ ] Config validation raises ValueError for missing required params

--- a/docs/ai/L1/L2/testing.md
+++ b/docs/ai/L1/L2/testing.md
@@ -215,6 +215,27 @@ checks `ENABLE_SAMPLE_RATE` env var. Extensions like `openai_tts_python`,
 - If a vendor does not expose that data, document the gap clearly and treat
   `test_subtitle_alignment` as out of scope rather than forcing fake support.
 
+### Interpreting Skips: What a Full Pass Looks Like
+
+For an HTTP-based TTS extension, `15 passed, 2 skipped` IS the full pass —
+the two skips are guarder-side conditions on whole classes of extensions,
+not gaps in the change under review:
+
+- `test_connection_status` only runs for websocket TTS extensions (and only
+  when explicitly enabled); HTTP extensions have no connection state machine
+  to test.
+- `test_subtitle_alignment` is disabled by default for all extensions
+  (`--enable_subtitle_alignment=True` to run) and restricted to vendors that
+  return per-word timing.
+
+When posting guarder evidence on a PR, run with `-v` so the per-test
+PASSED/SKIPPED lines are visible, and expect to explain skips in exactly
+these terms if a reviewer asks.
+
+MLLM (speech-to-speech) extensions have no guarder suite — only
+`asr_guarder` and `tts_guarder` exist. For MLLM PRs, provide the standalone
+pytest suite result plus a note on live-service verification instead.
+
 ---
 
 ## ASR Guarder Tests (10 Tests, 1 Excluded by Test Runner)


### PR DESCRIPTION
Two items reviewers consistently request on ASR/TTS extension PRs but the pre-submission checklist omits:

- bump the version in **both** `manifest.json` and `pyproject.toml` for any change to an existing extension
- attach the guarder test result (screenshot or pasted summary) as a PR comment

Adding them at the top of the checklist in `docs/ai/L1/L2/extension_development.md` so agents and contributors stop rediscovering this via review feedback.