### PR TITLE
fix(asr): reconnect when smallest message loop exits

### DIFF
--- a/ai_agents/agents/integration_tests/asr_guarder/tests/test_reconnection.py
+++ b/ai_agents/agents/integration_tests/asr_guarder/tests/test_reconnection.py
@@ -292,7 +292,7 @@ class AsrReconnectionTester(AsyncExtensionTester):
             error_code: int = json_data.get("code", 0)
             self.error_codes.append(error_code)
 
-            is_fatal = error_code == ModuleErrorCode.FATAL_ERROR.value
+            is_fatal = error_code == int(ModuleErrorCode.FATAL_ERROR.value)
 
             error_message: str = json_data.get("message", "")
 
@@ -372,7 +372,7 @@ def test_reconnection(extension_name: str, config_dir: str) -> None:
         # Check that fatal error is present in error codes
         fatal_error_index = -1
         for i, code in enumerate(tester.error_codes):
-            if code == ModuleErrorCode.FATAL_ERROR.value:
+            if code == int(ModuleErrorCode.FATAL_ERROR.value):
                 fatal_error_index = i
                 break
 
@@ -397,9 +397,7 @@ def test_reconnection(extension_name: str, config_dir: str) -> None:
         # Verify all received errors are non-fatal (should retry on connection failure)
         # Note: ModuleErrorCode is a str Enum, so we need to convert to int for comparison
         non_fatal_code = int(ModuleErrorCode.NON_FATAL_ERROR.value)
-        assert all(
-            code == non_fatal_code for code in tester.error_codes
-        ), (
+        assert all(code == non_fatal_code for code in tester.error_codes), (
             f"All errors should be non-fatal (code={non_fatal_code}), "
             f"but found unexpected codes in sequence: {tester.error_codes}"
         )

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/extension.py
@@ -55,6 +55,7 @@ class SmallestASRExtension(AsyncASRBaseExtension):
         # it cannot cancel the message task that detected the disconnect.
         # A single task also serializes retry-budget and connection mutations.
         self._reconnect_task: asyncio.Task[None] | None = None
+        self._reconnect_pending: bool = False
 
     @override
     async def on_stop(self, ten_env: AsyncTenEnv) -> None:
@@ -79,6 +80,7 @@ class SmallestASRExtension(AsyncASRBaseExtension):
         """Cancel and drain the outstanding reconnection task, if any."""
         task = self._reconnect_task
         self._reconnect_task = None
+        self._reconnect_pending = False
         if task is None or task is asyncio.current_task():
             return
         task.cancel()
@@ -278,9 +280,14 @@ class SmallestASRExtension(AsyncASRBaseExtension):
         if self.stopped:
             return
         if self._reconnect_task and not self._reconnect_task.done():
+            # The active reconnect may have opened a socket which then closed
+            # before the reconnect task finished unwinding. Remember that
+            # disconnect so the done callback can start another attempt.
+            self._reconnect_pending = True
             self.ten_env.log_debug("Reconnect already in progress, skip")
             return
 
+        self._reconnect_pending = False
         task = asyncio.create_task(self._handle_reconnect())
         self._reconnect_task = task
 
@@ -291,6 +298,14 @@ class SmallestASRExtension(AsyncASRBaseExtension):
                     self.ten_env.log_error(f"Reconnect task failed: {exc}")
             if self._reconnect_task is done_task:
                 self._reconnect_task = None
+                reconnect_pending = self._reconnect_pending
+                self._reconnect_pending = False
+                if (
+                    reconnect_pending
+                    and not self.stopped
+                    and not self.connected
+                ):
+                    self._schedule_reconnect()
 
         task.add_done_callback(clear_reconnect_task)
 
@@ -324,8 +339,9 @@ class SmallestASRExtension(AsyncASRBaseExtension):
 
     async def _process_messages(self) -> None:
         """Process incoming messages from the WebSocket."""
-        assert self.ws is not None
         ws = self.ws
+        if ws is None:
+            return
 
         try:
             async for msg in ws:
@@ -526,6 +542,8 @@ class SmallestASRExtension(AsyncASRBaseExtension):
             # Call the public hook so AsyncASRBaseExtension's wrapper emits a
             # DISCONNECTED -> CONNECTING transition for every retry. Request
             # propagation so ReconnectManager can apply its retry budget.
+            if self.stopped:
+                return
             await self.start_connection(_propagate_error=True)
 
         while not self.stopped and self.reconnect_manager.can_retry():

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/extension.py
@@ -51,11 +51,18 @@ class SmallestASRExtension(AsyncASRBaseExtension):
         self.reconnect_manager: ReconnectManager | None = None
 
         self._message_task: Optional[asyncio.Task] = None
-        # In-flight reconnection tasks. Reconnection is always run on its own
-        # task (never awaited inline) so it cannot cancel the caller; see
-        # `_schedule_reconnect`. Tracked here so tasks are not garbage
-        # collected mid-flight and can be cancelled on shutdown.
-        self._reconnect_tasks: set[asyncio.Task] = set()
+        # Reconnection is always run on its own task (never awaited inline) so
+        # it cannot cancel the message task that detected the disconnect.
+        # A single task also serializes retry-budget and connection mutations.
+        self._reconnect_task: asyncio.Task[None] | None = None
+
+    @override
+    async def on_stop(self, ten_env: AsyncTenEnv) -> None:
+        # Close the race between the base on_stop() and on_deinit(): prevent a
+        # reconnect sleeping in backoff from opening a new socket after stop.
+        self.stopped = True
+        await self._cancel_reconnect_task()
+        await super().on_stop(ten_env)
 
     @override
     async def on_deinit(self, ten_env: AsyncTenEnv) -> None:
@@ -65,20 +72,17 @@ class SmallestASRExtension(AsyncASRBaseExtension):
             self.audio_dumper = None
         # Cancel any in-flight reconnection before tearing down the connection
         # so a pending reconnect cannot re-open the socket during shutdown.
-        await self._cancel_reconnect_tasks()
+        await self._cancel_reconnect_task()
         await self.stop_connection()
 
-    async def _cancel_reconnect_tasks(self) -> None:
-        """Cancel and drain any outstanding reconnection tasks."""
-        tasks = list(self._reconnect_tasks)
-        for task in tasks:
-            task.cancel()
-        for task in tasks:
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-        self._reconnect_tasks.clear()
+    async def _cancel_reconnect_task(self) -> None:
+        """Cancel and drain the outstanding reconnection task, if any."""
+        task = self._reconnect_task
+        self._reconnect_task = None
+        if task is None or task is asyncio.current_task():
+            return
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
 
     @override
     def vendor(self) -> str:
@@ -149,110 +153,182 @@ class SmallestASRExtension(AsyncASRBaseExtension):
         return f"{ws_url}?{urlencode(params)}"
 
     @override
-    async def start_connection(self) -> None:
+    async def start_connection(self, *, _propagate_error: bool = False) -> None:
+        if self.stopped:
+            return
+
+        try:
+            await self._connect_once()
+        except Exception as e:
+            await self._report_connection_failure(e)
+            if _propagate_error:
+                raise
+            self._schedule_reconnect()
+
+    async def _connect_once(self) -> None:
+        """Open one vendor connection, propagating failure to the caller."""
         assert self.config is not None
         self.ten_env.log_info("start_connection")
 
+        await self.stop_connection()
+        if self.stopped:
+            return
+
+        # Create aiohttp session if not exists
+        if self.session is None or self.session.closed:
+            self.session = aiohttp.ClientSession()
+
+        if self.audio_dumper:
+            await self.audio_dumper.start()
+
+        # Build WebSocket URL
+        ws_url = self._build_websocket_url()
+        # Get API key from config or params
+        api_key = self.config.api_key or self.config.params.get("api_key", "")
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "X-Source": SOURCE_NAME,
+        }
+
+        self.ten_env.log_info(
+            f"Connecting to Smallest AI WebSocket: {ws_url}",
+            category=LOG_CATEGORY_VENDOR,
+        )
+
+        # Connect to WebSocket
         try:
