### PR TITLE
chore: bump smallest extension versions to 0.1.1

### DIFF
--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "smallest_asr_python",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smallest-asr-python"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",

--- a/ai_agents/agents/ten_packages/extension/smallest_tts_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/smallest_tts_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "smallest_tts_python",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/smallest_tts_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/smallest_tts_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smallest-tts-python"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.10"
 dependencies = [
     "httpx[http2]>=0.27.0",


### PR DESCRIPTION
## Summary

- bump `smallest_asr_python` from `0.1.0` to `0.1.1`
- bump `smallest_tts_python` from `0.1.0` to `0.1.1`
- keep each extension's `manifest.json` and `pyproject.toml` versions aligned

This is the follow-up requested after #2293 because `0.1.0` has already been published and cannot be reused for the fixes merged there.

