### PR TITLE
fix(asr): align iFLYTEK integration for 0.2.1

### DIFF
--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/CHANGELOG.md
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the iFLYTEK ASR Python Extension are documented here.
 
+## 0.2.1 - 2026-09-02
+
+- Align the packaged extension with the reviewed conversational agent
+  integration, including the reconnect-limit error naming used by vendor
+  error classification.
+- Preserve `ReconnectLimitReached` as a legacy alias for 0.2.x callers.
+- Modernize the protocol `Mapping` import to use `collections.abc`.
+
 ## 0.2.0 - 2026-08-20
 
 - Standardize vendor and connection settings under `property.params` so TEN

--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/docs/PRODUCTION_READINESS.md
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/docs/PRODUCTION_READINESS.md
@@ -1,6 +1,6 @@
 # iFLYTEK ASR Production Readiness
 
-This checklist applies to `iflytek_asr_python` version `0.2.0`. It complements
+This checklist applies to `iflytek_asr_python` version `0.2.1`. It complements
 the automated tests; deployment-specific networking, credentials, privacy,
 capacity, and monitoring remain operator responsibilities.
 

--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/extension.py
@@ -34,7 +34,7 @@ from ten_runtime import AsyncTenEnv, AudioFrame
 from .client import IFlytekAsrClient, IFlytekAsrClientListener
 from .config import IFlytekAsrConfig
 from .protocol import IFlytekProtocolError, IFlytekResponse
-from .reconnect_manager import ReconnectLimitReached, ReconnectManager
+from .reconnect_manager import ReconnectLimitReachedError, ReconnectManager
 
 DUMP_FILE_NAME = "iflytek_asr_in.pcm"
 
@@ -369,7 +369,7 @@ class IFlytekAsrExtension(AsyncASRBaseExtension, IFlytekAsrClientListener):
 
                 try:
                     await self.reconnect_manager.attempt(connect)
-                except ReconnectLimitReached as error:
+                except ReconnectLimitReachedError as error:
                     self._should_reconnect = False
                     await self._send_framework_error(error, fatal=True)
                     return
@@ -390,7 +390,7 @@ class IFlytekAsrExtension(AsyncASRBaseExtension, IFlytekAsrClientListener):
                     )
                     if exhausted:
                         self._should_reconnect = False