-            await self.stop_connection()
-
-            # Create aiohttp session if not exists
-            if self.session is None or self.session.closed:
-                self.session = aiohttp.ClientSession()
-
-            if self.audio_dumper:
-                await self.audio_dumper.start()
-
-            # Build WebSocket URL
-            ws_url = self._build_websocket_url()
-            # Get API key from config or params
-            api_key = self.config.api_key or self.config.params.get(
-                "api_key", ""
+            timeout = aiohttp.ClientTimeout(total=30)
+            self.ws = await asyncio.wait_for(
+                self.session.ws_connect(
+                    ws_url, headers=headers, timeout=timeout
+                ),
+                timeout=30.0,
             )
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "X-Source": SOURCE_NAME,
-            }
-
-            self.ten_env.log_info(
-                f"Connecting to Smallest AI WebSocket: {ws_url}",
-                category=LOG_CATEGORY_VENDOR,
-            )
-
-            # Connect to WebSocket
-            try:
-                timeout = aiohttp.ClientTimeout(total=30)
-                self.ws = await asyncio.wait_for(
-                    self.session.ws_connect(
-                        ws_url, headers=headers, timeout=timeout
-                    ),
-                    timeout=30.0,
-                )
-            except asyncio.TimeoutError:
-                self.ten_env.log_error("WebSocket connection timeout")
-                raise
-            except Exception as e:
-                self.ten_env.log_error(f"WebSocket connection failed: {e}")
-                raise
-
-            self.connected = True
-            self.sent_user_audio_duration_ms_before_last_reset += (
-                self.audio_timeline.get_total_user_audio_duration()
-            )
-            self.audio_timeline.reset()
-            self._utterance_start_ms = None
-
-            # Report the socket as usable now that the handshake succeeded,
-            # not just "connecting" — the base class only emits CONNECTING
-            # before this hook runs.
-            await self.on_connected()
-
-            # Start message processing task
-            self._message_task = asyncio.create_task(self._process_messages())
-
-            self.ten_env.log_info(
-                "start_connection completed",
-                category=LOG_CATEGORY_VENDOR,
-            )
-
+        except asyncio.TimeoutError:
+            self.ten_env.log_error("WebSocket connection timeout")
+            raise
         except Exception as e:
