### PR TITLE
feat(demo): add OrcaRouter as a named LLM provider in the demo app

### DIFF
--- a/ai_agents/agents/examples/demo/README.md
+++ b/ai_agents/agents/examples/demo/README.md
@@ -7,7 +7,7 @@ Comprehensive demo showcasing TEN Framework's AI agent capabilities with multipl
 ## Features
 
 - **Multiple AI Agent Types**: Support for different AI agent configurations
-  - **Voice AI (STT + LLM + TTS)**: OpenAI GPT 5, Llama 4, Qwen 3 Reasoning
+  - **Voice AI (STT + LLM + TTS)**: OpenAI GPT 5, Llama 4, Qwen 3 Reasoning, OrcaRouter
   - **Speech to Speech Voice AI**: OpenAI GPT Realtime, OpenAI GPT Realtime 1.5, Gemini 2.0/2.5 Flash, Azure Voice AI API
   - **AI Platform Integrations**: OceanBase PowerRAG, Dify Agent, Coze Bot
 - **Multi-language Support**: English, Chinese, Korean, Japanese
@@ -37,6 +37,7 @@ Comprehensive demo showcasing TEN Framework's AI agent capabilities with multipl
    - `GROQ_CLOUD_API_KEY` - For Llama 4 agent
    - `QWEN_API_KEY` - For Qwen 3 agent
    - `DEEPSEEK_API_KEY` - For DeepSeek V3.1 agent
+   - `ORCAROUTER_API_KEY` - For OrcaRouter agent
    - `GEMINI_API_KEY` - For Gemini 2.0/2.5 agents
    - `AZURE_AI_FOUNDRY_API_KEY` - For Azure Voice AI agent
    - `AZURE_AI_FOUNDRY_BASE_URI` - For Azure Voice AI agent
@@ -79,6 +80,7 @@ GROK_API_KEY=your_grok_api_key_here
 GROQ_CLOUD_API_KEY=your_groq_api_key_here
 QWEN_API_KEY=your_qwen_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
+ORCAROUTER_API_KEY=your_orcarouter_api_key_here
 GEMINI_API_KEY=your_gemini_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 
@@ -197,6 +199,7 @@ The demo is configured in `property.json`:
 | `GROQ_CLOUD_API_KEY` | string | - | Groq API key (required for Llama agent) |
 | `QWEN_API_KEY` | string | - | Qwen API key (required for Qwen agent) |
 | `DEEPSEEK_API_KEY` | string | - | DeepSeek API key (required for DeepSeek agent) |
+| `ORCAROUTER_API_KEY` | string | - | OrcaRouter API key (required for OrcaRouter agent) |
 | `GEMINI_API_KEY` | string | - | Gemini API key (required for Gemini agents) |
 | `OPENAI_API_KEY` | string | - | OpenAI API key (required for OpenAI agents) |
 | `COZE_TOKEN` | string | - | Coze token (required for Coze agent) |

--- a/ai_agents/agents/examples/demo/frontend/src/app/api/agents/start/graph.ts
+++ b/ai_agents/agents/examples/demo/frontend/src/app/api/agents/start/graph.ts
@@ -408,6 +408,31 @@ export const getGraphProperties = (
         },
       },
     };