-                        limit_error = ReconnectLimitReached(
+                        limit_error = ReconnectLimitReachedError(
                             "maximum reconnection attempts reached"
                         )
                         await self._send_framework_error(
@@ -572,7 +572,7 @@ class IFlytekAsrExtension(AsyncASRBaseExtension, IFlytekAsrClientListener):
         vendor_message = self._error_message(error)
         if isinstance(error, IFlytekProtocolError):
             vendor_code = self._sanitize_text(error.code)[:128]
-        elif isinstance(error, ReconnectLimitReached):
+        elif isinstance(error, ReconnectLimitReachedError):
             vendor_code = "reconnect_exhausted"
         elif isinstance(error, ValidationError):
             vendor_code = "invalid_config"

--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/manifest.json
@@ -1,7 +1,7 @@
 {
   "type": "extension",
   "name": "iflytek_asr_python",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "display_name": {
     "locales": {
       "en-US": {

--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/protocol.py
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/protocol.py
@@ -4,9 +4,10 @@
 # See the LICENSE file for more information.
 #
 import base64
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 import json
-from typing import Any, Mapping
+from typing import Any
 
 from .config import IFlytekAsrConfig
 

--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/pyproject.toml
@@ -8,7 +8,7 @@
 [project]
 name = "iflytek-asr-python"
 description = "TEN Framework ASR extension for iFLYTEK realtime transcription"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">=3.10"
 dependencies = [
     "websockets>=14.0",

--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/reconnect_manager.py
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/reconnect_manager.py
@@ -7,8 +7,12 @@ import asyncio
 from collections.abc import Awaitable, Callable
 
 
-class ReconnectLimitReached(RuntimeError):
+class ReconnectLimitReachedError(RuntimeError):
     pass
+
+
+# Legacy compatibility alias for 0.2.x; remove in 0.3.0.
+ReconnectLimitReached = ReconnectLimitReachedError
 
 
 SleepCallable = Callable[[float], Awaitable[None]]
@@ -47,7 +51,9 @@ class ReconnectManager:
 
     def next_delay(self) -> float:
         if not self.can_retry():
-            raise ReconnectLimitReached("maximum reconnection attempts reached")
+            raise ReconnectLimitReachedError(
+                "maximum reconnection attempts reached"
+            )
         return min(
             self.base_delay * (2**self.current_attempts),
             self.max_delay,

--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/tests/test_package_contract.py
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/tests/test_package_contract.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -6,9 +7,48 @@ import pytest
 PACKAGE_ROOT = Path(__file__).parents[1]
 
 
+def test_package_versions_match() -> None:
+    manifest = json.loads(
+        (PACKAGE_ROOT / "manifest.json").read_text(encoding="utf-8")
+    )
+    pyproject = (PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    project = re.search(
+        r"^\[project\]\s*$\n(?P<body>.*?)(?=^\[|\Z)",
+        pyproject,
+        re.MULTILINE | re.DOTALL,
+    )
+
+    assert project is not None, "pyproject.toml is missing [project]"
+    pyproject_version = re.search(
+        r'^version\s*=\s*"([^"]+)"',
+        project.group("body"),
+        re.MULTILINE,
+    )
+
+    assert pyproject_version is not None, "[project] is missing a version"
+    version = manifest["version"]
+    assert version == pyproject_version.group(1)
+
+    production_readiness = (
+        PACKAGE_ROOT / "docs" / "PRODUCTION_READINESS.md"
+    ).read_text(encoding="utf-8")
+    changelog = (PACKAGE_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert f"version `{version}`." in production_readiness
+    assert re.search(
+        rf"^## {re.escape(version)} - \d{{4}}-\d{{2}}-\d{{2}}$",
+        changelog,
+        re.MULTILINE,
+    )
+
+
 def test_default_properties_are_declared_in_manifest() -> None:
-    manifest = json.loads((PACKAGE_ROOT / "manifest.json").read_text())
-    defaults = json.loads((PACKAGE_ROOT / "property.json").read_text())
+    manifest = json.loads(
+        (PACKAGE_ROOT / "manifest.json").read_text(encoding="utf-8")
+    )
+    defaults = json.loads(
+        (PACKAGE_ROOT / "property.json").read_text(encoding="utf-8")
+    )
     properties = manifest["api"]["property"]["properties"]
 
     assert set(properties) == {"params", "dump", "dump_path"}
@@ -23,7 +63,7 @@ def test_default_properties_are_declared_in_manifest() -> None:
     ids=lambda path: path.name,
 )
 def test_guarder_configs_use_nested_params(config_path: Path) -> None:
-    config = json.loads(config_path.read_text())
+    config = json.loads(config_path.read_text(encoding="utf-8"))
 
     assert set(config) <= {"params", "dump", "dump_path"}
     assert "params" in config

--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/tests/test_reconnect_manager.py
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/tests/test_reconnect_manager.py
@@ -4,8 +4,13 @@ import pytest
 
 from iflytek_asr_python.reconnect_manager import (
     ReconnectLimitReached,
+    ReconnectLimitReachedError,
     ReconnectManager,
 )
+
+
+def test_legacy_reconnect_limit_exception_name_is_preserved() -> None:
+    assert ReconnectLimitReached is ReconnectLimitReachedError
 
 
 def test_reconnect_manager_uses_capped_exponential_backoff_and_resets() -> None:
@@ -65,7 +70,7 @@ def test_reconnect_manager_stops_at_configured_limit() -> None:
                 await manager.attempt(fail)
 
         assert manager.can_retry() is False
-        with pytest.raises(ReconnectLimitReached):
+        with pytest.raises(ReconnectLimitReachedError):
             await manager.attempt(fail)
 
     asyncio.run(run())

--- a/ai_agents/agents/ten_packages/extension/iflytek_asr_python/tests/test_vendor_error.py
+++ b/ai_agents/agents/ten_packages/extension/iflytek_asr_python/tests/test_vendor_error.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from iflytek_asr_python.protocol import IFlytekProtocolError
-from iflytek_asr_python.reconnect_manager import ReconnectLimitReached
+from iflytek_asr_python.reconnect_manager import ReconnectLimitReachedError
 
 from .helpers import create_extension, data_as_dict
 
@@ -14,7 +14,7 @@ def test_vendor_errors_include_classification_code_and_message() -> None:
             IFlytekProtocolError("vendor-429", "temporarily overloaded")
         )
         await extension._send_framework_error(
-            ReconnectLimitReached("maximum reconnection attempts reached"),
+            ReconnectLimitReachedError("maximum reconnection attempts reached"),
             fatal=True,
         )
 


### PR DESCRIPTION
Align reconnect error naming and Python compatibility with the reviewed conversational agent integration. Update extension metadata, release documentation, and affected tests for the 0.2.1 package.