-            self.ten_env.log_error(
-                f"KEYPOINT start_connection failed: invalid vendor config: {e}"
-            )
-            self.connected = False
-            error = ModuleError(
-                module=MODULE_NAME_ASR,
-                code=ModuleErrorCode.NON_FATAL_ERROR.value,
-                message=str(e),
-            )
-            await self.send_asr_error(error)
-            await self.on_disconnected(code=error.code, message=error.message)
-            self._schedule_reconnect()
+            self.ten_env.log_error(f"WebSocket connection failed: {e}")
+            raise
+
+        self.connected = True
+        self.sent_user_audio_duration_ms_before_last_reset += (
+            self.audio_timeline.get_total_user_audio_duration()
+        )
+        self.audio_timeline.reset()
+        self._utterance_start_ms = None
+
+        # Report the socket as usable now that the handshake succeeded, not
+        # just "connecting" — the base class only emits CONNECTING first.
+        await self.on_connected()
+
+        self._message_task = asyncio.create_task(self._process_messages())
+
+        self.ten_env.log_info(
+            "start_connection completed",
+            category=LOG_CATEGORY_VENDOR,
+        )
+
+    async def _report_connection_failure(self, exc: Exception) -> None:
+        self.ten_env.log_error(f"KEYPOINT start_connection failed: {exc}")
+        self.connected = False
+        message = str(exc)
+        error = ModuleError(
+            module=MODULE_NAME_ASR,
+            code=ModuleErrorCode.NON_FATAL_ERROR.value,
+            message=message,
+        )
+        vendor_info = ModuleErrorVendorInfo(
+            vendor=self.vendor(),
+            code=str(getattr(exc, "status", type(exc).__name__)),
+            message=message,
+        )
+        await self.send_asr_error(error, vendor_info)
+        await self.on_disconnected(
+            code=error.code,
+            message=error.message,
+            vendor_info=vendor_info,
+        )
+
+    async def _send_reconnect_manager_error(self, error: ModuleError) -> None:
+        """Report retry-manager errors with a complete vendor payload."""
+        await self.send_asr_error(
+            error,
+            ModuleErrorVendorInfo(
+                vendor=self.vendor(),
+                code=str(error.code),
+                message=error.message,
+            ),
+        )
 
     def _schedule_reconnect(self) -> None:
         """Trigger a reconnection attempt on an independent task.
 
         Reconnection must never be awaited from within `_message_task`. The
-        reconnect path runs `start_connection()` -> `stop_connection()`, and
+        reconnect path runs `start_connection()` -> `_connect_once()` ->
+        `stop_connection()`, and
         `stop_connection()` cancels `_message_task`. Awaiting the reconnect
         inline would therefore cancel the very task executing it, tearing the
         flow down before `start_connection()` can spawn a fresh message task.
 
         Running it as a standalone task lets the message loop return cleanly
-        while the reconnect proceeds. Tasks are retained in a set (and removed
-        on completion) so they are not garbage collected mid-flight and can be
-        cancelled on shutdown.
+        while the reconnect proceeds. At most one task may run so concurrent
+        send, finalize, and receive failures cannot race the retry manager.
         """
+        if self.stopped:
+            return
+        if self._reconnect_task and not self._reconnect_task.done():
+            self.ten_env.log_debug("Reconnect already in progress, skip")
+            return
+
         task = asyncio.create_task(self._handle_reconnect())
-        self._reconnect_tasks.add(task)
-        task.add_done_callback(self._reconnect_tasks.discard)
+        self._reconnect_task = task
+
+        def clear_reconnect_task(done_task: asyncio.Task[None]) -> None:
+            if not done_task.cancelled():
+                exc = done_task.exception()
+                if exc is not None:
+                    self.ten_env.log_error(f"Reconnect task failed: {exc}")
+            if self._reconnect_task is done_task:
+                self._reconnect_task = None
+
+        task.add_done_callback(clear_reconnect_task)
+
+    async def _handle_unexpected_disconnect(
+        self,
+        message: str,
+        ws: aiohttp.ClientWebSocketResponse,
+    ) -> None:
+        """Report and reconnect only if `ws` is still the active socket."""
+        if self.stopped or self.ws is not ws or not self.connected:
+            return
+
+        self.connected = False
+        error = ModuleError(
+            module=MODULE_NAME_ASR,
+            code=ModuleErrorCode.NON_FATAL_ERROR.value,
+            message=message,
+        )
+        vendor_info = ModuleErrorVendorInfo(
+            vendor=self.vendor(),
+            code="websocket",
+            message=message,
+        )
+        await self.send_asr_error(error, vendor_info)
+        await self.on_disconnected(
+            code=error.code,
+            message=error.message,
+            vendor_info=vendor_info,
+        )
+        self._schedule_reconnect()
 
     async def _process_messages(self) -> None:
         """Process incoming messages from the WebSocket."""
         assert self.ws is not None
+        ws = self.ws
 
         try:
-            async for msg in self.ws:
+            async for msg in ws:
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     try:
                         data = json.loads(msg.data)
@@ -271,71 +347,29 @@ class SmallestASRExtension(AsyncASRBaseExtension):
                         raise
 
                 elif msg.type == aiohttp.WSMsgType.ERROR:
-                    error_msg = f"WebSocket error: {self.ws.exception()}"
+                    error_msg = f"WebSocket error: {ws.exception()}"
                     self.ten_env.log_error(
                         error_msg,
                         category=LOG_CATEGORY_VENDOR,
                     )
                     raise RuntimeError(error_msg)
 
-                elif msg.type in (
-                    aiohttp.WSMsgType.CLOSED,
-                    aiohttp.WSMsgType.CLOSE,
-                    aiohttp.WSMsgType.CLOSING,
-                ):
-                    self.ten_env.log_info(
-                        f"WebSocket closed: {msg.type}",
-                        category=LOG_CATEGORY_VENDOR,
-                    )
-                    # WebSocket closed unexpectedly, trigger reconnection
-                    if not self.stopped:
-                        self.connected = False
-                        error = ModuleError(
-                            module=MODULE_NAME_ASR,
-                            code=ModuleErrorCode.NON_FATAL_ERROR.value,
-                            message=f"WebSocket closed unexpectedly: {msg.type}",
-                        )
-                        await self.send_asr_error(error)
-                        await self.on_disconnected(
-                            code=error.code, message=error.message
-                        )
-                        # Schedule (do not await) so this task can exit before
-                        # the reconnect path cancels it via stop_connection.
-                        self._schedule_reconnect()
-                    return
-
-            # aiohttp's ClientWebSocketResponse.__anext__ raises
-            # StopAsyncIteration for CLOSE, CLOSING, and CLOSED messages, so
-            # production sockets reach this point instead of the close-message
-            # branch above. Treat an otherwise normal iterator exit as an
-            # unexpected disconnect while the extension is still running.
-            if not self.stopped:
-                self.connected = False
-                close_code = getattr(self.ws, "close_code", None)
-                raise RuntimeError(
-                    "WebSocket message loop ended unexpectedly "
-                    f"(close code: {close_code})"
-                )
-
         except Exception as e:
             self.ten_env.log_error(
                 f"Error in message processing loop: {e}",
                 category=LOG_CATEGORY_VENDOR,
             )
