### PR TITLE
ci: pass the release tag through env in the docs-sync dispatch

### DIFF
--- a/.github/workflows/trigger_sync_remote_docs.yml
+++ b/.github/workflows/trigger_sync_remote_docs.yml
@@ -11,12 +11,17 @@ on:
         type: string
         default: "latest"
 
+permissions:
+  contents: read
+
 jobs:
   trigger_sync_remote_docs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger remote workflow_dispatch
         uses: actions/github-script@v8
+        env:
+          TARGET_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
         with:
           github-token: ${{ secrets.TEN_FRAMEWORK_PORTAL_ACTION_PAT }} # need repo + workflow permissions
           script: |
@@ -26,6 +31,6 @@ jobs:
               workflow_id: 'sync-remote-docs.yml', // target workflow
               ref: 'main', // branch
               inputs: {
-                target_tag: '${{ github.event.release.tag_name || github.event.inputs.tag_name }}' // workflow_dispatch.inputs.target_tag
+                target_tag: process.env.TARGET_TAG // workflow_dispatch.inputs.target_tag
               }
             });


### PR DESCRIPTION
### What

`.github/workflows/trigger_sync_remote_docs.yml` interpolates the release tag directly into an `actions/github-script` body:

```js
target_tag: '${{ github.event.release.tag_name || github.event.inputs.tag_name }}'
```

The `script:` block is JavaScript source, and `${{ ... }}` is substituted as **text before the script is parsed** — it is not a runtime variable. A tag name containing a single quote closes the string literal and everything after it is evaluated as JavaScript.

A tag such as:

```
v1.0'});console.log(process.env);//
```

ends the call and runs attacker-chosen code in the step.

### Why it matters here

This particular step carries `TEN_FRAMEWORK_PORTAL_ACTION_PAT` — a token with repo + workflow permissions on `TEN-framework/portal`. Code execution in this step reaches that token, so the blast radius extends to a second repository.

To be clear about severity: both triggers (`release: created` and `workflow_dispatch`) require write access, so this is **defense in depth rather than an externally reachable vulnerability**. It matters because it removes a path from "can push a tag" to "controls the portal PAT" — a meaningful step up in privilege, and one that release automation or a compromised maintainer account could take.

### The fix

Pass the value through `env:` and read it with `process.env.TARGET_TAG`. The environment variable is only ever data, never source text. Behaviour is unchanged.

Also adds `permissions: contents: read`, which the file had never declared — the job only needs to dispatch through the PAT, not to use the default `GITHUB_TOKEN`.

### Verification

The workflow parses cleanly, and the `env` block resolves as expected. The diff is three lines plus the permissions block; no logic changed.

### AI assistance

I used an AI coding agent to sweep release workflows for this pattern and to draft this description. What I traced in the file myself, rather than accepted from a model: that the interpolated step is the one carrying `TEN_FRAMEWORK_PORTAL_ACTION_PAT`, and that its dispatch targets `TEN-framework/portal` — which is why I described the blast radius as reaching a second repository. I did not inspect the PAT's actual scopes, since I cannot see them; if they are narrower than the workflow implies, the severity note above is correspondingly weaker and I would rather you correct me than take it at face value.
