### PR TITLE
docs: fix agent quick start task command

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ cd agents/examples/voice-assistant-realtime
 
 ##### 6. Start the web server
 
-Run `task build` if you changed any local source code. This step is required for compiled languages (for example, TypeScript or Go) and not needed for Python.
+Run `task install` before the first launch and after changing dependencies or Go source code. It installs the TEN, Python, and frontend dependencies and builds the Go API server. Python-only source changes do not require reinstalling.
 
 ```bash
 task install

--- a/docs/README-CN.md
+++ b/docs/README-CN.md
@@ -289,7 +289,7 @@ cd agents/examples/voice-assistant-realtime
 
 ##### 6. 启动 Web 服务
 
-如果修改过本地源码，先运行 `task build`。对于 TypeScript、Go 等需要编译的语言必须执行此步骤，Python 项目则无需。
+首次启动前，以及依赖或 Go 源码发生变化后，请运行 `task install`。它会安装 TEN、Python 和前端依赖，并构建 Go API 服务。仅修改 Python 源码时无需重新安装。
 
 ```bash
 task install

--- a/docs/README-ES.md
+++ b/docs/README-ES.md
@@ -255,7 +255,7 @@ cd agents/examples/voice-assistant-realtime
 
 ##### 6. Inicia el servidor web
 
-Ejecuta `task build` si cambiaste código local. Es obligatorio para lenguajes compilados (TypeScript, Go, etc.) y opcional para Python.
+Ejecuta `task install` antes del primer inicio y después de cambiar las dependencias o el código fuente de Go. Este comando instala las dependencias de TEN, Python y frontend, y compila el servidor API de Go. Los cambios que solo afectan a Python no requieren reinstalación.
 
 ```bash
 task install

--- a/docs/README-FR.md
+++ b/docs/README-FR.md
@@ -255,7 +255,7 @@ cd agents/examples/voice-assistant-realtime
 
 ##### 6. Démarrez le serveur web
 
-Exécutez `task build` si vous avez modifié le code. Obligatoire pour les langages compilés (TypeScript, Go, etc.), inutile pour Python.
+Exécutez `task install` avant le premier lancement et après toute modification des dépendances ou du code source Go. Cette commande installe les dépendances TEN, Python et frontend, puis compile le serveur API Go. Les modifications portant uniquement sur Python ne nécessitent pas de nouvelle installation.
 
 ```bash
 task install

--- a/docs/README-IT.md
+++ b/docs/README-IT.md
@@ -255,7 +255,7 @@ cd agents/examples/voice-assistant-realtime
 
 ##### 6. Avvia il server web
 
-Esegui `task build` se hai modificato il codice locale. È obbligatorio per i linguaggi compilati (TypeScript, Go, ecc.) e facoltativo per Python.
+Esegui `task install` prima del primo avvio e dopo aver modificato le dipendenze o il codice sorgente Go. Questo comando installa le dipendenze TEN, Python e frontend e compila il server API Go. Le modifiche al solo codice Python non richiedono una nuova installazione.
 
 ```bash
 task install

--- a/docs/README-JP.md
+++ b/docs/README-JP.md
@@ -255,7 +255,7 @@ cd agents/examples/voice-assistant-realtime
 
 ##### 6. Web サーバーを起動
 
-ローカルコードを変更した場合は `task build` を実行してください。TypeScript や Go などのコンパイル言語では必須、Python では不要です。
+初回起動前、および依存関係や Go のソースコードを変更した後は `task install` を実行してください。このコマンドは TEN、Python、フロントエンドの依存関係をインストールし、Go API サーバーをビルドします。Python のソースコードのみを変更した場合、再インストールは不要です。
 
 ```bash
 task install

--- a/docs/README-KR.md
+++ b/docs/README-KR.md
@@ -255,7 +255,7 @@ cd agents/examples/voice-assistant-realtime
 
 ##### 6. 웹 서버 시작
 
-로컬 소스를 수정했다면 `task build`를 실행하세요. TypeScript, Go 등 컴파일 언어에서는 필수이며 Python 에서는 선택입니다.
+처음 실행하기 전과 종속성 또는 Go 소스 코드를 변경한 후에는 `task install`을 실행하세요. 이 명령은 TEN, Python, 프런트엔드 종속성을 설치하고 Go API 서버를 빌드합니다. Python 소스 코드만 변경한 경우에는 다시 설치할 필요가 없습니다.
 
 ```bash
 task install


### PR DESCRIPTION
## Summary

- replace the obsolete `task build` instruction with the available `task install` workflow
- clarify when installation and the Go API server rebuild are required
- keep all localized quick-start READMEs consistent

## Testing

- `git diff --check`
- verified the example Taskfile exposes `install`, `build-api-server`, and `run`, but no `build` task