-            if not self.stopped:
-                # Send error before attempting reconnection
-                error = ModuleError(
-                    module=MODULE_NAME_ASR,
-                    code=ModuleErrorCode.NON_FATAL_ERROR.value,
-                    message=f"WebSocket error, attempting reconnection: {str(e)}",
-                )
-                await self.send_asr_error(error)
-                await self.on_disconnected(
-                    code=error.code, message=error.message
-                )
-                # Schedule (do not await): this runs inside `_message_task`,
-                # which the reconnect path cancels via stop_connection.
-                self._schedule_reconnect()
+            await self._handle_unexpected_disconnect(
+                f"WebSocket error, attempting reconnection: {e}", ws
+            )
+        else:
+            # ClientWebSocketResponse.__anext__ ends iteration for CLOSE,
+            # CLOSING, and CLOSED instead of yielding those messages.
+            await self._handle_unexpected_disconnect(
+                "WebSocket message loop ended unexpectedly "
+                f"(close code: {ws.close_code})",
+                ws,
+            )
 
     async def _handle_message(self, data: dict) -> None:
         """Handle different types of messages from the Pulse streaming API."""
@@ -470,11 +504,8 @@ class SmallestASRExtension(AsyncASRBaseExtension):
             ),
         )
 
-    async def _handle_reconnect(self):
-        """
-        Handle a single reconnection attempt using the ReconnectManager.
-        Connection success is determined by the start_connection callback.
-        """
+    async def _handle_reconnect(self) -> None:
+        """Retry serially until a connection opens or the budget is spent."""
         if not self.reconnect_manager:
             self.ten_env.log_error("ReconnectManager not initialized")
             return
@@ -482,7 +513,7 @@ class SmallestASRExtension(AsyncASRBaseExtension):
         # Check if we can still retry
         if not self.reconnect_manager.can_retry():
             self.ten_env.log_warn("No more reconnection attempts allowed")
