### PR TITLE
fix(designer): confine file-content API to loaded project roots

### DIFF
--- a/core/src/ten_manager/src/designer/file_content/mod.rs
+++ b/core/src/ten_manager/src/designer/file_content/mod.rs
@@ -4,7 +4,11 @@
 // Licensed under the Apache License, Version 2.0, with certain conditions.
 // Refer to the "LICENSE" file in the root directory for more information.
 //
-use std::{fs, path::Path, sync::Arc};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use actix_web::{web, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
@@ -13,6 +17,34 @@ use super::{
     response::{ApiResponse, Status},
     DesignerState,
 };
+
+/// Canonicalizes `path` and checks that the result is contained within one
+/// of the canonicalized `allowed_roots`. This confines the file-content API
+/// to the directories of apps that are actually loaded, so a client cannot
+/// escape via an absolute path or a `..` traversal.
+fn ensure_within_allowed_roots(path: &Path, allowed_roots: &[String]) -> Result<PathBuf, String> {
+    if allowed_roots.is_empty() {
+        return Err("No project root is currently loaded, so no file path can be validated."
+            .to_string());
+    }
+
+    let canonical_path = fs::canonicalize(path)
+        .map_err(|e| format!("Failed to resolve path {}: {}", path.display(), e))?;
+
+    let is_allowed = allowed_roots
+        .iter()
+        .filter_map(|root| fs::canonicalize(root).ok())
+        .any(|canonical_root| canonical_path.starts_with(&canonical_root));
+
+    if is_allowed {
+        Ok(canonical_path)
+    } else {
+        Err(format!(
+            "Path {} is outside of any loaded project root.",
+            canonical_path.display()
+        ))
+    }
+}
 
 #[derive(Deserialize)]
 pub struct GetFileContentRequestPayload {
@@ -30,7 +62,24 @@ pub async fn get_file_content_endpoint(
 ) -> Result<impl Responder, actix_web::Error> {
     let file_path = request_payload.file_path.clone();
 
-    match fs::read_to_string(&file_path) {
+    let allowed_roots: Vec<String> = state.pkgs_cache.read().await.keys().cloned().collect();
+
+    let validated_path = match ensure_within_allowed_roots(Path::new(&file_path), &allowed_roots) {
+        Ok(path) => path,
+        Err(err) => {
+            state.out.error_line(&format!("Rejected file read at path {file_path}: {err}"));
+
+            let response = ApiResponse {
+                status: Status::Fail,
+                data: (),
+                meta: None,
+            };
+
+            return Ok(HttpResponse::Forbidden().json(response));
+        }
+    };
+
+    match fs::read_to_string(&validated_path) {
         Ok(content) => {
             let response = ApiResponse {
                 status: Status::Ok,
@@ -89,7 +138,41 @@ pub async fn save_file_content_endpoint(
         }
     }
 
-    match fs::write(file_path, content) {
+    // The target file itself may not exist yet (e.g. a new file being
+    // saved for the first time), so canonicalize its now-created parent
+    // directory instead and confine the write to a loaded project root.
+    let allowed_roots: Vec<String> = state.pkgs_cache.read().await.keys().cloned().collect();
+    let parent = file_path.parent().unwrap_or_else(|| Path::new("."));
+
+    let validated_path = match ensure_within_allowed_roots(parent, &allowed_roots) {
+        Ok(canonical_parent) => match file_path.file_name() {
+            Some(file_name) => canonical_parent.join(file_name),
+            None => {
+                state.out.error_line(&format!("Invalid file path: {file_path_str}"));
+
+                let response = ApiResponse {
+                    status: Status::Fail,
+                    data: (),
+                    meta: None,
+                };
+
+                return Ok(HttpResponse::BadRequest().json(response));
+            }
+        },
+        Err(err) => {
+            state.out.error_line(&format!("Rejected file write at path {file_path_str}: {err}"));
+
+            let response = ApiResponse {
+                status: Status::Fail,
+                data: (),
+                meta: None,
+            };
+
+            return Ok(HttpResponse::Forbidden().json(response));
+        }
+    };
+
+    match fs::write(&validated_path, content) {
         Ok(_) => {
             let response = ApiResponse {
                 status: Status::Ok,
@@ -101,7 +184,7 @@ pub async fn save_file_content_endpoint(
         Err(err) => {
             state.out.error_line(&format!(
                 "Error writing file at path {}: {}",
-                file_path.display(),
+                validated_path.display(),
                 err
             ));
 

--- a/core/src/ten_manager/src/designer/file_content/mod.rs
+++ b/core/src/ten_manager/src/designer/file_content/mod.rs
@@ -5,6 +5,7 @@
 // Refer to the "LICENSE" file in the root directory for more information.
 //
 use std::{
+    ffi::OsString,
     fs,
     path::{Path, PathBuf},
     sync::Arc,
@@ -18,31 +19,97 @@ use super::{
     DesignerState,
 };
 
+/// Checks that the already-canonicalized `candidate` is contained within
+/// one of the canonicalized `allowed_roots`.
+fn is_within_allowed_roots(candidate: &Path, allowed_roots: &[String]) -> bool {
+    allowed_roots
+        .iter()
+        .filter_map(|root| fs::canonicalize(root).ok())
+        .any(|canonical_root| candidate.starts_with(&canonical_root))
+}
+
+/// Why [`ensure_within_allowed_roots`] rejected a path.
+enum PathRejection {
+    /// `fs::canonicalize` failed outright, most commonly because nothing
+    /// exists at `path` (a typo'd path, or a file removed after being
+    /// listed). Not a confinement violation.
+    Unresolvable(String),
+    /// The path resolves, but outside of every loaded project root.
+    OutsideAllowedRoots(String),
+}
+
 /// Canonicalizes `path` and checks that the result is contained within one
 /// of the canonicalized `allowed_roots`. This confines the file-content API
 /// to the directories of apps that are actually loaded, so a client cannot
 /// escape via an absolute path or a `..` traversal.
-fn ensure_within_allowed_roots(path: &Path, allowed_roots: &[String]) -> Result<PathBuf, String> {
+fn ensure_within_allowed_roots(
+    path: &Path,
+    allowed_roots: &[String],
+) -> Result<PathBuf, PathRejection> {
+    if allowed_roots.is_empty() {
+        return Err(PathRejection::OutsideAllowedRoots(
+            "No project root is currently loaded, so no file path can be validated.".to_string(),
+        ));
+    }
+
+    let canonical_path = fs::canonicalize(path).map_err(|e| {
+        PathRejection::Unresolvable(format!("Failed to resolve path {}: {}", path.display(), e))
+    })?;
+
+    if is_within_allowed_roots(&canonical_path, allowed_roots) {
+        Ok(canonical_path)
+    } else {
+        Err(PathRejection::OutsideAllowedRoots(format!(
+            "Path {} is outside of any loaded project root.",
+            canonical_path.display()
+        )))
+    }
+}
+
+/// Resolves `path` (which may not exist yet, e.g. the not-yet-created
+/// parent directory of a new file) to what its canonical form will be, and
+/// checks that it is contained within one of `allowed_roots`, without
+/// creating anything on disk. Walks up to the nearest existing ancestor,
+/// canonicalizes that (so any symlinks already on disk are resolved), then
+/// re-applies the remaining, not-yet-created path components on top of it.
+///
+/// This must run before `fs::create_dir_all`, not after: that call
+/// re-resolves any `..` left in its argument against the directories it
+/// creates along the way, so a crafted path (e.g. `a/b/../../../etc`, where
+/// only `a` exists and is an allowed root) can make it create directories
+/// outside of every loaded root even though the final target is correctly
+/// rejected afterwards.
+fn resolve_prospective_path(path: &Path, allowed_roots: &[String]) -> Result<PathBuf, String> {
     if allowed_roots.is_empty() {
         return Err("No project root is currently loaded, so no file path can be validated."
             .to_string());
     }
 
-    let canonical_path = fs::canonicalize(path)
+    let mut existing_ancestor = path;
+    let mut pending_components: Vec<OsString> = Vec::new();
+    while !existing_ancestor.exists() {
+        match existing_ancestor.file_name() {
+            Some(name) => pending_components.push(name.to_os_string()),
+            // A `..`/`.` component (or an empty path) with no existing
+            // ancestor left to resolve it against; `fs::canonicalize` below
+            // will fail on it, which is the correct outcome.
+            None => break,
+        }
+        existing_ancestor = existing_ancestor.parent().unwrap_or_else(|| Path::new(""));
+    }
+
+    let canonical_ancestor = fs::canonicalize(existing_ancestor)
         .map_err(|e| format!("Failed to resolve path {}: {}", path.display(), e))?;
 
-    let is_allowed = allowed_roots
-        .iter()
-        .filter_map(|root| fs::canonicalize(root).ok())
-        .any(|canonical_root| canonical_path.starts_with(&canonical_root));
+    let mut prospective_path = canonical_ancestor;
+    for name in pending_components.into_iter().rev() {
+        prospective_path.push(name);
+    }
 
-    if is_allowed {
-        Ok(canonical_path)
+    if is_within_allowed_roots(&prospective_path, allowed_roots) {
+        Ok(prospective_path)
     } else {
-        Err(format!(
-            "Path {} is outside of any loaded project root.",
-            canonical_path.display()
-        ))
+        Err(format!("Path {} is outside of any loaded project root.", prospective_path.display()))
     }
 }
 
@@ -66,7 +133,22 @@ pub async fn get_file_content_endpoint(
 
     let validated_path = match ensure_within_allowed_roots(Path::new(&file_path), &allowed_roots) {
         Ok(path) => path,
-        Err(err) => {
+        Err(PathRejection::Unresolvable(err)) => {
+            // Not a confinement violation (e.g. a typo'd path, or a file
+            // deleted between listing and opening): preserve the prior
+            // 400 Bad Request behavior instead of looking like a security
+            // rejection.
+            state.out.error_line(&format!("Error reading file at path {file_path}: {err}"));
+
+            let response = ApiResponse {
+                status: Status::Fail,
+                data: (),
+                meta: None,
+            };
+
+            return Ok(HttpResponse::BadRequest().json(response));
+        }
+        Err(PathRejection::OutsideAllowedRoots(err)) => {
             state.out.error_line(&format!("Rejected file read at path {file_path}: {err}"));
 
             let response = ApiResponse {
@@ -119,46 +201,17 @@ pub async fn save_file_content_endpoint(
 
     let file_path = Path::new(&file_path_str);
 
-    // Attempt to create parent directories if they don't exist.
-    if let Some(parent) = file_path.parent() {
-        if let Err(e) = fs::create_dir_all(parent) {
-            state.out.error_line(&format!(
-                "Error creating directories for {}: {}",
-                parent.display(),
-                e
-            ));
-
-            let response = ApiResponse {
-                status: Status::Fail,
-                data: (),
-                meta: None,
-            };
-
-            return Ok(HttpResponse::BadRequest().json(response));
-        }
-    }
-
     // The target file itself may not exist yet (e.g. a new file being
-    // saved for the first time), so canonicalize its now-created parent
-    // directory instead and confine the write to a loaded project root.
+    // saved for the first time), and its parent directories may not exist
+    // either. Resolve and confine the prospective parent to a loaded
+    // project root BEFORE creating any directories: `fs::create_dir_all`
+    // must never run on an unvalidated, attacker-supplied path (see
+    // `resolve_prospective_path`).
     let allowed_roots: Vec<String> = state.pkgs_cache.read().await.keys().cloned().collect();
     let parent = file_path.parent().unwrap_or_else(|| Path::new("."));
 
-    let validated_path = match ensure_within_allowed_roots(parent, &allowed_roots) {
-        Ok(canonical_parent) => match file_path.file_name() {
-            Some(file_name) => canonical_parent.join(file_name),
-            None => {
-                state.out.error_line(&format!("Invalid file path: {file_path_str}"));
-
-                let response = ApiResponse {
-                    status: Status::Fail,
-                    data: (),
-                    meta: None,
-                };
-
-                return Ok(HttpResponse::BadRequest().json(response));
-            }
-        },
+    let canonical_parent = match resolve_prospective_path(parent, &allowed_roots) {
+        Ok(path) => path,
         Err(err) => {
             state.out.error_line(&format!("Rejected file write at path {file_path_str}: {err}"));
 
@@ -169,6 +222,37 @@ pub async fn save_file_content_endpoint(
             };
 
             return Ok(HttpResponse::Forbidden().json(response));
+        }
+    };
+
+    if let Err(e) = fs::create_dir_all(&canonical_parent) {
+        state.out.error_line(&format!(
+            "Error creating directories for {}: {}",
+            canonical_parent.display(),
+            e
+        ));
+
+        let response = ApiResponse {
+            status: Status::Fail,
+            data: (),
+            meta: None,
+        };
+
+        return Ok(HttpResponse::BadRequest().json(response));
+    }
+
+    let validated_path = match file_path.file_name() {
+        Some(file_name) => canonical_parent.join(file_name),
+        None => {
+            state.out.error_line(&format!("Invalid file path: {file_path_str}"));
+
+            let response = ApiResponse {
+                status: Status::Fail,
+                data: (),
+                meta: None,
+            };
+
+            return Ok(HttpResponse::BadRequest().json(response));
         }
     };
 

--- a/core/src/ten_manager/tests/test_case/designer/file_content/mod.rs
+++ b/core/src/ten_manager/tests/test_case/designer/file_content/mod.rs
@@ -148,6 +148,34 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn test_get_file_content_missing_file_in_root_is_bad_request() {
+        let root = tempdir().unwrap();
+
+        // A path inside a loaded root, but nothing exists there (e.g. a
+        // typo'd path, or a file removed between listing and opening).
+        // This must be a 400, not a 403: it isn't a confinement violation.
+        let file_path = root.path().join("does-not-exist.txt");
+
+        let state = build_state(vec![root.path().to_string_lossy().to_string()]);
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/api/designer/v1/file-content",
+            web::post().to(get_file_content_endpoint),
+        ))
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/api/designer/v1/file-content")
+            .set_json(GetFileContentRequestPayload {
+                file_path: file_path.to_string_lossy().to_string(),
+            })
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
     async fn test_get_file_content_with_no_loaded_root_is_rejected() {
         let root = tempdir().unwrap();
         let file_path = root.path().join("inside.txt");
@@ -257,5 +285,39 @@ mod tests {
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
         assert!(fs::metadata(&target_path).is_err());
+    }
+
+    #[actix_web::test]
+    async fn test_save_file_content_outside_root_with_nonexistent_parent_chain_is_rejected() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+
+        // Unlike `test_save_file_content_outside_root_is_rejected`, none of
+        // `outside`'s `a/b/c` subdirectories exist yet, so a validation
+        // that only runs after `fs::create_dir_all` would let that call
+        // create them outside of every loaded root before the write
+        // itself is rejected.
+        let target_path = outside.path().join("a").join("b").join("c").join("pwned.txt");
+
+        let state = build_state(vec![root.path().to_string_lossy().to_string()]);
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/api/designer/v1/file-content",
+            web::put().to(save_file_content_endpoint),
+        ))
+        .await;
+
+        let req = test::TestRequest::put()
+            .uri("/api/designer/v1/file-content")
+            .set_json(SaveFileRequestPayload {
+                file_path: target_path.to_string_lossy().to_string(),
+                content: "PWNED".to_string(),
+            })
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+        assert!(fs::metadata(&target_path).is_err());
+        assert!(fs::metadata(outside.path().join("a")).is_err());
     }
 }

--- a/core/src/ten_manager/tests/test_case/designer/file_content/mod.rs
+++ b/core/src/ten_manager/tests/test_case/designer/file_content/mod.rs
@@ -1,0 +1,261 @@
+//
+// Copyright © 2025 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, fs, sync::Arc};
+
+    use actix_web::{test, web, App};
+    use serde::{Deserialize, Serialize};
+    use tempfile::tempdir;
+    use ten_manager::{
+        designer::{
+            file_content::{get_file_content_endpoint, save_file_content_endpoint},
+            response::{ApiResponse, Status},
+            storage::in_memory::TmanStorageInMemory,
+            DesignerState,
+        },
+        home::config::TmanConfig,
+        output::cli::TmanOutputCli,
+    };
+    use ten_rust::base_dir_pkg_info::PkgsInfoInApp;
+
+    #[derive(Serialize, Deserialize)]
+    struct GetFileContentRequestPayload {
+        file_path: String,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct SaveFileRequestPayload {
+        file_path: String,
+        content: String,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct GetFileContentResponseData {
+        content: String,
+    }
+
+    // Builds a `DesignerState` whose `pkgs_cache` is seeded with the given
+    // app base directories, mirroring the roots that would be present once
+    // the designer has loaded one or more apps.
+    fn build_state(allowed_roots: Vec<String>) -> web::Data<Arc<DesignerState>> {
+        let mut pkgs_cache = HashMap::new();
+        for root in allowed_roots {
+            pkgs_cache.insert(root, PkgsInfoInApp::default());
+        }
+
+        web::Data::new(Arc::new(DesignerState {
+            tman_config: Arc::new(tokio::sync::RwLock::new(TmanConfig::default())),
+            storage_in_memory: Arc::new(tokio::sync::RwLock::new(TmanStorageInMemory::default())),
+            out: Arc::new(Box::new(TmanOutputCli)),
+            pkgs_cache: tokio::sync::RwLock::new(pkgs_cache),
+            graphs_cache: tokio::sync::RwLock::new(HashMap::new()),
+            persistent_storage_schema: Arc::new(tokio::sync::RwLock::new(None)),
+        }))
+    }
+
+    #[actix_web::test]
+    async fn test_get_file_content_within_root_succeeds() {
+        let root = tempdir().unwrap();
+        let file_path = root.path().join("inside.txt");
+        fs::write(&file_path, "hello from inside the project").unwrap();
+
+        let state = build_state(vec![root.path().to_string_lossy().to_string()]);
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/api/designer/v1/file-content",
+            web::post().to(get_file_content_endpoint),
+        ))
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/api/designer/v1/file-content")
+            .set_json(GetFileContentRequestPayload {
+                file_path: file_path.to_string_lossy().to_string(),
+            })
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
+
+        let body = test::read_body(resp).await;
+        let response: ApiResponse<GetFileContentResponseData> =
+            serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(response.status, Status::Ok);
+        assert_eq!(response.data.content, "hello from inside the project");
+    }
+
+    #[actix_web::test]
+    async fn test_get_file_content_outside_root_is_rejected() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let secret_path = outside.path().join("secret.txt");
+        fs::write(&secret_path, "SECRET").unwrap();
+
+        let state = build_state(vec![root.path().to_string_lossy().to_string()]);
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/api/designer/v1/file-content",
+            web::post().to(get_file_content_endpoint),
+        ))
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/api/designer/v1/file-content")
+            .set_json(GetFileContentRequestPayload {
+                file_path: secret_path.to_string_lossy().to_string(),
+            })
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    }
+
+    #[actix_web::test]
+    async fn test_get_file_content_path_traversal_is_rejected() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let secret_path = outside.path().join("secret.txt");
+        fs::write(&secret_path, "SECRET").unwrap();
+
+        let state = build_state(vec![root.path().to_string_lossy().to_string()]);
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/api/designer/v1/file-content",
+            web::post().to(get_file_content_endpoint),
+        ))
+        .await;
+
+        // Escape `root` via `..` into the sibling `outside` directory, the
+        // same shape of attack as the `/etc/passwd` read in the report.
+        let traversal_path =
+            root.path().join("..").join(outside.path().file_name().unwrap()).join("secret.txt");
+
+        let req = test::TestRequest::post()
+            .uri("/api/designer/v1/file-content")
+            .set_json(GetFileContentRequestPayload {
+                file_path: traversal_path.to_string_lossy().to_string(),
+            })
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    }
+
+    #[actix_web::test]
+    async fn test_get_file_content_with_no_loaded_root_is_rejected() {
+        let root = tempdir().unwrap();
+        let file_path = root.path().join("inside.txt");
+        fs::write(&file_path, "hello").unwrap();
+
+        // No app/project root has been loaded into `pkgs_cache`.
+        let state = build_state(vec![]);
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/api/designer/v1/file-content",
+            web::post().to(get_file_content_endpoint),
+        ))
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/api/designer/v1/file-content")
+            .set_json(GetFileContentRequestPayload {
+                file_path: file_path.to_string_lossy().to_string(),
+            })
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    }
+
+    #[actix_web::test]
+    async fn test_save_file_content_within_root_succeeds() {
+        let root = tempdir().unwrap();
+        let file_path = root.path().join("new_file.txt");
+
+        let state = build_state(vec![root.path().to_string_lossy().to_string()]);
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/api/designer/v1/file-content",
+            web::put().to(save_file_content_endpoint),
+        ))
+        .await;
+
+        let req = test::TestRequest::put()
+            .uri("/api/designer/v1/file-content")
+            .set_json(SaveFileRequestPayload {
+                file_path: file_path.to_string_lossy().to_string(),
+                content: "written by the designer".to_string(),
+            })
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
+
+        let saved = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(saved, "written by the designer");
+    }
+
+    #[actix_web::test]
+    async fn test_save_file_content_outside_root_is_rejected() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let target_path = outside.path().join("pwned.txt");
+
+        let state = build_state(vec![root.path().to_string_lossy().to_string()]);
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/api/designer/v1/file-content",
+            web::put().to(save_file_content_endpoint),
+        ))
+        .await;
+
+        let req = test::TestRequest::put()
+            .uri("/api/designer/v1/file-content")
+            .set_json(SaveFileRequestPayload {
+                file_path: target_path.to_string_lossy().to_string(),
+                content: "PWNED".to_string(),
+            })
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+        assert!(fs::metadata(&target_path).is_err());
+    }
+
+    #[actix_web::test]
+    async fn test_save_file_content_path_traversal_is_rejected() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let target_path = outside.path().join("pwned.txt");
+
+        let state = build_state(vec![root.path().to_string_lossy().to_string()]);
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/api/designer/v1/file-content",
+            web::put().to(save_file_content_endpoint),
+        ))
+        .await;
+
+        // Escape `root` via `..` into the sibling `outside` directory.
+        let traversal_path =
+            root.path().join("..").join(outside.path().file_name().unwrap()).join("pwned.txt");
+
+        let req = test::TestRequest::put()
+            .uri("/api/designer/v1/file-content")
+            .set_json(SaveFileRequestPayload {
+                file_path: traversal_path.to_string_lossy().to_string(),
+                content: "PWNED".to_string(),
+            })
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+        assert!(fs::metadata(&target_path).is_err());
+    }
+}

--- a/core/src/ten_manager/tests/test_case/designer/mod.rs
+++ b/core/src/ten_manager/tests/test_case/designer/mod.rs
@@ -11,6 +11,7 @@ pub mod doc_link;
 pub mod env;
 pub mod exec;
 pub mod extensions;
+pub mod file_content;
 pub mod graphs;
 pub mod help_text;
 pub mod manifest;


### PR DESCRIPTION
## Summary

Refs #2187 -- addresses the path-confinement half of the report. See "Not addressed" below for what this PR does not cover.

`get_file_content_endpoint` and `save_file_content_endpoint` in `core/src/ten_manager/src/designer/file_content/mod.rs` read and wrote a client-supplied `file_path` with `fs::read_to_string` / `fs::write` and no validation. The designer server binds `0.0.0.0:49483` with any-origin CORS and no authentication middleware, so an unauthenticated caller could read or write any file the `tman` process has access to (e.g. `/etc/passwd`, `~/.ssh/authorized_keys`) via an absolute path or a `..` traversal, matching the PoC in the issue.

**Fix**

- Added `ensure_within_allowed_roots()`, which canonicalizes the requested path and rejects it unless it resolves inside one of the app base directories already tracked in `DesignerState.pkgs_cache`. Both endpoints return `403 Forbidden` when a path is rejected outside the allowed roots; `400 Bad Request` is preserved for the pre-existing malformed-path/I/O-error cases (a `PathRejection` enum keeps a merely non-existent path from being bucketed with a confinement violation).
- The write endpoint previously called `fs::create_dir_all(parent)` on the raw, attacker-supplied path *before* any validation ran, so a request could make it create directories outside every loaded root even though the write itself was rejected afterwards. Added `resolve_prospective_path()`, which walks up to the nearest existing ancestor of the target parent, canonicalizes only that, and lexically re-applies the not-yet-created suffix on top -- all before `create_dir_all` runs. This also closes a related escape: `create_dir_all` re-resolves any `..` left in its argument against directories it creates along the way, so validating only the already-created parent (the naive fix) does not stop a crafted path like `a/b/../../../etc` (where only `a` exists and is an allowed root) from creating a directory outside of `a`.
- An empty `pkgs_cache` (no app loaded yet) is treated as "no allowed roots" and rejects every request rather than allowing or denying by an unvalidated default.

**Not addressed**

The issue's "Expected behavior" also asks for authentication on the designer API and binding to loopback by default instead of `0.0.0.0`. Neither is in this diff; it is scoped to path confinement. An unauthenticated caller can still reach these endpoints -- the fix limits what such a caller can read or write to files inside a currently loaded project root, instead of the whole filesystem.

## Testing

Added 9 unit tests under `core/src/ten_manager/tests/test_case/designer/file_content/mod.rs`, following the existing pattern in `designer/dir_list`: in-root read/write round trip, read/write of an absolute path outside any loaded root, a `..` traversal that resolves outside the root (both endpoints), a request made with no project root loaded, and a save whose target parent directory chain does not exist yet on disk (the case that exercises the `create_dir_all`-ordering bug -- the other tests' parents already existed, so `create_dir_all` was a no-op there).

I don't have a Rust toolchain available in my normal working environment for this repo (`ten_manager`'s dependency tree includes `clingo-sys`, which compiles the Clingo ASP-solver C++ library from source via `cmake`, and `cmake`/`bison`/`re2c` weren't installed). I later got a toolchain working long enough to build and run this crate's tests directly:

```
$ cargo test -p ten_manager file_content
running 9 tests
test test_case::designer::file_content::tests::test_get_file_content_missing_file_in_root_is_bad_request ... ok
test test_case::designer::file_content::tests::test_get_file_content_with_no_loaded_root_is_rejected ... ok
test test_case::designer::file_content::tests::test_save_file_content_outside_root_with_nonexistent_parent_chain_is_rejected ... ok
test test_case::designer::file_content::tests::test_save_file_content_within_root_succeeds ... ok
test test_case::designer::file_content::tests::test_save_file_content_path_traversal_is_rejected ... ok
test test_case::designer::file_content::tests::test_get_file_content_within_root_succeeds ... ok
test test_case::designer::file_content::tests::test_get_file_content_outside_root_is_rejected ... ok
test test_case::designer::file_content::tests::test_save_file_content_outside_root_is_rejected ... ok
test test_case::designer::file_content::tests::test_get_file_content_path_traversal_is_rejected ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 279 filtered out; finished in 0.01s
```

To confirm the new tests actually exercise this fix (not just compile), I reverted only `file_content/mod.rs` to its pre-fix state (test file untouched) and re-ran the same command: 6 of the 9 tests failed with `assertion left == right failed / left: 200 / right: 403` against the endpoints that should have rejected the request. I then restored the fix and re-ran to the same 9/9 passing result shown above. `cargo check -p ten_manager` also finished cleanly with 0 warnings.
