### PR TITLE
fix(ai_agents): bump example graphs' pinned model to gpt-realtime-2.1

### DIFF
--- a/ai_agents/agents/examples/demo/frontend/src/app/api/agents/start/graph.ts
+++ b/ai_agents/agents/examples/demo/frontend/src/app/api/agents/start/graph.ts
@@ -1,7 +1,7 @@
 import type { LanguageMap } from "@/common/constant";
 import type { IOceanBaseSettings } from "@/types";
 
-const OPENAI_REALTIME_MODEL = "gpt-realtime";
+const OPENAI_REALTIME_MODEL = "gpt-realtime-2.1";
 const OPENAI_REALTIME_15_MODEL = "gpt-realtime-1.5";
 const OPENAI_REALTIME_MINI_MODEL = "gpt-realtime-mini";
 const MINIMAX_DEFAULT_PROMPT =

--- a/ai_agents/agents/examples/demo/tenapp/property.json
+++ b/ai_agents/agents/examples/demo/tenapp/property.json
@@ -1530,7 +1530,7 @@
               "property": {
                 "api_key": "${env:OPENAI_API_KEY}",
                 "temperature": 0.9,
-                "model": "gpt-realtime",
+                "model": "gpt-realtime-2.1",
                 "max_tokens": 2048,
                 "voice": "alloy",
                 "language": "en",

--- a/ai_agents/agents/examples/voice-assistant-companion/README.md
+++ b/ai_agents/agents/examples/voice-assistant-companion/README.md
@@ -110,7 +110,7 @@ The voice assistant companion is configured in `tenapp/property.json`:
               "addon": "openai_mllm_python",
               "property": {
                 "api_key": "${env:OPENAI_API_KEY}",
-                "model": "gpt-realtime",
+                "model": "gpt-realtime-2.1",
                 "voice": "shimmer",
                 "language": "en",
                 "vad_type": "semantic_vad",

--- a/ai_agents/agents/examples/voice-assistant-companion/tenapp/property.json
+++ b/ai_agents/agents/examples/voice-assistant-companion/tenapp/property.json
@@ -61,7 +61,7 @@
               "property": {
                 "api_key": "${env:OPENAI_API_KEY}",
                 "temperature": 0.8,
-                "model": "gpt-realtime",
+                "model": "gpt-realtime-2.1",
                 "max_tokens": 2048,
                 "voice": "shimmer",
                 "language": "en",

--- a/ai_agents/agents/examples/voice-assistant-realtime/README.md
+++ b/ai_agents/agents/examples/voice-assistant-realtime/README.md
@@ -107,7 +107,7 @@ The realtime voice assistant is configured in `tenapp/property.json`:
               "addon": "openai_mllm_python",
               "property": {
                 "api_key": "${env:OPENAI_API_KEY}",
-                "model": "gpt-realtime",
+                "model": "gpt-realtime-2.1",
                 "voice": "alloy",
                 "language": "en",
                 "vad_type": "semantic_vad",

--- a/ai_agents/agents/examples/voice-assistant-realtime/tenapp/property.json
+++ b/ai_agents/agents/examples/voice-assistant-realtime/tenapp/property.json
@@ -61,7 +61,7 @@
               "property": {
                 "api_key": "${env:OPENAI_API_KEY}",
                 "temperature": 0.9,
-                "model": "gpt-realtime",
+                "model": "gpt-realtime-2.1",
                 "max_tokens": 2048,
                 "voice": "alloy",
                 "language": "en",


### PR DESCRIPTION
## Summary

`voice-assistant-realtime`, `voice-assistant-companion` and `demo` each pin `"model": "gpt-realtime"` explicitly in their `tenapp/property.json`, so they don't pick up whatever default `openai_mllm_python` ships internally — they always use exactly the string written in the graph. OpenAI announced `gpt-realtime`'s deprecation on 2026-07-20 with shutdown on 2027-01-20; the GA replacement is `gpt-realtime-2.1` (per `developers.openai.com/api/docs/deprecations`). This bumps the three pins to match, and updates the two README.md snippets that document the same `property.json` fields so the docs stay in sync.

`demo/tenapp/property.json` also pins `"gpt-realtime-mini"` on a separate node (a different agent config in the same file). That model's correct replacement is `gpt-realtime-2.1-mini`, not `gpt-realtime-2.1`, so it is intentionally left untouched here.

`demo`'s own web UI (`frontend/src/app/api/agents/start/graph.ts`) sends its own `OPENAI_REALTIME_MODEL` constant as `properties.v2v.model` on every "OpenAI GPT Realtime" (`va_openai_v2v`) launch, and the backend's `mergeProperties` path overwrites the `property.json` node value with whatever the frontend sends. That constant also pinned `"gpt-realtime"`, which would have silently defeated the `property.json` bump for anyone launching the demo through its own UI, so it is bumped here too. The "OpenAI GPT Realtime 1.5" (`va_openai_v2v_1_5`) and "OpenAI GPT Realtime Mini" (`va_openai_v2v_mini`) dropdown options are separate, explicitly versioned UI choices and are left pointing at `gpt-realtime-1.5` / `gpt-realtime-mini` respectively — same distinction already made for the mini node above. I checked `developers.openai.com/api/docs/deprecations` directly: `gpt-realtime-1.5` is not itself deprecated (it only appears as the replacement target for older 2025 preview snapshots), so collapsing it into `2.1` would silently break that labeled choice.

## Context

#2261 migrates `openai_mllm_python`'s realtime client to the GA wire protocol and, as part of that, bumps the extension's own internal config default to `gpt-realtime-2.1`. Its "Not covered" section flags that these three shipped example graphs override that default explicitly and calls it "worth a separate pass." This PR is that pass, scoped to the model-pin freshness issue across both the `property.json` graphs and the `demo` frontend that overrides them. Refs #2261 — it does not itself migrate the wire protocol.

## Scope note (please read before reviewing)

This is a freshness/consistency fix only, not a functional fix. As of `main`, `openai_mllm_python`'s `realtime/connection.py` still sends the header `OpenAI-Beta: realtime=v1` to `/v1/realtime`. OpenAI retired the Realtime Beta API on 2026-05-12 and now rejects that combination outright (`"The Realtime Beta API is no longer supported. Please use /v1/realtime for the GA API."`), per #2261's own live verification against `api.openai.com`. So none of these three example graphs' OpenAI realtime path currently connects, independent of which model string is pinned — this change has no functional effect on `main` today. Its value is that once the GA client migration lands (#2261 or equivalent), these examples and the demo UI won't still be pointing at a model that's already in its deprecation window.

## Testing

This is a static config/constant value bump (JSON string values and one TS `const`), no branching logic touched, so no unit test applies — there is no existing test harness anywhere in the repo (no jest/vitest config, no `*.test.*`/`*.spec.*` files) that exercises these example `property.json` files' `model` field or the demo frontend's `graph.ts` constants. Verified instead by direct inspection, re-run against the current branch state:

- `python3 -c "import json; json.load(open(f))"` on all three touched `property.json` files — `OK: <path>` for all three, confirming the JSON stays well-formed.
- `jq empty <path>` on the same three files — `jq OK: <path>` for all three, independent parse confirmation.
- `grep -n gpt-realtime ai_agents/agents/examples/demo/tenapp/property.json` post-edit — `1533: "model": "gpt-realtime-2.1",` and `1691: "model": "gpt-realtime-mini",`, confirming exactly the intended node changed and the mini node was correctly left untouched.
- `grep -n OPENAI_REALTIME ai_agents/agents/examples/demo/frontend/src/app/api/agents/start/graph.ts` — confirms `OPENAI_REALTIME_MODEL = "gpt-realtime-2.1"` while `OPENAI_REALTIME_15_MODEL` and `OPENAI_REALTIME_MINI_MODEL` are unchanged.
- `git diff origin/main..HEAD --stat` — `6 files changed, 6 insertions(+), 6 deletions(-)`, confirming a surgical diff with no unintended changes.

Did not attempt a full `ai_agents` build/run (Taskfile-driven Docker build, requires a live `OPENAI_API_KEY` to actually connect) — out of scope for a config-value change, and also moot: per PR #2261's own live verification, `openai_mllm_python` still sends the retired Realtime Beta header, so no real call would succeed on `main` today regardless of which model string is pinned.