-            await self.send_asr_error(
+            await self._send_reconnect_manager_error(
                 ModuleError(
                     module=MODULE_NAME_ASR,
                     code=ModuleErrorCode.FATAL_ERROR.value,
@@ -491,17 +522,24 @@ class SmallestASRExtension(AsyncASRBaseExtension):
             )
             return
 
-        # Attempt a single reconnection
-        success = await self.reconnect_manager.handle_reconnect(
-            connection_func=self.start_connection,
-            error_handler=self.send_asr_error,
-        )
+        async def reconnect_once() -> None:
+            # Call the public hook so AsyncASRBaseExtension's wrapper emits a
+            # DISCONNECTED -> CONNECTING transition for every retry. Request
+            # propagation so ReconnectManager can apply its retry budget.
+            await self.start_connection(_propagate_error=True)
 
-        if success:
-            self.ten_env.log_debug(
-                "Reconnection attempt initiated successfully"
+        while not self.stopped and self.reconnect_manager.can_retry():
+            success = await self.reconnect_manager.handle_reconnect(
+                connection_func=reconnect_once,
+                error_handler=self._send_reconnect_manager_error,
             )
-        else:
+
+            if success or self.stopped:
+                self.ten_env.log_debug(
+                    "Reconnection attempt completed successfully"
+                )
+                return
+
             info = self.reconnect_manager.get_attempts_info()
             self.ten_env.log_debug(
                 f"Reconnection attempt failed. Status: {info}"
@@ -533,22 +571,26 @@ class SmallestASRExtension(AsyncASRBaseExtension):
         """Stop the Smallest AI connection."""
         try:
             # Cancel message processing task
-            if self._message_task and not self._message_task.done():
-                self._message_task.cancel()
+            message_task = self._message_task
+            self._message_task = None
+            if message_task and not message_task.done():
+                message_task.cancel()
                 try:
-                    await self._message_task
+                    await message_task
                 except asyncio.CancelledError:
                     pass
 
             # Close WebSocket
-            if self.ws and not self.ws.closed:
-                await self.ws.close()
-                self.ws = None
+            ws = self.ws
+            self.ws = None
+            if ws and not ws.closed:
+                await ws.close()
 
             # Close session
-            if self.session and not self.session.closed:
-                await self.session.close()
-                self.session = None
+            session = self.session
+            self.session = None
+            if session and not session.closed:
+                await session.close()
 
             self.connected = False
             self.ten_env.log_info("smallest connection stopped")
@@ -568,15 +610,17 @@ class SmallestASRExtension(AsyncASRBaseExtension):
             )
             await self._finalize_end()
             return
+        ws = self.ws
         try:
             finalize_message = {"type": "finalize"}
-            await self.ws.send_str(json.dumps(finalize_message))
+            await ws.send_str(json.dumps(finalize_message))
             self.ten_env.log_debug("smallest finalize sent")
         except Exception as e:
             self.ten_env.log_error(f"Error sending smallest finalize: {e}")
             await self._finalize_end()
-            if not self.stopped:
-                self._schedule_reconnect()
+            await self._handle_unexpected_disconnect(
+                f"WebSocket finalize send failed: {e}", ws
+            )
 
     @override
     def is_connected(self) -> bool:
@@ -606,7 +650,9 @@ class SmallestASRExtension(AsyncASRBaseExtension):
             self.ten_env.log_error("Smallest AI connection is not established")
             return False
 
+        ws = self.ws
         buf = frame.lock_buf()
+        send_error: Exception | None = None
         try:
             audio_data = bytes(buf)
 
@@ -618,13 +664,18 @@ class SmallestASRExtension(AsyncASRBaseExtension):
             )
 
             # Pulse accepts raw PCM binary frames directly.
-            await self.ws.send_bytes(audio_data)
-            return True
+            await ws.send_bytes(audio_data)
 
         except Exception as e:
-            self.ten_env.log_error(f"Error sending audio: {e}")
-            if not self.stopped:
-                self._schedule_reconnect()
-            return False
+            send_error = e
         finally:
             frame.unlock_buf(buf)
+
+        if send_error is not None:
+            self.ten_env.log_error(f"Error sending audio: {send_error}")
+            await self._handle_unexpected_disconnect(
+                f"WebSocket audio send failed: {send_error}", ws
+            )
+            return False
+
+        return True

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/extension.py
@@ -289,6 +289,7 @@ class SmallestASRExtension(AsyncASRBaseExtension):
                     )
                     # WebSocket closed unexpectedly, trigger reconnection
                     if not self.stopped:
+                        self.connected = False
                         error = ModuleError(
                             module=MODULE_NAME_ASR,
                             code=ModuleErrorCode.NON_FATAL_ERROR.value,
@@ -301,7 +302,20 @@ class SmallestASRExtension(AsyncASRBaseExtension):
                         # Schedule (do not await) so this task can exit before
                         # the reconnect path cancels it via stop_connection.
                         self._schedule_reconnect()
-                    break
+                    return
+
+            # aiohttp's ClientWebSocketResponse.__anext__ raises
+            # StopAsyncIteration for CLOSE, CLOSING, and CLOSED messages, so
+            # production sockets reach this point instead of the close-message
+            # branch above. Treat an otherwise normal iterator exit as an
+            # unexpected disconnect while the extension is still running.
+            if not self.stopped:
+                self.connected = False
+                close_code = getattr(self.ws, "close_code", None)
+                raise RuntimeError(
+                    "WebSocket message loop ended unexpectedly "
+                    f"(close code: {close_code})"
+                )
 
         except Exception as e:
             self.ten_env.log_error(

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "smallest_asr_python",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": [
     {
       "type": "system",

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smallest-asr-python"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.14.1",

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/mock.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/mock.py
@@ -52,6 +52,12 @@ def patch_smallest_ws():
             self.close_code: int | None = None
             self._exception = None
 
+        def reset(self) -> None:
+            """Prepare the shared socket for a fresh ws_connect call."""
+            self.closed = False
+            self.close_code = None
+            self._exception = None
+
         async def send_str(self, data: str) -> bool:
             self.sent_messages.append(data)
             return True
@@ -88,6 +94,11 @@ def patch_smallest_ws():
                                 aiohttp.WSMsgType.CLOSED,
                             ):
                                 self.closed = True
+                                self.close_code = (
+                                    msg.data
+                                    if isinstance(msg.data, int)
+                                    else 1000
+                                )
                                 return
                             yield msg
                     else:
@@ -101,13 +112,19 @@ def patch_smallest_ws():
             self.closed: bool = False
 
         async def ws_connect(self, url, headers=None, timeout=None):
-            # Always return the same mock WebSocket instance
-            return ws
+            return prepare_connection()
 
         async def close(self) -> None:
             self.closed = True
 
     ws = MockWebSocket()
+
+    def prepare_connection():
+        """Reset the shared socket and discard the previous session's queue."""
+        ws.reset()
+        with messages_lock:
+            messages.clear()
+        return ws
 
     # Patch the ClientSession used inside the Smallest AI extension module
     with patch(
@@ -124,6 +141,7 @@ def patch_smallest_ws():
             ws=ws,
             messages=messages,
             messages_lock=messages_lock,  # Expose lock for thread-safe access
+            prepare_connection=prepare_connection,
             add_message=add_message,  # Helper function to add messages thread-safely
             WSMsgType=aiohttp.WSMsgType,  # Expose WSMsgType for tests
             MockWebSocketMessage=MockWebSocketMessage,  # Helper for creating messages

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/mock.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/mock.py
@@ -26,7 +26,7 @@ def patch_smallest_ws():
       - async send_str (finalize control message)
       - async send_bytes (binary PCM audio)
       - async close
-      - async iterator yielding predefined messages
+      - async iterator matching aiohttp's close-frame semantics
     - Exposes the WebSocket and message list so tests can control behavior.
     """
 
@@ -49,6 +49,7 @@ def patch_smallest_ws():
             self.sent_messages: list[str] = []
             self.sent_bytes: list[bytes] = []
             self.closed: bool = False
+            self.close_code: int | None = None
             self._exception = None
 
         async def send_str(self, data: str) -> bool:
@@ -78,6 +79,16 @@ def patch_smallest_ws():
 
                     if current_messages:
                         for msg in current_messages:
+                            # ClientWebSocketResponse.__anext__ consumes close
+                            # frames and ends iteration instead of yielding
+                            # them to an async-for loop.
+                            if msg.type in (
+                                aiohttp.WSMsgType.CLOSE,
+                                aiohttp.WSMsgType.CLOSING,
+                                aiohttp.WSMsgType.CLOSED,
+                            ):
+                                self.closed = True
+                                return
                             yield msg
                     else:
                         # Small sleep to avoid busy waiting when no messages

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_connection_status.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_connection_status.py
@@ -98,11 +98,11 @@ def test_connection_status_reports_connected_after_handshake(
     ), f"never observed a 'connected' transition: {tester.transitions}"
 
 
-# The vendor drops the socket mid-session (a CLOSED frame). The extension
-# must report "disconnected" (with close details) before scheduling the
-# reconnect — otherwise the reported connection_status stays wrong for the
-# whole reconnect window.
-def test_connection_status_reports_disconnected_on_ws_close(
+# aiohttp consumes CLOSE/CLOSING/CLOSED frames in __anext__ and ends iteration
+# via StopAsyncIteration. The extension must report "disconnected" and
+# reconnect after that normal loop exit rather than waiting for a close frame
+# that aiohttp never yields to the loop body.
+def test_connection_status_reports_disconnected_on_iterator_exit(
     patch_smallest_ws,
 ):
     connect_attempts = 0
@@ -128,6 +128,26 @@ def test_connection_status_reports_disconnected_on_ws_close(
 
     from unittest.mock import patch
 
+    class IteratorEndingWebSocket:
+        def __init__(self) -> None:
+            self.closed = False
+            self.close_code = None
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            self.closed = True
+            self.close_code = 1000
+            raise StopAsyncIteration
+
+        async def close(self) -> bool:
+            self.closed = True
+            return True
+
+        def exception(self):
+            return None
+
     class MockSessionMidClose:
         def __init__(self, *args, **kwargs) -> None:
             self.closed: bool = False
@@ -136,20 +156,20 @@ def test_connection_status_reports_disconnected_on_ws_close(
             nonlocal connect_attempts
             connect_attempts += 1
 
-            ws = patch_smallest_ws.ws
-            ws.closed = False
-            ws._exception = None
             with patch_smallest_ws.messages_lock:
                 patch_smallest_ws.messages.clear()
 
             if connect_attempts == 1:
-                push_after(0.3, patch_smallest_ws.WSMsgType.CLOSED)
-            else:
-                push_after(
-                    0.3,
-                    patch_smallest_ws.WSMsgType.TEXT,
-                    json.dumps(transcript_message),
-                )
+                return IteratorEndingWebSocket()
+
+            ws = patch_smallest_ws.ws
+            ws.closed = False
+            ws._exception = None
+            push_after(
+                0.3,
+                patch_smallest_ws.WSMsgType.TEXT,
+                json.dumps(transcript_message),
+            )
             return ws
 
         async def close(self) -> None:
@@ -187,11 +207,18 @@ def test_connection_status_reports_disconnected_on_ws_close(
             "connected" in statuses
         ), f"never observed a 'connected' transition: {tester.transitions}"
         assert "disconnected" in statuses, (
-            "never observed a 'disconnected' transition after the ws close: "
+            "never observed a 'disconnected' transition after iterator exit: "
             f"{tester.transitions}"
         )
-        # The close must be reported before the reconnect's own "connected"
-        # transition, not silently skipped.
-        assert statuses.index("disconnected") > statuses.index(
-            "connected"
-        ), f"disconnected did not follow the initial connect: {statuses}"
+        assert connect_attempts >= 2, "iterator exit did not trigger reconnect"
+        assert statuses.count("connected") >= 2, (
+            "never observed the reconnect's 'connected' transition: "
+            f"{statuses}"
+        )
+        first_connected = statuses.index("connected")
+        disconnected = statuses.index("disconnected")
+        reconnected = statuses.index("connected", first_connected + 1)
+        assert first_connected < disconnected < reconnected, (
+            "expected connected -> disconnected -> connected transitions: "
+            f"{statuses}"
+        )

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_connection_status.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_connection_status.py
@@ -136,15 +136,10 @@ def test_connection_status_reports_disconnected_on_iterator_exit(
             nonlocal connect_attempts
             connect_attempts += 1
 
-            ws = patch_smallest_ws.ws
-            ws.closed = False
-            ws.close_code = None
-            ws._exception = None
-            with patch_smallest_ws.messages_lock:
-                patch_smallest_ws.messages.clear()
+            ws = patch_smallest_ws.prepare_connection()
 
             if connect_attempts == 1:
-                push_after(0.3, patch_smallest_ws.WSMsgType.CLOSED)
+                push_after(0.3, patch_smallest_ws.WSMsgType.CLOSED, 1006)
             else:
                 push_after(
                     0.3,
@@ -204,3 +199,11 @@ def test_connection_status_reports_disconnected_on_iterator_exit(
             "expected connected -> disconnected -> connected transitions: "
             f"{statuses}"
         )
+        disconnected_transition = next(
+            transition
+            for transition in tester.transitions
+            if transition.get("current") == "disconnected"
+        )
+        assert "close code: 1006" in disconnected_transition.get(
+            "message", ""
+        ), f"close code was not reported: {disconnected_transition}"

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_connection_status.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_connection_status.py
@@ -128,26 +128,6 @@ def test_connection_status_reports_disconnected_on_iterator_exit(
 
     from unittest.mock import patch
 
-    class IteratorEndingWebSocket:
-        def __init__(self) -> None:
-            self.closed = False
-            self.close_code = None
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            self.closed = True
-            self.close_code = 1000
-            raise StopAsyncIteration
-
-        async def close(self) -> bool:
-            self.closed = True
-            return True
-
-        def exception(self):
-            return None
-
     class MockSessionMidClose:
         def __init__(self, *args, **kwargs) -> None:
             self.closed: bool = False
@@ -156,20 +136,21 @@ def test_connection_status_reports_disconnected_on_iterator_exit(
             nonlocal connect_attempts
             connect_attempts += 1
 
+            ws = patch_smallest_ws.ws
+            ws.closed = False
+            ws.close_code = None
+            ws._exception = None
             with patch_smallest_ws.messages_lock:
                 patch_smallest_ws.messages.clear()
 
             if connect_attempts == 1:
-                return IteratorEndingWebSocket()
-
-            ws = patch_smallest_ws.ws
-            ws.closed = False
-            ws._exception = None
-            push_after(
-                0.3,
-                patch_smallest_ws.WSMsgType.TEXT,
-                json.dumps(transcript_message),
-            )
+                push_after(0.3, patch_smallest_ws.WSMsgType.CLOSED)
+            else:
+                push_after(
+                    0.3,
+                    patch_smallest_ws.WSMsgType.TEXT,
+                    json.dumps(transcript_message),
+                )
             return ws
 
         async def close(self) -> None:
@@ -198,7 +179,8 @@ def test_connection_status_reports_disconnected_on_iterator_exit(
         )
         err = tester.run()
         assert err is None, (
-            f"test_connection_status_reports_disconnected_on_ws_close err "
+            "test_connection_status_reports_disconnected_on_iterator_exit "
+            "err "
             f"code: {err.error_code()} message: {err.error_message()}"
         )
 

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_reconnect.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_reconnect.py
@@ -92,8 +92,7 @@ def test_reconnect(patch_smallest_ws):
 
             # On 4th attempt, allow connection to succeed
             # Reset closed state and exception for successful connection
-            patch_smallest_ws.ws.closed = False
-            patch_smallest_ws.ws._exception = None
+            patch_smallest_ws.prepare_connection()
 
             # Schedule transcript message after a short delay
             def delayed_transcript():
@@ -233,14 +232,7 @@ def test_reconnect_after_ws_close(patch_smallest_ws):
             nonlocal connect_attempts
             connect_attempts += 1
 
-            ws = patch_smallest_ws.ws
-            ws.closed = False
-            ws.close_code = None
-            ws._exception = None
-            # Each connection starts with a fresh message buffer so a new
-            # message loop does not replay the previous session's messages.
-            with patch_smallest_ws.messages_lock:
-                patch_smallest_ws.messages.clear()
+            ws = patch_smallest_ws.prepare_connection()
 
             if connect_attempts == 1:
                 # Simulate the vendor dropping the socket mid-session.

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_reconnect.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_reconnect.py
@@ -235,6 +235,7 @@ def test_reconnect_after_ws_close(patch_smallest_ws):
 
             ws = patch_smallest_ws.ws
             ws.closed = False
+            ws.close_code = None
             ws._exception = None
             # Each connection starts with a fresh message buffer so a new
             # message loop does not replay the previous session's messages.

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_reconnect_lifecycle.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_reconnect_lifecycle.py
@@ -42,6 +42,36 @@ def test_schedule_reconnect_is_single_flight():
     asyncio.run(run_test())
 
 
+def test_disconnect_during_reconnect_unwind_schedules_follow_up():
+    async def run_test() -> None:
+        extension = make_extension()
+        reconnect_calls = 0
+        second_reconnect = asyncio.Event()
+
+        async def reconnect() -> None:
+            nonlocal reconnect_calls
+            reconnect_calls += 1
+            if reconnect_calls == 1:
+                # Model a successful handshake followed by an immediate close
+                # before this reconnect task's done callback has run.
+                extension.connected = True
+                extension.connected = False
+                extension._schedule_reconnect()
+            else:
+                extension.connected = True
+                second_reconnect.set()
+
+        extension._handle_reconnect = reconnect  # type: ignore[method-assign]
+
+        extension._schedule_reconnect()
+        await asyncio.wait_for(second_reconnect.wait(), timeout=1.0)
+
+        assert reconnect_calls == 2
+        await extension._cancel_reconnect_task()
+
+    asyncio.run(run_test())
+
+
 def test_on_stop_cancels_reconnect_during_backoff():
     async def run_test() -> None:
         extension = make_extension()

--- a/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_reconnect_lifecycle.py
+++ b/ai_agents/agents/ten_packages/extension/smallest_asr_python/tests/test_reconnect_lifecycle.py
@@ -1,0 +1,166 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+
+from ten_ai_base.asr import AsyncASRBaseExtension
+
+from ..extension import SmallestASRExtension
+
+
+def make_extension() -> SmallestASRExtension:
+    extension = SmallestASRExtension("smallest_asr_python")
+    extension.ten_env = MagicMock()
+    extension.send_asr_error = AsyncMock()  # type: ignore[method-assign]
+    extension.on_disconnected = AsyncMock()  # type: ignore[method-assign]
+    return extension
+
+
+def test_schedule_reconnect_is_single_flight():
+    async def run_test() -> None:
+        extension = make_extension()
+        reconnect_calls = 0
+        release = asyncio.Event()
+
+        async def reconnect() -> None:
+            nonlocal reconnect_calls
+            reconnect_calls += 1
+            await release.wait()
+
+        extension._handle_reconnect = reconnect  # type: ignore[method-assign]
+
+        extension._schedule_reconnect()
+        extension._schedule_reconnect()
+        await asyncio.sleep(0)
+
+        assert reconnect_calls == 1
+
+        release.set()
+        await extension._cancel_reconnect_task()
+
+    asyncio.run(run_test())
+
+
+def test_on_stop_cancels_reconnect_during_backoff():
+    async def run_test() -> None:
+        extension = make_extension()
+        reconnect_started = asyncio.Event()
+        reconnect_cancelled = asyncio.Event()
+
+        async def reconnect() -> None:
+            reconnect_started.set()
+            try:
+                await asyncio.Future()
+            finally:
+                reconnect_cancelled.set()
+
+        async def base_on_stop(
+            self: AsyncASRBaseExtension, ten_env: MagicMock
+        ) -> None:
+            self.stopped = True
+
+        extension._handle_reconnect = reconnect  # type: ignore[method-assign]
+        extension._schedule_reconnect()
+        await reconnect_started.wait()
+
+        with patch.object(AsyncASRBaseExtension, "on_stop", base_on_stop):
+            await extension.on_stop(extension.ten_env)
+
+        assert reconnect_cancelled.is_set()
+        assert extension._reconnect_task is None
+
+    asyncio.run(run_test())
+
+
+def test_stale_message_loop_does_not_reconnect_replacement_socket():
+    async def run_test() -> None:
+        extension = make_extension()
+        extension.connected = True
+        iterator_started = asyncio.Event()
+        finish_iteration = asyncio.Event()
+
+        class PausingWebSocket:
+            closed = False
+            close_code = 1006
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                iterator_started.set()
+                await finish_iteration.wait()
+                raise StopAsyncIteration
+
+        stale_ws = PausingWebSocket()
+        replacement_ws = SimpleNamespace(closed=False, close_code=None)
+        extension.ws = stale_ws  # type: ignore[assignment]
+        extension._schedule_reconnect = MagicMock()  # type: ignore[method-assign]
+
+        message_task = asyncio.create_task(extension._process_messages())
+        await iterator_started.wait()
+        extension.ws = replacement_ws  # type: ignore[assignment]
+        finish_iteration.set()
+        await message_task
+
+        assert extension.connected is True
+        extension.send_asr_error.assert_not_awaited()  # type: ignore[attr-defined]
+        extension.on_disconnected.assert_not_awaited()  # type: ignore[attr-defined]
+        extension._schedule_reconnect.assert_not_called()  # type: ignore[attr-defined]
+
+    asyncio.run(run_test())
+
+
+def test_message_error_marks_connection_disconnected():
+    async def run_test() -> None:
+        extension = make_extension()
+        extension.connected = True
+
+        class ErrorWebSocket:
+            closed = False
+            close_code = None
+            yielded = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.yielded:
+                    raise StopAsyncIteration
+                self.yielded = True
+                return SimpleNamespace(type=aiohttp.WSMsgType.ERROR)
+
+            def exception(self):
+                return RuntimeError("vendor socket failed")
+
+        ws = ErrorWebSocket()
+        extension.ws = ws  # type: ignore[assignment]
+        extension._schedule_reconnect = MagicMock()  # type: ignore[method-assign]
+
+        await extension._process_messages()
+
+        assert extension.connected is False
+        extension.send_asr_error.assert_awaited_once()  # type: ignore[attr-defined]
+        extension.on_disconnected.assert_awaited_once()  # type: ignore[attr-defined]
+        extension._schedule_reconnect.assert_called_once()  # type: ignore[attr-defined]
+
+    asyncio.run(run_test())
+
+
+def test_same_socket_disconnect_is_reported_once():
+    async def run_test() -> None:
+        extension = make_extension()
+        extension.connected = True
+        ws = SimpleNamespace(closed=False, close_code=1006)
+        extension.ws = ws  # type: ignore[assignment]
+        extension._schedule_reconnect = MagicMock()  # type: ignore[method-assign]
+
+        await extension._handle_unexpected_disconnect("first failure", ws)  # type: ignore[arg-type]
+        await extension._handle_unexpected_disconnect("second failure", ws)  # type: ignore[arg-type]
+
+        assert extension.connected is False
+        extension.send_asr_error.assert_awaited_once()  # type: ignore[attr-defined]
+        extension.on_disconnected.assert_awaited_once()  # type: ignore[attr-defined]
+        extension._schedule_reconnect.assert_called_once()  # type: ignore[attr-defined]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary

`aiohttp.ClientWebSocketResponse.__anext__` raises `StopAsyncIteration` for
`CLOSE`, `CLOSING`, and `CLOSED`, so the previous in-loop close branch was
unreachable in production. A normal message-loop exit therefore left the
session dead without scheduling a reconnect.

This PR:

- treats a normal WebSocket iterator exit as an unexpected disconnect while   the extension is running;
- reports `disconnected`, including the WebSocket close code, and reconnects;
- removes the unreachable in-loop close branch;
- makes the shared WebSocket mock end iteration on close frames, matching aiohttp (so`test_reconnect_after_ws_close` now exercises the production  path too);
- serializes reconnect work, ignores stale socket callbacks, drains reconnect tasks during shutdown, preserves disconnects that arrive while a reconnect task is unwinding, and preserves the reconnect retry/status lifecycle;
- corrects the Guarder fatal-code comparison exposed by the repaired retry exhaustion path.

This is a follow-up to #2293.

## Extension version

`smallest_asr_python` **0.1.1 -> 0.1.2**

The version is synchronized in `manifest.json` and `pyproject.toml`.

## Regression coverage

The connection-status regression now ends the iterator with a close code of `1006` and verifies:

- `connected -> disconnected -> connected` status transitions;
- a second vendor connection attempt;
- propagation of the close code in the disconnect message.

Additional focused tests cover single-flight reconnect scheduling, reconnect cancellation during shutdown backoff, a socket closing while the prior reconnect task is unwinding, stale message-loop completion, error disconnect handling, and duplicate disconnect suppression.


## Guarder test results

`task asr-guarder-test EXTENSION=smallest_asr_python`

```text
12 passed, 1 deselected, 19 warnings in 174.26s (0:02:54)
```

This includes `test_reconnection`, `test_connection_status_reconnection`, and
`test_same_session_finalize_reconnect`.

Long-duration live Pulse case (run explicitly because it is excluded by the
default Guarder selection):

```text
1 passed, 12 deselected, 1 warning in 310.53s (0:05:10)
```

## Shared Guarder finding

Repairing retry failure propagation made the Guarder's fatal-exhaustion path reachable for this extension. That exposed an existing type mismatch: `ModuleErrorCode` is a `str` enum, so `FATAL_ERROR.value` is `"-1000"`, while the error payload carries the integer `-1000`. The Guarder assertion now casts the enum value to `int`, matching the existing `NON_FATAL_ERROR` comparison.

The underlying enum contract remains owned by `ten_ai_base`; this PR only corrects the shared conformance check that it exercises.

## Extension-local tests

`cd ai_agents/agents/ten_packages/extension/smallest_asr_python/tests && ./bin/start`

```text
16 passed, 1 warning in 17.00s
```