+  } else if (graphName === "orcarouter") {
+    return {
+      stt: {
+        params: {
+          language: language,
+        },
+      },
+      llm: {
+        prompt: prompt,
+        model: "orcarouter/fusion",
+      },
+      main_control: {
+        greeting: combined_greeting,
+      },
+      tts: {
+        params: {
+          propertys: [
+            [
+              "SpeechServiceConnection_SynthVoice",
+              voiceNameMap[language].azure[voiceType],
+            ],
+          ],
+        },
+      },
+    };
   } else if (graphName === "minimax") {
     const resolvedMinimaxPrompt = prompt?.trim()
       ? prompt

--- a/ai_agents/agents/examples/demo/frontend/src/common/constant.ts
+++ b/ai_agents/agents/examples/demo/frontend/src/common/constant.ts
@@ -95,6 +95,10 @@ export const GROUPED_GRAPH_OPTIONS = {
       label: "Qwen 3 Reasoning",
       value: "qwen3",
     },
+    {
+      label: "OrcaRouter",
+      value: "orcarouter",
+    },
     // {
     //   label: "Grok 4 Reasoning",
     //   value: "grok4",

--- a/ai_agents/agents/examples/demo/frontend/src/components/Chat/ChatCfgSelect.tsx
+++ b/ai_agents/agents/examples/demo/frontend/src/components/Chat/ChatCfgSelect.tsx
@@ -16,6 +16,7 @@ import {
   NovaIcon,
   OceanBaseIcon,
   OpenAIIcon,
+  OrcaRouterIcon,
   QwenIcon,
   XAIIcon,
   MinimaxIcon,
@@ -42,6 +43,7 @@ const getBrandIcon = (label: string) => {
   if (label.includes("Grok")) return XAIIcon;
   if (label.includes("Qwen") || label.includes("QwQ")) return QwenIcon;
   if (label.includes("Minimax")) return MinimaxIcon;
+  if (label.includes("OrcaRouter")) return OrcaRouterIcon;
   if (label.includes("Dify")) return DifyIcon;
   if (label.includes("Coze")) return CozeIcon;
   if (label.includes("OceanBase")) return OceanBaseIcon;

--- a/ai_agents/agents/examples/demo/frontend/src/components/Icon/index.tsx
+++ b/ai_agents/agents/examples/demo/frontend/src/components/Icon/index.tsx
@@ -798,6 +798,24 @@ export const DeepSeekIcon = (props: React.SVGProps<SVGSVGElement>) => {
   );
 };
 
+export const OrcaRouterIcon = (props: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      fill="currentColor"
+      fillRule="evenodd"
+      height="1em"
+      style={{ flex: "none", lineHeight: 1 }}
+      viewBox="0 0 24 24"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <title>OrcaRouter</title>
+      <path d="M12 2c-3.5 0-6 1.6-7.2 4.1-.4.8-.6 1.6-.7 2.6C3.1 9.7 2 11.4 2 13.6c0 2.8 1.5 5 3.6 6.2.8.5 1.7.8 2.7 1 .3.1.5-.2.5-.5v-2.1c0-1.9.9-3.2 3.2-3.2s3.2 1.3 3.2 3.2V20.3c0 .3.2.5.5.5 1-.2 1.9-.5 2.7-1 2.1-1.2 3.6-3.4 3.6-6.2 0-2.2-1.1-3.9-2.1-4.9-.1-1-.3-1.8-.7-2.6C18 3.6 15.5 2 12 2zm0 5.1c.5 0 .9.4.9.9s-.4.9-.9.9-.9-.4-.9-.9.4-.9.9-.9zm-2.6.7c.5 0 .9.4.9.9s-.4.9-.9.9-.9-.4-.9-.9.4-.9.9-.9zm5.2 0c.5 0 .9.4.9.9s-.4.9-.9.9-.9-.4-.9-.9.4-.9.9-.9z" />
+    </svg>
+  );
+};
+
 export const XAIIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/ai_agents/agents/examples/demo/tenapp/property.json
+++ b/ai_agents/agents/examples/demo/tenapp/property.json
@@ -582,6 +582,199 @@
         }
       },
       {
+        "name": "orcarouter",
+        "auto_start": true,
+        "graph": {
+          "nodes": [
+            {
+              "type": "extension",
+              "name": "agora_rtc",
+              "addon": "agora_rtc",
+              "extension_group": "default",
+              "property": {
+                "app_id": "${env:AGORA_APP_ID}",
+                "app_certificate": "${env:AGORA_APP_CERTIFICATE|}",
+                "channel": "ten_agent_test",
+                "stream_id": 1234,
+                "remote_stream_id": 123,
+                "subscribe_audio": true,
+                "publish_audio": true,
+                "publish_data": true,
+                "enable_agora_asr": false,
+                "agora_asr_vendor_name": "microsoft",
+                "agora_asr_language": "en-US",
+                "agora_asr_vendor_key": "${env:AZURE_STT_KEY|}",
+                "agora_asr_vendor_region": "${env:AZURE_STT_REGION|}",
+                "agora_asr_session_control_file_path": "session_control.conf"
+              }
+            },
+            {
+              "type": "extension",
+              "name": "stt",
+              "addon": "azure_asr_python",
+              "extension_group": "stt",
+              "property": {
+                "params": {
+                  "key": "${env:AZURE_STT_KEY}",
+                  "region": "${env:AZURE_STT_REGION}"
+                }
+              }
+            },
+            {
+              "type": "extension",
+              "name": "llm",
+              "addon": "openai_llm2_python",
+              "extension_group": "chatgpt",
+              "property": {
+                "api_key": "${env:ORCAROUTER_API_KEY}",
+                "base_url": "https://api.orcarouter.ai/v1",
+                "frequency_penalty": 0.9,
+                "max_tokens": 512,
+                "model": "orcarouter/fusion",
+                "prompt": ""
+              }
+            },
+            {
+              "type": "extension",
+              "name": "tts",
+              "addon": "azure_tts_python",
+              "extension_group": "tts",
+              "property": {
+                "params": {
+                  "subscription": "${env:AZURE_TTS_API_KEY}",
+                  "region": "${env:AZURE_TTS_REGION}",
+                  "speech_recognition_language": "en-US",
+                  "output_format": "Raw16Khz16BitMonoPcm",
+                  "propertys": [
+                    [
+                      "Speech_LogFilename",
+                      "azure_tts_log.txt"
+                    ],
+                    [
+                      "SpeechServiceConnection_SynthVoice",
+                      "en-US-AriaNeural"
+                    ]
+                  ]
+                }
+              }
+            },
+            {
+              "type": "extension",
+              "name": "main_control",
+              "addon": "main_cascade_python",
+              "extension_group": "control",
+              "property": {
+                "greeting": "TEN Agent connected. How can I help you today?"
+              }
+            },
+            {
+              "type": "extension",
+              "name": "message_collector",
+              "addon": "message_collector2",
+              "extension_group": "transcriber",
+              "property": {}
+            },
+            {
+              "type": "extension",
+              "name": "weatherapi_tool_python",
+              "addon": "weatherapi_tool_python",
+              "extension_group": "default",
+              "property": {
+                "api_key": "${env:WEATHERAPI_API_KEY|}"
+              }
+            },
+            {
+              "type": "extension",
+              "name": "streamid_adapter",
+              "addon": "streamid_adapter",
+              "property": {}
+            }
+          ],
+          "connections": [
+            {
+              "extension": "main_control",
+              "cmd": [
+                {
+                  "names": [
+                    "on_user_joined",
+                    "on_user_left"
+                  ],
+                  "source": [
+                    {
+                      "extension": "agora_rtc"
+                    }
+                  ]
+                },
+                {
+                  "names": [
+                    "tool_register"
+                  ],
+                  "source": [
+                    {
+                      "extension": "weatherapi_tool_python"
+                    }
+                  ]
+                }
+              ],
+              "data": [
+                {
+                  "name": "asr_result",
+                  "source": [
+                    {
+                      "extension": "stt"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "extension": "agora_rtc",
+              "audio_frame": [
+                {
+                  "name": "pcm_frame",
+                  "dest": [
+                    {
+                      "extension": "streamid_adapter"
+                    }
+                  ]
+                },
+                {
+                  "name": "pcm_frame",
+                  "source": [
+                    {
+                      "extension": "tts"
+                    }
+                  ]
+                }
+              ],
+              "data": [
+                {
+                  "name": "data",
+                  "source": [
+                    {
+                      "extension": "message_collector"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "extension": "streamid_adapter",
+              "audio_frame": [
+                {
+                  "name": "pcm_frame",
+                  "dest": [
+                    {
+                      "extension": "stt"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
         "name": "minimax",
         "auto_start": true,
         "graph": {


### PR DESCRIPTION
Add OrcaRouter as a named LLM provider in the Agent Demo, mirroring how the existing Llama 4 (Groq) and Qwen 3 options wire an OpenAI-compatible endpoint into `openai_llm2_python`.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means TEN users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Changes:
- Add an `orcarouter` predefined graph (`base_url: https://api.orcarouter.ai/v1`, model `orcarouter/fusion`) to the demo `property.json`
- Expose it as a selectable option in the demo frontend graph dropdown with an OrcaRouter icon
- Document `ORCAROUTER_API_KEY` in the demo README

Verification:
- `next build` (compiles + type-checks) passes for the demo frontend
- Live-tested `https://api.orcarouter.ai/v1/chat/completions` with model `orcarouter/fusion` (stream + non-stream) → HTTP 200 with valid content
- `property.json` validated as JSON

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
