### PR TITLE
feat(mllm): add ThunderPhone speech-to-speech extension

### DIFF
--- a/ai_agents/.env.example
+++ b/ai_agents/.env.example
@@ -80,6 +80,11 @@ DEEPSEEK_API_KEY=
 
 # Stepfun API Key
 STEPFUN_API_KEY=
+
+# Extension: thunderphone_mllm_python
+# ThunderPhone secret key (sk_live_...) and, optionally, a saved agent id
+THUNDERPHONE_API_KEY=
+THUNDERPHONE_AGENT_ID=
 GLADIA_API_KEY=
 
 # Extension: bedrock_llm

--- a/ai_agents/agents/examples/voice-assistant-realtime/README.md
+++ b/ai_agents/agents/examples/voice-assistant-realtime/README.md
@@ -5,7 +5,7 @@ A real-time voice assistant optimized for ultra-low-latency conversation using v
 ## Features
 
 - **Ultra-Low Latency Voice Interaction**: Direct speech-to-speech conversation with minimal delay
-- **Multi-Provider Support**: Compatible with OpenAI GPT Realtime, Azure Voice AI, Gemini 2.0 Flash, GLM, StepFun, and other voice-to-voice models
+- **Multi-Provider Support**: Compatible with OpenAI GPT Realtime, Azure Voice AI, Gemini 2.0 Flash, GLM, StepFun, ThunderPhone, and other voice-to-voice models
 
 ## Prerequisites
 
@@ -20,6 +20,7 @@ A real-time voice assistant optimized for ultra-low-latency conversation using v
    - **Gemini**: `GEMINI_API_KEY` - For Gemini 2.0 Flash
    - **GLM**: `GLM_API_KEY` - For GLM voice models
    - **StepFun**: `STEPFUN_API_KEY` - For StepFun voice models
+   - **ThunderPhone**: `THUNDERPHONE_API_KEY` (and optionally `THUNDERPHONE_AGENT_ID`) - For ThunderPhone phone agents
 
 ### Optional Environment Variables
 
@@ -48,6 +49,8 @@ GEMINI_API_KEY=your_gemini_api_key_here
 GLM_API_KEY=your_glm_api_key_here
 # OR
 STEPFUN_API_KEY=your_stepfun_api_key_here
+# OR
+THUNDERPHONE_API_KEY=your_thunderphone_secret_key_here
 
 # Optional
 WEATHERAPI_API_KEY=your_weather_api_key_here

--- a/ai_agents/agents/examples/voice-assistant-realtime/tenapp/manifest.json
+++ b/ai_agents/agents/examples/voice-assistant-realtime/tenapp/manifest.json
@@ -37,6 +37,9 @@
       "path": "../../../ten_packages/extension/stepfun_mllm_python"
     },
     {
+      "path": "../../../ten_packages/extension/thunderphone_mllm_python"
+    },
+    {
       "path": "../../../ten_packages/extension/message_collector2"
     },
     {

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/README.md
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/README.md
@@ -1,0 +1,89 @@
+# thunderphone_mllm_python
+
+Run a [ThunderPhone](https://thunderphone.com) voice agent as the
+speech-to-speech (multimodal LLM) model of a TEN graph. ThunderPhone handles
+speech recognition, the language model, the voice, turn-taking, 47 languages
+and tools; TEN handles the transport (Agora RTC, WebSocket, ...) and the rest
+of the graph.
+
+ThunderPhone's [Realtime WebSocket API](https://thunderphone.com/docs/api-reference/realtime)
+speaks the OpenAI Realtime protocol, so this extension mirrors
+`openai_mllm_python` and implements the same `mllm-interface.json`.
+
+## Two ways to use it
+
+**Saved agent.** Set `agent_id`. The agent's prompt, voice, engine, languages,
+tools, greeting and silence handling are configured on ThunderPhone; the
+graph only moves audio. Tools registered in the graph are ignored.
+
+**Inline session.** Leave `agent_id` empty and set `prompt` (and optionally
+`product`, `voice`, `language`). Tools registered in the graph
+(`tool_register`) are sent to ThunderPhone with the first `session.update`,
+which starts the call. ThunderPhone freezes instructions, tools and voice at
+that point, so tools must be registered before audio starts (the extension
+waits up to 500 ms after the session is created for late registrations).
+
+Every WebSocket session is one call, visible in ThunderPhone's call history
+and billed per minute. When the ThunderPhone agent hangs up (`call.ended`)
+the extension does not reconnect, because a reconnect would start a new call.
+
+## Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `api_key` | `string` | ThunderPhone secret key (`sk_live_...`). Default `${env:THUNDERPHONE_API_KEY}`. |
+| `agent_id` | `string` | Id of a saved ThunderPhone agent. Leave empty for an inline session. |
+| `product` | `string` | Engine for inline sessions: `spark`, `bolt` or `storm`. |
+| `voice` | `string` | ThunderPhone voice name for inline sessions. |
+| `language` | `string` | Primary language hint for inline sessions, e.g. `es`. |
+| `prompt` | `string` | Instructions for inline sessions. Required without `agent_id`. |
+| `from_number`, `to_number` | `string` | Numbers to record on the call when the graph fronts a phone line. |
+| `live_transcripts` | `bool` | Stream caller transcript fragments mid-utterance (billed extra). |
+| `sample_rate` | `int32` | PCM sample rate in both directions: `24000` (default) or `16000`. |
+| `base_url`, `path` | `string` | Endpoint override. Defaults to `wss://api.thunderphone.com` + `/v1/realtime`. |
+
+## Graph
+
+Swap the `v2v` node of `examples/voice-assistant-realtime` for:
+
+```json
+{
+  "type": "extension",
+  "name": "v2v",
+  "addon": "thunderphone_mllm_python",
+  "property": {
+    "api_key": "${env:THUNDERPHONE_API_KEY}",
+    "agent_id": "${env:THUNDERPHONE_AGENT_ID|}",
+    "product": "bolt",
+    "language": "en",
+    "prompt": "You are Acme Dental's receptionist. Be brief."
+  }
+}
+```
+
+The extension emits the standard MLLM server events
+(`mllm_server_session_ready`, `mllm_server_input_transcript`,
+`mllm_server_output_transcript`, `mllm_server_interrupted`,
+`mllm_server_function_call`). Transcript metadata carries the ThunderPhone
+`call_id`, usable with `GET /v1/calls/{call_id}` for the recording,
+transcript and grade after the call.
+
+## Notes
+
+- Turn detection is server-side and always on.
+- Injected assistant messages (`mllm_client_message_item` with role
+  `assistant`) are not accepted by ThunderPhone; put the greeting in the
+  prompt or on the saved agent, then trigger it with
+  `mllm_client_create_response` (inline sessions only; a saved agent greets
+  on its own).
+- Audio is 16-bit mono PCM in both directions.
+
+## Tests
+
+```bash
+task test-extension EXTENSION=agents/ten_packages/extension/thunderphone_mllm_python
+```
+
+`tests/test_realtime.py` needs no credentials. `tests/test_extension.py`
+drives the addon through the TEN runtime; with `THUNDERPHONE_API_KEY` set it
+opens a real (billed) session.

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/__init__.py
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/__init__.py
@@ -1,0 +1,6 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+from . import addon

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/addon.py
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/addon.py
@@ -1,0 +1,22 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+from ten_runtime import (
+    Addon,
+    register_addon_as_extension,
+    TenEnv,
+)
+
+
+@register_addon_as_extension("thunderphone_mllm_python")
+class ThunderPhoneRealtimeExtensionAddon(Addon):
+
+    def on_create_instance(self, ten_env: TenEnv, name: str, context) -> None:
+        from .extension import ThunderPhoneRealtimeExtension
+
+        ten_env.log_info("ThunderPhoneRealtimeExtensionAddon on_create_instance")
+        ten_env.on_create_instance_done(
+            ThunderPhoneRealtimeExtension(name), context
+        )

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/config.py
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/config.py
@@ -1,0 +1,136 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+"""Extension configuration and the session.update it turns into.
+
+Kept free of ten_runtime imports so it can be unit-tested anywhere.
+"""
+from typing import Any, Union
+
+from pydantic import BaseModel, field_validator
+
+from .realtime.struct import SessionUpdate, SessionUpdateParams
+
+DEFAULT_BASE_URL = "wss://api.thunderphone.com"
+DEFAULT_PATH = "/v1/realtime"
+API_KEY_PREFIX = "sk_live_"
+SUPPORTED_SAMPLE_RATES = (16000, 24000)
+
+
+class ThunderPhoneRealtimeConfig(BaseModel):
+    api_key: str = ""
+    base_url: str = DEFAULT_BASE_URL
+    path: str = DEFAULT_PATH
+    # A saved ThunderPhone agent: prompt, voice, engine, languages, tools and
+    # greeting live on ThunderPhone. Leave empty for an inline session.
+    agent_id: Union[str, int] = ""
+    # Inline sessions only.
+    product: str = ""
+    voice: str = ""
+    language: str = ""
+    prompt: str = ""
+    # Recorded on the call when the graph fronts a phone line.
+    from_number: str = ""
+    to_number: str = ""
+    # Stream caller transcript fragments mid-utterance (billed extra).
+    live_transcripts: bool = False
+    sample_rate: int = 24000
+    dump: bool = False
+    dump_path: str = ""
+
+    @field_validator("agent_id", mode="before")
+    @classmethod
+    def _agent_id_as_str(cls, value: Any) -> str:
+        return "" if value is None else str(value).strip()
+
+    @property
+    def saved_agent(self) -> bool:
+        return bool(self.agent_id)
+
+    def validate_for_start(self) -> None:
+        """Raise ValueError for a configuration the server would reject."""
+        if not self.api_key.startswith(API_KEY_PREFIX):
+            raise ValueError(
+                f"api_key must be a ThunderPhone secret key ({API_KEY_PREFIX}...)"
+            )
+        if not self.saved_agent and not self.prompt.strip():
+            raise ValueError(
+                "prompt is required for an inline session (or set agent_id)"
+            )
+        if self.sample_rate not in SUPPORTED_SAMPLE_RATES:
+            raise ValueError(
+                f"sample_rate must be one of {SUPPORTED_SAMPLE_RATES}"
+            )
+
+    def query(self) -> dict[str, str]:
+        """Connect-URL query: who to call, wire audio, and call.* events."""
+        query: dict[str, str] = {}
+        if self.saved_agent:
+            query["agent_id"] = self.agent_id
+        else:
+            if self.product:
+                query["product"] = self.product
+            if self.language:
+                query["language"] = self.language
+        if self.from_number:
+            query["from_number"] = self.from_number
+        if self.to_number:
+            query["to_number"] = self.to_number
+        rate = str(self.sample_rate)
+        query.update(
+            {
+                "input_audio_format": "pcm16",
+                "input_rate": rate,
+                "output_audio_format": "pcm16",
+                "output_rate": rate,
+                # Hang-up reason, transfer and keypad events. For a saved
+                # agent this is the only way to opt in; inline sessions also
+                # set it in session.config below.
+                "call_events": "1",
+            }
+        )
+        return query
+
+
+def tool_dict(tool: Any) -> dict[str, Any]:
+    """An LLMToolMetadata as an OpenAI function tool."""
+    t: dict[str, Any] = {
+        "type": "function",
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": False,
+        },
+    }
+    for param in tool.parameters:
+        t["parameters"]["properties"][param.name] = {
+            "type": param.type,
+            "description": param.description,
+        }
+        if param.required:
+            t["parameters"]["required"].append(param.name)
+    return t
+
+
+def inline_session_update(
+    config: ThunderPhoneRealtimeConfig, tools: list[Any]
+) -> SessionUpdate:
+    """The one session.update that starts an inline call.
+
+    ThunderPhone freezes instructions, tools and voice on this event, so
+    everything the session needs goes into it at once.
+    """
+    params = SessionUpdateParams(
+        instructions=config.prompt,
+        tools=[tool_dict(t) for t in tools] if tools else None,
+        tool_choice="auto" if tools else None,
+        voice=config.voice or None,
+        config={"call_events": True},
+        live_transcripts=True if config.live_transcripts else None,
+    )
+    return SessionUpdate(session=params)

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/extension.py
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/extension.py
@@ -1,0 +1,513 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+"""ThunderPhone voice agents as a TEN multimodal (speech-to-speech) LLM.
+
+ThunderPhone's Realtime WebSocket API speaks the OpenAI Realtime protocol,
+so this extension follows openai_mllm_python closely. What differs:
+
+* one WebSocket is one billable call. It never reconnects after the
+  platform ends the call (``call.ended``), and an inline session starts on
+  its first ``session.update``, which freezes instructions, tools and voice;
+  the extension therefore sends a single, complete update once audio starts
+  (or shortly after the session is created), so tools registered at graph
+  start are included;
+* a saved agent (``agent_id``) brings its own prompt, voice, engine,
+  languages, tools and greeting; nothing is sent to configure it;
+* ThunderPhone's ``call.*`` events (hang-up reason, transfer, keypad) are
+  logged, and ``call.ended`` stops the extension from reconnecting.
+"""
+import asyncio
+import base64
+import traceback
+
+import aiohttp
+
+from ten_ai_base.mllm import AsyncMLLMBaseExtension
+from ten_ai_base.struct import (
+    MLLMClientFunctionCallOutput,
+    MLLMClientMessageItem,
+    MLLMServerFunctionCall,
+    MLLMServerInputTranscript,
+    MLLMServerInterrupt,
+    MLLMServerOutputTranscript,
+    MLLMServerSessionReady,
+)
+from ten_ai_base.types import LLMToolMetadata
+from ten_runtime import AsyncTenEnv, AudioFrame, Data
+
+from .config import ThunderPhoneRealtimeConfig, inline_session_update
+from .realtime.connection import ThunderPhoneConnection
+from .realtime.struct import (
+    CallEvent,
+    ContentType,
+    ErrorMessage,
+    FunctionCallOutputItemParam,
+    InputAudioBufferSpeechStarted,
+    InputAudioBufferSpeechStopped,
+    ItemCreate,
+    ItemCreated,
+    ItemInputAudioTranscriptionCompleted,
+    ItemInputAudioTranscriptionDelta,
+    ItemInputAudioTranscriptionFailed,
+    ResponseAudioDelta,
+    ResponseAudioDone,
+    ResponseAudioTranscriptDelta,
+    ResponseAudioTranscriptDone,
+    ResponseCreate,
+    ResponseCreated,
+    ResponseDone,
+    ResponseFunctionCallArgumentsDone,
+    ResponseOutputItemAdded,
+    ResponseOutputItemDone,
+    ResponseTextDelta,
+    ResponseTextDone,
+    SessionCreated,
+    SessionUpdated,
+    UnknownMessage,
+    UserMessageItemParam,
+)
+
+# How long an inline session waits for tool registrations before starting
+# the call on its own. The first audio frame starts it earlier.
+INLINE_START_GRACE_S = 0.5
+RECONNECT_DELAY_S = 1.0
+
+
+class ThunderPhoneRealtimeExtension(AsyncMLLMBaseExtension):
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.ten_env: AsyncTenEnv = None
+        self.config: ThunderPhoneRealtimeConfig = None
+        self.conn: ThunderPhoneConnection | None = None
+        self.loop: asyncio.AbstractEventLoop = None
+
+        self.stopped: bool = False
+        self.connected: bool = False
+        self.call_ended: bool = False
+        self.call_id = None
+        self.session_ready: bool = False
+        # Inline sessions: the call has started once the session.update is out.
+        self.started: bool = False
+        self._start_task: asyncio.Task | None = None
+
+        self.request_transcript: str = ""
+        self.response_transcript: str = ""
+        self.available_tools: list[LLMToolMetadata] = []
+
+    # ------------------------------------------------------------ lifecycle
+
+    async def on_init(self, ten_env: AsyncTenEnv) -> None:
+        await super().on_init(ten_env)
+        ten_env.log_debug("on_init")
+        self.ten_env = ten_env
+
+        properties, _ = await ten_env.get_property_to_json(None)
+        self.config = ThunderPhoneRealtimeConfig.model_validate_json(properties)
+        ten_env.log_info(
+            f"config: {self.config.model_copy(update={'api_key': '***'})}"
+        )
+        try:
+            self.config.validate_for_start()
+        except ValueError as e:
+            ten_env.log_error(str(e))
+            raise
+        if self.config.saved_agent and (
+            self.config.prompt or self.config.voice or self.config.product
+        ):
+            ten_env.log_info(
+                "agent_id is set: prompt, voice and product are ignored, the "
+                "saved agent's own configuration is used"
+            )
+
+    async def on_stop(self, ten_env: AsyncTenEnv) -> None:
+        await super().on_stop(ten_env)
+        self.stopped = True
+        if self._start_task:
+            self._start_task.cancel()
+        if self.conn:
+            await self.conn.close()
+
+    async def on_data(self, ten_env: AsyncTenEnv, data: Data) -> None:
+        await super().on_data(ten_env, data)
+
+    def vendor(self) -> str:
+        return "thunderphone"
+
+    def input_audio_sample_rate(self) -> int:
+        return self.config.sample_rate
+
+    def synthesize_audio_sample_rate(self) -> int:
+        return self.config.sample_rate
+
+    def is_connected(self) -> bool:
+        return self.connected
+
+    # ----------------------------------------------------------- connection
+
+    async def start_connection(self) -> None:
+        if self.call_ended:
+            self.ten_env.log_info("ThunderPhone call already ended; not starting a new one")
+            return
+        self.loop = asyncio.get_running_loop()
+        try:
+            self.conn = ThunderPhoneConnection(
+                ten_env=self.ten_env,
+                base_url=self.config.base_url,
+                path=self.config.path,
+                api_key=self.config.api_key,
+                query=self.config.query(),
+            )
+            try:
+                await self.conn.connect()
+            except aiohttp.WSServerHandshakeError as e:
+                # A rejected key or agent never gets better on retry.
+                self.ten_env.log_error(
+                    f"ThunderPhone refused the connection: {e.status} {e.message}"
+                )
+                self.stopped = True
+                return
+
+            response_id = ""
+            flushed: set[str] = set()
+            self.ten_env.log_info("Client loop started")
+            async for message in self.conn.listen():
+                try:
+                    match message:
+                        case SessionCreated():
+                            self.ten_env.log_info(
+                                f"Session is created: {message.session}"
+                            )
+                            self.connected = True
+                            self._note_call_id(message.session.call_id)
+                            if self.config.saved_agent:
+                                # The agent is already live and greets on its own.
+                                await self._mark_session_ready()
+                            else:
+                                self._arm_inline_start()
+                            await self._resume_context(self.message_context)
+                        case SessionUpdated():
+                            self.ten_env.log_info(
+                                f"Session is updated: {message.session}"
+                            )
+                            self._note_call_id(message.session.call_id)
+                            await self._mark_session_ready()
+                        case ItemInputAudioTranscriptionDelta():
+                            self.request_transcript += message.delta
+                            await self.send_server_input_transcript(
+                                MLLMServerInputTranscript(
+                                    content=self.request_transcript,
+                                    delta=message.delta,
+                                    final=False,
+                                    metadata=self._metadata(),
+                                )
+                            )
+                        case ItemInputAudioTranscriptionCompleted():
+                            self.ten_env.log_debug(
+                                f"On request transcript {message.transcript}"
+                            )
+                            await self.send_server_input_transcript(
+                                MLLMServerInputTranscript(
+                                    content=message.transcript,
+                                    delta=message.transcript,
+                                    final=True,
+                                    metadata=self._metadata(),
+                                )
+                            )
+                            self.request_transcript = ""
+                        case ItemInputAudioTranscriptionFailed():
+                            self.ten_env.log_warn(
+                                f"On request transcript failed {message.item_id} {message.error}"
+                            )
+                            self.request_transcript = ""
+                        case ItemCreated():
+                            self.ten_env.log_debug(f"On item {message.item}")
+                        case ResponseCreated():
+                            response_id = message.response.id
+                            self.ten_env.log_debug(
+                                f"On response created {response_id}"
+                            )
+                        case ResponseDone():
+                            if message.response.id == response_id:
+                                response_id = ""
+                            self.ten_env.log_debug(
+                                f"On response done {message.response.id} {message.response.status}"
+                            )
+                        case ResponseAudioTranscriptDelta() | ResponseTextDelta():
+                            if message.response_id in flushed:
+                                continue
+                            self.response_transcript += message.delta
+                            await self.send_server_output_text(
+                                MLLMServerOutputTranscript(
+                                    content=self.response_transcript,
+                                    delta=message.delta,
+                                    final=False,
+                                    metadata=self._metadata(),
+                                )
+                            )
+                        case ResponseAudioTranscriptDone() | ResponseTextDone():
+                            if message.response_id in flushed:
+                                continue
+                            await self.send_server_output_text(
+                                MLLMServerOutputTranscript(
+                                    content=self.response_transcript,
+                                    delta="",
+                                    final=True,
+                                    metadata=self._metadata(),
+                                )
+                            )
+                            self.response_transcript = ""
+                        case ResponseOutputItemAdded() | ResponseOutputItemDone():
+                            self.ten_env.log_debug(f"Output item {message.item}")
+                        case ResponseAudioDelta():
+                            if message.response_id in flushed:
+                                continue
+                            await self.send_server_output_audio_data(
+                                base64.b64decode(message.delta)
+                            )
+                        case ResponseAudioDone():
+                            pass
+                        case InputAudioBufferSpeechStarted():
+                            # Server-side turn detection: the caller took the
+                            # turn, so whatever the agent was saying is over.
+                            self.ten_env.log_info(
+                                f"On server listening, in response {response_id}"
+                            )
+                            await self.send_server_interrupted(
+                                sos=MLLMServerInterrupt()
+                            )
+                            if response_id and self.response_transcript:
+                                await self.send_server_output_text(
+                                    MLLMServerOutputTranscript(
+                                        content=self.response_transcript
+                                        + "[interrupted]",
+                                        delta=None,
+                                        final=True,
+                                        metadata=self._metadata(),
+                                    )
+                                )
+                                self.response_transcript = ""
+                                flushed.add(response_id)
+                        case InputAudioBufferSpeechStopped():
+                            self.ten_env.log_debug("On server stop listening")
+                        case ResponseFunctionCallArgumentsDone():
+                            self.ten_env.log_info(
+                                f"need to call func {message.name}"
+                            )
+                            asyncio.create_task(
+                                self._handle_tool_call(
+                                    message.call_id,
+                                    message.name,
+                                    message.arguments,
+                                )
+                            )
+                        case CallEvent():
+                            self._on_call_event(message)
+                        case ErrorMessage():
+                            # ThunderPhone errors are per-event and non-fatal;
+                            # a fatal one is followed by the socket closing.
+                            self.ten_env.log_warn(
+                                f"Error message received: {message.error}"
+                            )
+                        case UnknownMessage():
+                            self.ten_env.log_debug(
+                                f"Not handled message {message.type}"
+                            )
+                        case _:
+                            self.ten_env.log_debug(
+                                f"Not handled message {message}"
+                            )
+                except Exception as e:
+                    traceback.print_exc()
+                    self.ten_env.log_error(
+                        f"Error processing message: {message} {e}"
+                    )
+            self.ten_env.log_info(
+                f"Client loop finished (close code {self.conn.close_code})"
+            )
+        except Exception as e:
+            traceback.print_exc()
+            self.ten_env.log_error(f"Failed to handle loop {e}")
+
+        await self._handle_reconnect()
+
+    async def stop_connection(self) -> None:
+        self.connected = False
+        if self._start_task:
+            self._start_task.cancel()
+            self._start_task = None
+        if self.conn is not None:
+            await self.conn.close()
+
+    async def _handle_reconnect(self) -> None:
+        await self.stop_connection()
+        if self.stopped:
+            return
+        if self.call_ended:
+            self.ten_env.log_info(
+                "ThunderPhone ended the call; not reconnecting (a reconnect "
+                "would start a new call)"
+            )
+            return
+        # The socket dropped mid-call. The call is over on ThunderPhone's
+        # side, so this starts a fresh one for the participant still here.
+        self.started = False
+        self.session_ready = False
+        await asyncio.sleep(RECONNECT_DELAY_S)
+        await self.start_connection()
+
+    # ------------------------------------------------------- inline session
+
+    def _arm_inline_start(self) -> None:
+        # Tools register through `tool_register` cmds that may land after
+        # the socket is up; wait briefly for them unless audio arrives first.
+        if self._start_task is None:
+            self._start_task = asyncio.create_task(self._start_after_grace())
+
+    async def _start_after_grace(self) -> None:
+        try:
+            await asyncio.sleep(INLINE_START_GRACE_S)
+            await self._ensure_started()
+        except asyncio.CancelledError:
+            pass
+
+    async def _ensure_started(self) -> None:
+        """Send the session.update that starts an inline call, once."""
+        if self.started or self.config.saved_agent or not self.connected:
+            return
+        self.started = True
+        if self._start_task is not None and self._start_task is not asyncio.current_task():
+            self._start_task.cancel()
+        self._start_task = None
+        update = inline_session_update(self.config, self.available_tools)
+        self.ten_env.log_info(
+            f"update session with {len(self.available_tools)} tool(s)"
+        )
+        await self.conn.send_request(update)
+
+    async def _mark_session_ready(self) -> None:
+        if self.session_ready:
+            return
+        self.session_ready = True
+        await self.send_server_session_ready(MLLMServerSessionReady())
+
+    def _note_call_id(self, call_id) -> None:
+        if call_id is not None and call_id != self.call_id:
+            self.call_id = call_id
+            self.ten_env.log_info(f"ThunderPhone call id: {call_id}")
+
+    def _metadata(self) -> dict:
+        return {
+            "session_id": self.session_id if self.session_id else "-1",
+            "call_id": str(self.call_id) if self.call_id is not None else "",
+        }
+
+    def _on_call_event(self, event: CallEvent) -> None:
+        self.ten_env.log_info(
+            f"ThunderPhone {event.type} reason={event.reason} detail={event.detail}"
+        )
+        if event.type == "call.ended":
+            # The server closes the socket right after this event.
+            self.call_ended = True
+            self.connected = False
+
+    # ---------------------------------------------------------- client side
+
+    async def send_audio(
+        self, frame: AudioFrame, session_id: str | None
+    ) -> bool:
+        self.session_id = session_id
+        if not self.connected or self.conn is None:
+            return False
+        await self._ensure_started()
+        await self.conn.send_audio_data(frame.get_buf())
+        return True
+
+    async def send_client_message_item(
+        self, item: MLLMClientMessageItem, session_id: str | None = None
+    ) -> None:
+        match item.role:
+            case "user":
+                await self._ensure_started()
+                await self.conn.send_request(
+                    ItemCreate(
+                        item=UserMessageItemParam(
+                            content=[
+                                {
+                                    "type": ContentType.InputText,
+                                    "text": item.content,
+                                }
+                            ]
+                        )
+                    )
+                )
+            case "assistant":
+                # ThunderPhone keeps the agent's own words; injected assistant
+                # turns are rejected by the server.
+                self.ten_env.log_warn(
+                    "ThunderPhone does not accept injected assistant messages; "
+                    "put the greeting in the prompt or on the saved agent"
+                )
+            case _:
+                self.ten_env.log_error(f"Unknown role: {item.role}")
+
+    async def send_client_create_response(
+        self, session_id: str | None = None
+    ) -> None:
+        if self.config.saved_agent:
+            # A saved agent greets and takes turns on its own.
+            return
+        await self._ensure_started()
+        await self.conn.send_request(ResponseCreate())
+
+    async def send_client_register_tool(self, tool: LLMToolMetadata) -> None:
+        if self.config.saved_agent:
+            self.ten_env.log_warn(
+                f"tool {tool.name} ignored: a saved ThunderPhone agent runs "
+                "its own tools; use an inline session for graph tools"
+            )
+            return
+        if self.started:
+            self.ten_env.log_warn(
+                f"tool {tool.name} registered after the call started; "
+                "ThunderPhone freezes tools on the first session.update"
+            )
+            return
+        self.available_tools.append(tool)
+
+    async def send_client_function_call_output(
+        self, function_call_output: MLLMClientFunctionCallOutput
+    ) -> None:
+        self.ten_env.log_info(
+            f"Sending function call output: {function_call_output.output}"
+        )
+        await self.conn.send_request(
+            ItemCreate(
+                item=FunctionCallOutputItemParam(
+                    call_id=function_call_output.call_id,
+                    output=function_call_output.output,
+                )
+            )
+        )
+
+    async def _resume_context(
+        self, messages: list[MLLMClientMessageItem]
+    ) -> None:
+        for message in messages:
+            self.ten_env.log_info(f"Resuming context with messages: {message}")
+            await self.send_client_message_item(message)
+
+    async def _handle_tool_call(
+        self, tool_call_id: str, name: str, arguments: str
+    ) -> None:
+        self.ten_env.log_info(
+            f"_handle_tool_call {tool_call_id} {name} {arguments}"
+        )
+        await self.send_server_function_call(
+            MLLMServerFunctionCall(
+                call_id=tool_call_id, name=name, arguments=arguments
+            )
+        )

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/manifest.json
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/manifest.json
@@ -1,0 +1,76 @@
+{
+  "type": "extension",
+  "name": "thunderphone_mllm_python",
+  "version": "0.1.0",
+  "dependencies": [
+    {
+      "type": "system",
+      "name": "ten_runtime_python",
+      "version": "0.11"
+    },
+    {
+      "type": "system",
+      "name": "ten_ai_base",
+      "version": "0.7"
+    }
+  ],
+  "package": {
+    "include": [
+      "manifest.json",
+      "property.json",
+      "**.tent",
+      "**.py",
+      "README.md",
+      "realtime/**.tent",
+      "realtime/**.py",
+      "pyproject.toml"
+    ]
+  },
+  "api": {
+    "interface": [
+      {
+        "import_uri": "../../system/ten_ai_base/api/mllm-interface.json"
+      }
+    ],
+    "property": {
+      "properties": {
+        "api_key": {
+          "type": "string"
+        },
+        "base_url": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "agent_id": {
+          "type": "string"
+        },
+        "product": {
+          "type": "string"
+        },
+        "voice": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "prompt": {
+          "type": "string"
+        },
+        "from_number": {
+          "type": "string"
+        },
+        "to_number": {
+          "type": "string"
+        },
+        "live_transcripts": {
+          "type": "bool"
+        },
+        "sample_rate": {
+          "type": "int32"
+        }
+      }
+    }
+  }
+}

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/property.json
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/property.json
@@ -1,0 +1,7 @@
+{
+    "api_key": "${env:THUNDERPHONE_API_KEY}",
+    "agent_id": "${env:THUNDERPHONE_AGENT_ID|}",
+    "product": "bolt",
+    "language": "en",
+    "prompt": "You are a helpful voice assistant. Keep your answers short."
+}

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/pyproject.toml
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "thunderphone-mllm-python"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "aiohttp>=3.14.1",
+    "pydantic>=2.13.4",
+]

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/realtime/connection.py
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/realtime/connection.py
@@ -1,0 +1,125 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+import asyncio
+import base64
+import json
+from typing import TYPE_CHECKING, Any, AsyncGenerator
+from urllib.parse import urlencode
+
+import aiohttp
+
+from .struct import (
+    ClientToServerMessage,
+    InputAudioBufferAppend,
+    ServerToClientMessage,
+    parse_server_message,
+    to_json,
+)
+
+if TYPE_CHECKING:
+    from ten_runtime import AsyncTenEnv
+
+
+def smart_str(s: str, max_field_len: int = 128) -> str:
+    """Parse a JSON frame and truncate its audio/delta field for logging."""
+    try:
+        data = json.loads(s)
+        if "delta" in data:
+            key = "delta"
+        elif "audio" in data:
+            key = "audio"
+        else:
+            return s
+        if isinstance(data[key], str) and len(data[key]) > max_field_len:
+            data[key] = data[key][:max_field_len] + "..."
+        return json.dumps(data)
+    except (json.JSONDecodeError, TypeError):
+        return s
+
+
+def build_url(base_url: str, path: str, query: dict[str, str]) -> str:
+    """``base_url + path`` with ``query`` merged into any query the path has."""
+    url = base_url.rstrip("/") + path
+    if not query:
+        return url
+    return url + ("&" if "?" in url else "?") + urlencode(query)
+
+
+class ThunderPhoneConnection:
+    """One WebSocket to ThunderPhone's realtime endpoint, i.e. one call."""
+
+    def __init__(
+        self,
+        ten_env: "AsyncTenEnv",
+        base_url: str,
+        path: str,
+        api_key: str,
+        query: dict[str, str],
+        verbose: bool = False,
+    ):
+        self.ten_env = ten_env
+        self.url = build_url(base_url, path, query)
+        self.api_key = api_key
+        self.verbose = verbose
+        self.websocket: aiohttp.ClientWebSocketResponse | None = None
+        self.session = aiohttp.ClientSession()
+
+    async def connect(self) -> None:
+        self.websocket = await self.session.ws_connect(
+            url=self.url,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+
+    @property
+    def close_code(self) -> int | None:
+        return self.websocket.close_code if self.websocket else None
+
+    async def send_audio_data(self, audio_data: bytes) -> None:
+        """audio_data is pcm16 mono little-endian at the configured rate."""
+        await self.send_request(
+            InputAudioBufferAppend(
+                audio=base64.b64encode(audio_data).decode("utf-8")
+            )
+        )
+
+    async def send_request(self, message: ClientToServerMessage) -> None:
+        assert self.websocket is not None
+        message_str = to_json(message)
+        if self.verbose:
+            self.ten_env.log_info(f"-> {smart_str(message_str)}")
+        await self.websocket.send_str(message_str)
+
+    async def listen(self) -> AsyncGenerator[ServerToClientMessage, None]:
+        assert self.websocket is not None
+        try:
+            async for msg in self.websocket:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    if self.verbose:
+                        self.ten_env.log_info(f"<- {smart_str(msg.data)}")
+                    parsed = self.handle_server_message(msg.data)
+                    if parsed is not None:
+                        yield parsed
+                elif msg.type == aiohttp.WSMsgType.ERROR:
+                    self.ten_env.log_error(
+                        f"Error during receive: {self.websocket.exception()}"
+                    )
+                    break
+        except asyncio.CancelledError:
+            self.ten_env.log_info("Receive messages task cancelled")
+
+    def handle_server_message(self, message: str) -> ServerToClientMessage | None:
+        try:
+            return parse_server_message(message)
+        except Exception as e:  # a malformed frame must not end the call
+            self.ten_env.log_warn(f"Error handling message {e}")
+            return None
+
+    async def close(self) -> None:
+        if self.websocket:
+            await self.websocket.close()
+            self.websocket = None
+        if not self.session.closed:
+            await self.session.close()

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/realtime/struct.py
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/realtime/struct.py
@@ -1,0 +1,975 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+"""OpenAI Realtime protocol structs, as spoken by ThunderPhone.
+
+Adapted from openai_mllm_python: session objects tolerate ThunderPhone's GA
+shape (nested ``audio``, a ``call_id``, voices that are not OpenAI names),
+``session.update`` carries ThunderPhone's ``config``/``live_transcripts``
+keys, GA ``conversation.item.added/done`` map onto ``ItemCreated`` and the
+platform's ``call.*`` events parse into ``CallEvent`` instead of raising.
+"""
+import json
+
+from dataclasses import dataclass, asdict, field, is_dataclass
+from typing import Any, Dict, Literal, Optional, List, Set, Union
+from enum import Enum
+import uuid
+
+
+def generate_event_id() -> str:
+    return str(uuid.uuid4())
+
+
+# Enums
+class Voices(str, Enum):
+    Alloy = "alloy"
+    Echo = "echo"
+    Fable = "fable"
+    Nova = "nova"
+    Nova_2 = "nova_2"
+    Nova_3 = "nova_3"
+    Nova_4 = "nova_4"
+    Nova_5 = "nova_5"
+    Onyx = "onyx"
+    Shimmer = "shimmer"
+
+
+class AudioFormats(str, Enum):
+    PCM16 = "pcm16"
+    G711_ULAW = "g711_ulaw"
+    G711_ALAW = "g711_alaw"
+
+
+class ItemType(str, Enum):
+    Message = "message"
+    FunctionCall = "function_call"
+    FunctionCallOutput = "function_call_output"
+
+
+class MessageRole(str, Enum):
+    System = "system"
+    User = "user"
+    Assistant = "assistant"
+
+
+class ContentType(str, Enum):
+    InputText = "input_text"
+    InputAudio = "input_audio"
+    Text = "text"
+    Audio = "audio"
+
+
+@dataclass
+class FunctionToolChoice:
+    name: str  # Name of the function
+    type: str = "function"  # Fixed value for type
+
+
+# ToolChoice can be either a literal string or FunctionToolChoice
+ToolChoice = Union[
+    str, FunctionToolChoice
+]  # "none", "auto", "required", or FunctionToolChoice
+
+
+@dataclass
+class RealtimeError:
+    type: str  # The type of the error
+    message: str  # The error message
+    code: Optional[str] = None  # Optional error code
+    param: Optional[str] = None  # Optional parameter related to the error
+    event_id: Optional[str] = None  # Optional event ID for tracing
+
+
+@dataclass
+class InputAudioTranscription:
+    model: str = "gpt-4o-transcribe"
+    prompt: str = ""
+    language: str = "en"
+
+
+@dataclass
+class ServerVADUpdateParams:
+    threshold: Optional[float] = None  # Threshold for voice activity detection
+    prefix_padding_ms: Optional[int] = (
+        None  # Amount of padding before the voice starts (in milliseconds)
+    )
+    silence_duration_ms: Optional[int] = (
+        None  # Duration of silence before considering speech stopped (in milliseconds)
+    )
+    type: Literal["server_vad"] = "server_vad"
+    create_response: bool = True  # only in conversation mode
+    interrupt_response: bool = True  # only in conversation mode
+
+
+@dataclass
+class SemanticVADUpdateParams:
+    type: Literal["semantic_vad"] = "semantic_vad"
+    eagerness: Literal["low", "medium", "high", "auto"] = "auto"
+    create_response: bool = True  # only in conversation mode
+    interrupt_response: bool = True  # only in conversation mode
+
+
+@dataclass
+class Session:
+    id: str = ""  # The unique identifier for the session
+    model: str = ""  # The model ThunderPhone echoes ("thunderphone-realtime")
+    expires_at: int = 0  # Unused by ThunderPhone; a session lives as long as the call
+    call_id: Optional[Union[str, int]] = None  # ThunderPhone call id, for GET /v1/calls/{call_id}
+    object: str = "realtime.session"  # Fixed value indicating the object type
+    modalities: Set[str] = field(
+        default_factory=lambda: {"text", "audio"}
+    )  # Set of allowed modalities (e.g., "text", "audio")
+    instructions: Optional[str] = (
+        None  # Instructions or guidance for the session
+    )
+    voice: Optional[str] = None  # ThunderPhone voice name (e.g. "olivia")
+    turn_detection: Optional[Dict[str, Any]] = None  # Server-side, always on
+    input_audio_format: AudioFormats = (
+        AudioFormats.PCM16
+    )  # Audio format for input (e.g., "pcm16")
+    output_audio_format: AudioFormats = (
+        AudioFormats.PCM16
+    )  # Audio format for output (e.g., "pcm16")
+    input_audio_transcription: Optional[Dict[str, Any]] = None
+    tools: List[Dict[str, Union[str, Any]]] = field(
+        default_factory=list
+    )  # List of tools available during the session
+    tool_choice: Literal["auto", "none", "required"] = (
+        "auto"  # How tools should be used in the session
+    )
+    temperature: float = 0.8  # Temperature setting for model creativity
+    max_response_output_tokens: Union[int, Literal["inf"]] = (
+        "inf"  # Maximum number of tokens in the response, or "inf" for unlimited
+    )
+
+
+@dataclass
+class SessionUpdateParams:
+    model: Optional[str] = None  # Optional string to specify the model
+    modalities: Optional[Set[str]] = (
+        None  # Set of allowed modalities (e.g., "text", "audio")
+    )
+    instructions: Optional[str] = None  # Optional instructions string
+    voice: Optional[str] = None  # ThunderPhone voice name, e.g. "olivia"
+    turn_detection: Optional[
+        Union[ServerVADUpdateParams, SemanticVADUpdateParams]
+    ] = None  # Server VAD update params
+    input_audio_format: Optional[AudioFormats] = (
+        None  # Input audio format from `AudioFormats` Enum
+    )
+    output_audio_format: Optional[AudioFormats] = (
+        None  # Output audio format from `AudioFormats` Enum
+    )
+    input_audio_transcription: Optional[InputAudioTranscription] = None
+
+    tools: Optional[List[Dict[str, Union[str, any]]]] = (
+        None  # List of tools (e.g., dictionaries)
+    )
+    tool_choice: Optional[ToolChoice] = (
+        None  # ToolChoice, either string or `FunctionToolChoice`
+    )
+    temperature: Optional[float] = (
+        None  # Optional temperature for response generation
+    )
+    max_response_output_tokens: Optional[Union[int, str]] = (
+        None  # Max response tokens, "inf" for infinite
+    )
+    # ThunderPhone extensions: platform config (call_events, telephony, ...)
+    # and live caller transcript fragments.
+    config: Optional[Dict[str, Any]] = None
+    live_transcripts: Optional[bool] = None
+
+
+# Define individual message item param types
+@dataclass
+class SystemMessageItemParam:
+    content: List[dict]  # This can be more specific based on content structure
+    id: Optional[str] = None
+    status: Optional[str] = None
+    type: str = "message"
+    role: str = "system"
+
+
+@dataclass
+class UserMessageItemParam:
+    content: List[dict]  # Similarly, content can be more specific
+    id: Optional[str] = None
+    status: Optional[str] = None
+    type: str = "message"
+    role: str = "user"
+
+
+@dataclass
+class AssistantMessageItemParam:
+    content: List[dict]  # Content structure here depends on your schema
+    id: Optional[str] = None
+    status: Optional[str] = None
+    type: str = "message"
+    role: str = "assistant"
+
+
+@dataclass
+class FunctionCallItemParam:
+    name: str
+    call_id: str
+    arguments: str
+    type: str = "function_call"
+    id: Optional[str] = None
+    status: Optional[str] = None
+
+
+@dataclass
+class FunctionCallOutputItemParam:
+    call_id: str
+    output: str
+    id: Optional[str] = None
+    type: str = "function_call_output"
+
+
+# Union of all possible item types
+ItemParam = Union[
+    SystemMessageItemParam,
+    UserMessageItemParam,
+    AssistantMessageItemParam,
+    FunctionCallItemParam,
+    FunctionCallOutputItemParam,
+]
+
+
+# Assuming the EventType and other enums are already defined
+# For reference:
+class EventType(str, Enum):
+    SESSION_UPDATE = "session.update"
+    INPUT_AUDIO_BUFFER_APPEND = "input_audio_buffer.append"
+    INPUT_AUDIO_BUFFER_COMMIT = "input_audio_buffer.commit"
+    INPUT_AUDIO_BUFFER_CLEAR = "input_audio_buffer.clear"
+    UPDATE_CONVERSATION_CONFIG = "update_conversation_config"
+    ITEM_CREATE = "conversation.item.create"
+    ITEM_TRUNCATE = "conversation.item.truncate"
+    ITEM_DELETE = "conversation.item.delete"
+    RESPONSE_CREATE = "response.create"
+    RESPONSE_CANCEL = "response.cancel"
+
+    ERROR = "error"
+    SESSION_CREATED = "session.created"
+    SESSION_UPDATED = "session.updated"
+
+    INPUT_AUDIO_BUFFER_COMMITTED = "input_audio_buffer.committed"
+    INPUT_AUDIO_BUFFER_CLEARED = "input_audio_buffer.cleared"
+    INPUT_AUDIO_BUFFER_SPEECH_STARTED = "input_audio_buffer.speech_started"
+    INPUT_AUDIO_BUFFER_SPEECH_STOPPED = "input_audio_buffer.speech_stopped"
+
+    ITEM_CREATED = "conversation.item.created"
+    ITEM_ADDED = "conversation.item.added"  # GA name for the same event
+    ITEM_DONE = "conversation.item.done"
+    ITEM_DELETED = "conversation.item.deleted"
+    ITEM_TRUNCATED = "conversation.item.truncated"
+    ITEM_INPUT_AUDIO_TRANSCRIPTION_DELTA = (
+        "conversation.item.input_audio_transcription.delta"
+    )
+    ITEM_INPUT_AUDIO_TRANSCRIPTION_COMPLETED = (
+        "conversation.item.input_audio_transcription.completed"
+    )
+    ITEM_INPUT_AUDIO_TRANSCRIPTION_FAILED = (
+        "conversation.item.input_audio_transcription.failed"
+    )
+
+    RESPONSE_CREATED = "response.created"
+    RESPONSE_CANCELLED = "response.cancelled"
+    RESPONSE_DONE = "response.done"
+    RESPONSE_OUTPUT_ITEM_ADDED = "response.output_item.added"
+    RESPONSE_OUTPUT_ITEM_DONE = "response.output_item.done"
+    RESPONSE_CONTENT_PART_ADDED = "response.content_part.added"
+    RESPONSE_CONTENT_PART_DONE = "response.content_part.done"
+    RESPONSE_TEXT_DELTA = "response.text.delta"
+    RESPONSE_TEXT_DONE = "response.text.done"
+    RESPONSE_AUDIO_TRANSCRIPT_DELTA = "response.audio_transcript.delta"
+    RESPONSE_AUDIO_TRANSCRIPT_DONE = "response.audio_transcript.done"
+    RESPONSE_AUDIO_DELTA = "response.audio.delta"
+    RESPONSE_AUDIO_DONE = "response.audio.done"
+    # GA names for the same events; ThunderPhone sends these.
+    RESPONSE_OUTPUT_TEXT_DELTA = "response.output_text.delta"
+    RESPONSE_OUTPUT_TEXT_DONE = "response.output_text.done"
+    RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA = "response.output_audio_transcript.delta"
+    RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE = "response.output_audio_transcript.done"
+    RESPONSE_OUTPUT_AUDIO_DELTA = "response.output_audio.delta"
+    RESPONSE_OUTPUT_AUDIO_DONE = "response.output_audio.done"
+    RESPONSE_FUNCTION_CALL_ARGUMENTS_DELTA = (
+        "response.function_call_arguments.delta"
+    )
+    RESPONSE_FUNCTION_CALL_ARGUMENTS_DONE = (
+        "response.function_call_arguments.done"
+    )
+    RATE_LIMITS_UPDATED = "rate_limits.updated"
+
+
+# Base class for all ServerToClientMessages
+@dataclass
+class ServerToClientMessage:
+    event_id: str
+
+
+@dataclass
+class ErrorMessage(ServerToClientMessage):
+    error: RealtimeError
+    type: str = EventType.ERROR
+
+
+@dataclass
+class CallEvent(ServerToClientMessage):
+    """A ThunderPhone platform event (``call.ended``, ``call.transfer``,
+    ``call.keypad``, ``call.speech_ignored``, ...). Only sent when the
+    session opted in with ``call_events``."""
+
+    type: str = ""
+    reason: Optional[str] = None
+    detail: Optional[str] = None
+
+
+@dataclass
+class UnknownMessage(ServerToClientMessage):
+    """A server event this client does not model; logged and ignored."""
+
+    type: str = ""
+
+
+@dataclass
+class SessionCreated(ServerToClientMessage):
+    session: Session
+    type: str = EventType.SESSION_CREATED
+
+
+@dataclass
+class SessionUpdated(ServerToClientMessage):
+    session: Session
+    type: str = EventType.SESSION_UPDATED
+
+
+@dataclass
+class InputAudioBufferCommitted(ServerToClientMessage):
+    item_id: str
+    type: str = EventType.INPUT_AUDIO_BUFFER_COMMITTED
+    previous_item_id: Optional[str] = None
+
+
+@dataclass
+class InputAudioBufferCleared(ServerToClientMessage):
+    type: str = EventType.INPUT_AUDIO_BUFFER_CLEARED
+
+
+@dataclass
+class InputAudioBufferSpeechStarted(ServerToClientMessage):
+    audio_start_ms: int
+    item_id: str
+    type: str = EventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED
+
+
+@dataclass
+class InputAudioBufferSpeechStopped(ServerToClientMessage):
+    audio_end_ms: int
+    type: str = EventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED
+    item_id: Optional[str] = None
+
+
+@dataclass
+class ItemCreated(ServerToClientMessage):
+    item: ItemParam
+    type: str = EventType.ITEM_CREATED
+    previous_item_id: Optional[str] = None
+
+
+@dataclass
+class ItemTruncated(ServerToClientMessage):
+    item_id: str
+    content_index: int
+    audio_end_ms: int
+    type: str = EventType.ITEM_TRUNCATED
+
+
+@dataclass
+class ItemDeleted(ServerToClientMessage):
+    item_id: str
+    type: str = EventType.ITEM_DELETED
+
+
+# Assuming the necessary enums, ItemParam, and other classes are defined above
+# ResponseStatus could be a string or an enum, depending on your schema
+
+# Enum or Literal for ResponseStatus (could be more extensive)
+ResponseStatus = Union[
+    str,
+    Literal["in_progress", "completed", "cancelled", "incomplete", "failed"],
+]
+
+
+# Define status detail classes
+@dataclass
+class ResponseCancelledDetails:
+    reason: str  # e.g., "turn_detected", "client_cancelled"
+    type: str = "cancelled"
+
+
+@dataclass
+class ResponseIncompleteDetails:
+    reason: str  # e.g., "max_output_tokens", "content_filter"
+    type: str = "incomplete"
+
+
+@dataclass
+class ResponseError:
+    type: str  # The type of the error, e.g., "validation_error", "server_error"
+    message: str  # The error message describing what went wrong
+    code: Optional[str] = (
+        None  # Optional error code, e.g., HTTP status code, API error code
+    )
+
+
+@dataclass
+class ResponseFailedDetails:
+    error: ResponseError  # Assuming ResponseError is already defined
+    type: str = "failed"
+
+
+# Union of possible status details
+ResponseStatusDetails = Union[
+    ResponseCancelledDetails, ResponseIncompleteDetails, ResponseFailedDetails
+]
+
+
+# Define Usage class to handle token usage
+@dataclass
+class InputTokenDetails:
+    cached_tokens: int
+    text_tokens: int
+    audio_tokens: int
+
+
+@dataclass
+class OutputTokenDetails:
+    text_tokens: int
+    audio_tokens: int
+
+
+@dataclass
+class Usage:
+    total_tokens: int
+    input_tokens: int
+    output_tokens: int
+    input_token_details: InputTokenDetails
+    output_token_details: OutputTokenDetails
+
+
+# The Response dataclass definition
+@dataclass
+class Response:
+    id: str  # Unique ID for the response
+    output: List[ItemParam] = field(
+        default_factory=list
+    )  # List of items in the response
+    object: str = "realtime.response"  # Fixed value for object type
+    status: ResponseStatus = "in_progress"  # Status of the response
+    status_details: Optional[ResponseStatusDetails] = (
+        None  # Additional details based on status
+    )
+    usage: Optional[Usage] = None  # Token usage information
+    metadata: Optional[Dict[str, Any]] = (
+        None  # Additional metadata for the response
+    )
+
+
+@dataclass
+class ResponseCreated(ServerToClientMessage):
+    response: Response
+    type: str = EventType.RESPONSE_CREATED
+
+
+@dataclass
+class ResponseDone(ServerToClientMessage):
+    response: Response
+    type: str = EventType.RESPONSE_DONE
+
+
+@dataclass
+class ResponseTextDelta(ServerToClientMessage):
+    response_id: str
+    item_id: str
+    output_index: int
+    content_index: int
+    delta: str
+    type: str = EventType.RESPONSE_TEXT_DELTA
+
+
+@dataclass
+class ResponseTextDone(ServerToClientMessage):
+    response_id: str
+    item_id: str
+    output_index: int
+    content_index: int
+    text: str
+    type: str = EventType.RESPONSE_TEXT_DONE
+
+
+@dataclass
+class ResponseAudioTranscriptDelta(ServerToClientMessage):
+    response_id: str
+    item_id: str
+    output_index: int
+    content_index: int
+    delta: str
+    type: str = EventType.RESPONSE_AUDIO_TRANSCRIPT_DELTA
+
+
+@dataclass
+class ResponseAudioTranscriptDone(ServerToClientMessage):
+    response_id: str
+    item_id: str
+    output_index: int
+    content_index: int
+    transcript: str
+    type: str = EventType.RESPONSE_AUDIO_TRANSCRIPT_DONE
+
+
+@dataclass
+class ResponseAudioDelta(ServerToClientMessage):
+    response_id: str
+    item_id: str
+    output_index: int
+    content_index: int
+    delta: str
+    type: str = EventType.RESPONSE_AUDIO_DELTA
+
+
+@dataclass
+class ResponseAudioDone(ServerToClientMessage):
+    response_id: str
+    item_id: str
+    output_index: int
+    content_index: int
+    type: str = EventType.RESPONSE_AUDIO_DONE
+
+
+@dataclass
+class ResponseFunctionCallArgumentsDelta(ServerToClientMessage):
+    response_id: str
+    item_id: str
+    output_index: int
+    call_id: str
+    delta: str
+    type: str = EventType.RESPONSE_FUNCTION_CALL_ARGUMENTS_DELTA
+
+
+@dataclass
+class ResponseFunctionCallArgumentsDone(ServerToClientMessage):
+    response_id: str
+    item_id: str
+    output_index: int
+    call_id: str
+    name: str
+    arguments: str
+    type: str = EventType.RESPONSE_FUNCTION_CALL_ARGUMENTS_DONE
+
+
+@dataclass
+class RateLimitDetails:
+    name: str  # Name of the rate limit, e.g., "api_requests", "message_generation"
+    limit: (
+        int  # The maximum number of allowed requests in the current time window
+    )
+    remaining: (
+        int  # The number of requests remaining in the current time window
+    )
+    reset_seconds: float  # The number of seconds until the rate limit resets
+
+
+@dataclass
+class RateLimitsUpdated(ServerToClientMessage):
+    rate_limits: List[RateLimitDetails]
+    type: str = EventType.RATE_LIMITS_UPDATED
+
+
+@dataclass
+class ResponseOutputItemAdded(ServerToClientMessage):
+    response_id: str  # The ID of the response
+    output_index: int  # Index of the output item in the response
+    item: Union[
+        ItemParam, None
+    ]  # The added item (can be a message, function call, etc.)
+    type: str = EventType.RESPONSE_OUTPUT_ITEM_ADDED  # Fixed event type
+
+
+@dataclass
+class ResponseContentPartAdded(ServerToClientMessage):
+    response_id: str  # The ID of the response
+    item_id: str  # The ID of the item to which the content part was added
+    output_index: int  # Index of the output item in the response
+    content_index: int  # Index of the content part in the output
+    part: Union[ItemParam, None]  # The added content part
+    content: Union[ItemParam, None] = None  # The added content part for azure
+    type: str = EventType.RESPONSE_CONTENT_PART_ADDED  # Fixed event type
+
+
+@dataclass
+class ResponseContentPartDone(ServerToClientMessage):
+    response_id: str  # The ID of the response
+    item_id: str  # The ID of the item to which the content part belongs
+    output_index: int  # Index of the output item in the response
+    content_index: int  # Index of the content part in the output
+    part: Union[ItemParam, None]  # The content part that was completed
+    content: Union[ItemParam, None] = None  # The added content part for azure
+    type: str = EventType.RESPONSE_CONTENT_PART_ADDED  # Fixed event type
+
+
+@dataclass
+class ResponseOutputItemDone(ServerToClientMessage):
+    response_id: str  # The ID of the response
+    output_index: int  # Index of the output item in the response
+    item: Union[ItemParam, None]  # The output item that was completed
+    type: str = EventType.RESPONSE_OUTPUT_ITEM_DONE  # Fixed event type
+
+
+@dataclass
+class ItemInputAudioTranscriptionDelta(ServerToClientMessage):
+    item_id: str  # The ID of the item for which transcription was completed
+    content_index: int  # Index of the content part that was transcribed
+    delta: str  # The transcribed text
+    type: str = (
+        EventType.ITEM_INPUT_AUDIO_TRANSCRIPTION_DELTA
+    )  # Fixed event type
+
+
+@dataclass
+class ItemInputAudioTranscriptionCompleted(ServerToClientMessage):
+    item_id: str  # The ID of the item for which transcription was completed
+    content_index: int  # Index of the content part that was transcribed
+    transcript: str  # The transcribed text
+    type: str = (
+        EventType.ITEM_INPUT_AUDIO_TRANSCRIPTION_COMPLETED
+    )  # Fixed event type
+
+
+@dataclass
+class ItemInputAudioTranscriptionFailed(ServerToClientMessage):
+    item_id: str  # The ID of the item for which transcription failed
+    content_index: int  # Index of the content part that failed to transcribe
+    error: ResponseError  # Error details explaining the failure
+    type: str = (
+        EventType.ITEM_INPUT_AUDIO_TRANSCRIPTION_FAILED
+    )  # Fixed event type
+
+
+# Union of all server-to-client message types
+ServerToClientMessages = Union[
+    ErrorMessage,
+    SessionCreated,
+    SessionUpdated,
+    InputAudioBufferCommitted,
+    InputAudioBufferCleared,
+    InputAudioBufferSpeechStarted,
+    InputAudioBufferSpeechStopped,
+    ItemCreated,
+    ItemTruncated,
+    ItemDeleted,
+    ResponseCreated,
+    ResponseDone,
+    ResponseTextDelta,
+    ResponseTextDone,
+    ResponseAudioTranscriptDelta,
+    ResponseAudioTranscriptDone,
+    ResponseAudioDelta,
+    ResponseAudioDone,
+    ResponseFunctionCallArgumentsDelta,
+    ResponseFunctionCallArgumentsDone,
+    RateLimitsUpdated,
+    ResponseOutputItemAdded,
+    ResponseContentPartAdded,
+    ResponseContentPartDone,
+    ResponseOutputItemDone,
+    ItemInputAudioTranscriptionCompleted,
+    ItemInputAudioTranscriptionFailed,
+]
+
+
+# Base class for all ClientToServerMessages
+@dataclass
+class ClientToServerMessage:
+    event_id: str = field(default_factory=generate_event_id)
+
+
+@dataclass
+class InputAudioBufferAppend(ClientToServerMessage):
+    audio: Optional[str] = field(default=None)
+    type: str = (
+        EventType.INPUT_AUDIO_BUFFER_APPEND
+    )  # Default argument (has a default value)
+
+
+@dataclass
+class InputAudioBufferCommit(ClientToServerMessage):
+    type: str = EventType.INPUT_AUDIO_BUFFER_COMMIT
+
+
+@dataclass
+class InputAudioBufferClear(ClientToServerMessage):
+    type: str = EventType.INPUT_AUDIO_BUFFER_CLEAR
+
+
+@dataclass
+class ItemCreate(ClientToServerMessage):
+    item: Optional[ItemParam] = field(
+        default=None
+    )  # Assuming `ItemParam` is already defined
+    type: str = EventType.ITEM_CREATE
+    previous_item_id: Optional[str] = None
+
+
+@dataclass
+class ItemTruncate(ClientToServerMessage):
+    item_id: Optional[str] = field(default=None)
+    content_index: Optional[int] = field(default=None)
+    audio_end_ms: Optional[int] = field(default=None)
+    type: str = EventType.ITEM_TRUNCATE
+
+
+@dataclass
+class ItemDelete(ClientToServerMessage):
+    item_id: Optional[str] = field(default=None)
+    type: str = EventType.ITEM_DELETE
+
+
+@dataclass
+class ResponseCreateParams:
+    commit: bool = (
+        True  # Whether the generated messages should be appended to the conversation
+    )
+    cancel_previous: bool = (
+        True  # Whether to cancel the previous pending generation
+    )
+    append_input_items: Optional[List[ItemParam]] = (
+        None  # Messages to append before response generation
+    )
+    input_items: Optional[List[ItemParam]] = (
+        None  # Initial messages to use for generation
+    )
+    modalities: Optional[Set[str]] = (
+        None  # Allowed modalities (e.g., "text", "audio")
+    )
+    instructions: Optional[str] = None  # Instructions or guidance for the model
+    voice: Optional[Voices] = None  # Voice setting for audio output
+    output_audio_format: Optional[AudioFormats] = (
+        None  # Format for the audio output
+    )
+    tools: Optional[List[Dict[str, Any]]] = (
+        None  # Tools available for this response
+    )
+    tool_choice: Optional[ToolChoice] = (
+        None  # How to choose the tool ("auto", "required", etc.)
+    )
+    temperature: Optional[float] = (
+        None  # The randomness of the model's responses
+    )
+    max_response_output_tokens: Optional[Union[int, str]] = (
+        None  # Max number of tokens for the output, "inf" for infinite
+    )
+
+
+@dataclass
+class ResponseCreate(ClientToServerMessage):
+    type: str = EventType.RESPONSE_CREATE
+    response: Optional[ResponseCreateParams] = (
+        None  # Assuming `ResponseCreateParams` is defined
+    )
+
+
+@dataclass
+class ResponseCancel(ClientToServerMessage):
+    type: str = EventType.RESPONSE_CANCEL
+
+
+DEFAULT_CONVERSATION = "default"
+
+
+@dataclass
+class UpdateConversationConfig(ClientToServerMessage):
+    type: str = EventType.UPDATE_CONVERSATION_CONFIG
+    label: str = DEFAULT_CONVERSATION
+    subscribe_to_user_audio: Optional[bool] = None
+    voice: Optional[Voices] = None
+    system_message: Optional[str] = None
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    tools: Optional[List[dict]] = None
+    tool_choice: Optional[ToolChoice] = None
+    disable_audio: Optional[bool] = None
+    output_audio_format: Optional[AudioFormats] = None
+
+
+@dataclass
+class SessionUpdate(ClientToServerMessage):
+    session: Optional[SessionUpdateParams] = field(
+        default=None
+    )  # Assuming `SessionUpdateParams` is defined
+    type: str = EventType.SESSION_UPDATE
+
+
+# Union of all client-to-server message types
+ClientToServerMessages = Union[
+    InputAudioBufferAppend,
+    InputAudioBufferCommit,
+    InputAudioBufferClear,
+    ItemCreate,
+    ItemTruncate,
+    ItemDelete,
+    ResponseCreate,
+    ResponseCancel,
+    UpdateConversationConfig,
+    SessionUpdate,
+]
+
+
+def from_dict(data_class, data):
+    """Recursively convert a dictionary to a dataclass instance."""
+    if is_dataclass(data_class):  # Check if the target class is a dataclass
+        fieldtypes = {
+            f.name: f.type for f in data_class.__dataclass_fields__.values()
+        }
+        # Filter out keys that are not in the dataclass fields
+        valid_data = {f: data[f] for f in fieldtypes if f in data}
+        return data_class(
+            **{f: from_dict(fieldtypes[f], valid_data[f]) for f in valid_data}
+        )
+    elif isinstance(data, list):  # Handle lists of nested dataclass objects
+        return [from_dict(data_class.__args__[0], item) for item in data]
+    else:  # For primitive types (str, int, float, etc.), return the value as-is
+        return data
+
+
+def parse_client_message(unparsed_string: str) -> ClientToServerMessage:
+    data = json.loads(unparsed_string)
+
+    # Dynamically select the correct message class based on the `type` field, using from_dict
+    if data["type"] == EventType.INPUT_AUDIO_BUFFER_APPEND:
+        return from_dict(InputAudioBufferAppend, data)
+    elif data["type"] == EventType.INPUT_AUDIO_BUFFER_COMMIT:
+        return from_dict(InputAudioBufferCommit, data)
+    elif data["type"] == EventType.INPUT_AUDIO_BUFFER_CLEAR:
+        return from_dict(InputAudioBufferClear, data)
+    elif data["type"] == EventType.ITEM_CREATE:
+        return from_dict(ItemCreate, data)
+    elif data["type"] == EventType.ITEM_TRUNCATE:
+        return from_dict(ItemTruncate, data)
+    elif data["type"] == EventType.ITEM_DELETE:
+        return from_dict(ItemDelete, data)
+    elif data["type"] == EventType.RESPONSE_CREATE:
+        return from_dict(ResponseCreate, data)
+    elif data["type"] == EventType.RESPONSE_CANCEL:
+        return from_dict(ResponseCancel, data)
+    elif data["type"] == EventType.UPDATE_CONVERSATION_CONFIG:
+        return from_dict(UpdateConversationConfig, data)
+    elif data["type"] == EventType.SESSION_UPDATE:
+        return from_dict(SessionUpdate, data)
+
+    raise ValueError(f"Unknown message type: {data['type']}")
+
+
+# Assuming all necessary classes and enums (EventType, ServerToClientMessages, etc.) are imported
+# Here’s how you can dynamically parse a server-to-client message based on the `type` field:
+
+
+def parse_server_message(unparsed_string: str) -> ServerToClientMessage:
+    data = json.loads(unparsed_string)
+
+    # Dynamically select the correct message class based on the `type` field, using from_dict
+    if data["type"] == EventType.ERROR:
+        return from_dict(ErrorMessage, data)
+    elif data["type"] == EventType.SESSION_CREATED:
+        return from_dict(SessionCreated, data)
+    elif data["type"] == EventType.SESSION_UPDATED:
+        return from_dict(SessionUpdated, data)
+    elif data["type"] == EventType.INPUT_AUDIO_BUFFER_COMMITTED:
+        return from_dict(InputAudioBufferCommitted, data)
+    elif data["type"] == EventType.INPUT_AUDIO_BUFFER_CLEARED:
+        return from_dict(InputAudioBufferCleared, data)
+    elif data["type"] == EventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED:
+        return from_dict(InputAudioBufferSpeechStarted, data)
+    elif data["type"] == EventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
+        return from_dict(InputAudioBufferSpeechStopped, data)
+    elif data["type"] in (
+        EventType.ITEM_CREATED,
+        EventType.ITEM_ADDED,
+        EventType.ITEM_DONE,
+    ):
+        return from_dict(ItemCreated, data)
+    elif data["type"] == EventType.ITEM_TRUNCATED:
+        return from_dict(ItemTruncated, data)
+    elif data["type"] == EventType.ITEM_DELETED:
+        return from_dict(ItemDeleted, data)
+    elif data["type"] == EventType.RESPONSE_CREATED:
+        return from_dict(ResponseCreated, data)
+    elif data["type"] == EventType.RESPONSE_DONE:
+        return from_dict(ResponseDone, data)
+    elif data["type"] in (
+        EventType.RESPONSE_TEXT_DELTA,
+        EventType.RESPONSE_OUTPUT_TEXT_DELTA,
+    ):
+        return from_dict(ResponseTextDelta, data)
+    elif data["type"] in (
+        EventType.RESPONSE_TEXT_DONE,
+        EventType.RESPONSE_OUTPUT_TEXT_DONE,
+    ):
+        return from_dict(ResponseTextDone, data)
+    elif data["type"] in (
+        EventType.RESPONSE_AUDIO_TRANSCRIPT_DELTA,
+        EventType.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    ):
+        return from_dict(ResponseAudioTranscriptDelta, data)
+    elif data["type"] in (
+        EventType.RESPONSE_AUDIO_TRANSCRIPT_DONE,
+        EventType.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE,
+    ):
+        return from_dict(ResponseAudioTranscriptDone, data)
+    elif data["type"] in (
+        EventType.RESPONSE_AUDIO_DELTA,
+        EventType.RESPONSE_OUTPUT_AUDIO_DELTA,
+    ):
+        return from_dict(ResponseAudioDelta, data)
+    elif data["type"] in (
+        EventType.RESPONSE_AUDIO_DONE,
+        EventType.RESPONSE_OUTPUT_AUDIO_DONE,
+    ):
+        return from_dict(ResponseAudioDone, data)
+    elif data["type"] == EventType.RESPONSE_FUNCTION_CALL_ARGUMENTS_DELTA:
+        return from_dict(ResponseFunctionCallArgumentsDelta, data)
+    elif data["type"] == EventType.RESPONSE_FUNCTION_CALL_ARGUMENTS_DONE:
+        return from_dict(ResponseFunctionCallArgumentsDone, data)
+    elif data["type"] == EventType.RATE_LIMITS_UPDATED:
+        return from_dict(RateLimitsUpdated, data)
+    elif data["type"] == EventType.RESPONSE_OUTPUT_ITEM_ADDED:
+        return from_dict(ResponseOutputItemAdded, data)
+    elif data["type"] == EventType.RESPONSE_CONTENT_PART_ADDED:
+        return from_dict(ResponseContentPartAdded, data)
+    elif data["type"] == EventType.RESPONSE_CONTENT_PART_DONE:
+        return from_dict(ResponseContentPartDone, data)
+    elif data["type"] == EventType.RESPONSE_OUTPUT_ITEM_DONE:
+        return from_dict(ResponseOutputItemDone, data)
+    elif data["type"] == EventType.ITEM_INPUT_AUDIO_TRANSCRIPTION_COMPLETED:
+        return from_dict(ItemInputAudioTranscriptionCompleted, data)
+    elif data["type"] == EventType.ITEM_INPUT_AUDIO_TRANSCRIPTION_FAILED:
+        return from_dict(ItemInputAudioTranscriptionFailed, data)
+    elif data["type"] == EventType.ITEM_INPUT_AUDIO_TRANSCRIPTION_DELTA:
+        return from_dict(ItemInputAudioTranscriptionDelta, data)
+    elif isinstance(data["type"], str) and data["type"].startswith("call."):
+        return from_dict(CallEvent, data)
+
+    return UnknownMessage(event_id=data.get("event_id", ""), type=str(data["type"]))
+
+
+def to_json(obj: Union[ClientToServerMessage, ServerToClientMessage]) -> str:
+    # ignore none value
+    return json.dumps(
+        asdict(
+            obj, dict_factory=lambda x: {k: v for (k, v) in x if v is not None}
+        )
+    )

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/requirements.txt
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/requirements.txt
@@ -1,0 +1,2 @@
+pydantic
+aiohttp

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/tests/bin/start
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/tests/bin/start
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+export PYTHONPATH="$(pwd)/..":.ten/app:.ten/app/ten_packages/system/ten_runtime_python/lib:.ten/app/ten_packages/system/ten_runtime_python/interface:.ten/app/ten_packages/system/ten_ai_base/interface:$PYTHONPATH
+
+# If the Python app imports some modules that are compiled with a different
+# version of libstdc++ (ex: PyTorch), the Python app may encounter confusing
+# errors. To solve this problem, we can preload the correct version of
+# libstdc++.
+#
+# export LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6
+#
+# Another solution is to make sure the module 'ten_runtime_python' is imported
+# _after_ the module that requires another version of libstdc++ is imported.
+#
+# Refer to https://github.com/pytorch/pytorch/issues/102360?from_wecom=1#issuecomment-1708989096
+
+pytest -s tests/ "$@"

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/tests/conftest.py
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/tests/conftest.py
@@ -1,0 +1,100 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+import json
+import threading
+
+import pytest
+from typing_extensions import override
+
+from ten_runtime import (
+    App,
+    TenEnv,
+)
+
+
+class FakeApp(App):
+    def __init__(self):
+        super().__init__()
+        self.event: threading.Event | None = None
+
+    # In the case of a fake app, we use `on_init` to allow the blocked testing
+    # fixture to continue execution, rather than using `on_configure`. The
+    # reason is that in the TEN runtime C core, the relationship between the
+    # addon manager and the (fake) app is bound after `on_configure_done` is
+    # called. So we only need to let the testing fixture continue execution
+    # after this action in the TEN runtime C core, and at the upper layer
+    # timing, the earliest point is within the `on_init()` function of the
+    # upper TEN app. Therefore, we release the testing fixture lock within the
+    # user layer's `on_init()` of the TEN app.
+    def on_init(self, ten_env: TenEnv) -> None:
+        assert self.event
+        self.event.set()
+
+        ten_env.on_init_done()
+
+    @override
+    def on_configure(self, ten_env: TenEnv) -> None:
+        ten_env.init_property_from_json(
+            json.dumps(
+                {
+                    "ten": {
+                        "log": {
+                            "handlers": [
+                                {
+                                    "matchers": [{"level": "info"}],
+                                    "formatter": {
+                                        "type": "plain",
+                                        "colored": True,
+                                    },
+                                    "emitter": {
+                                        "type": "console",
+                                        "config": {"stream": "stdout"},
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                }
+            ),
+        )
+
+        ten_env.on_configure_done()
+
+
+class FakeAppCtx:
+    def __init__(self, event: threading.Event):
+        self.fake_app: FakeApp | None = None
+        self.event = event
+
+
+def run_fake_app(fake_app_ctx: FakeAppCtx):
+    app = FakeApp()
+    app.event = fake_app_ctx.event
+    fake_app_ctx.fake_app = app
+    app.run(False)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def global_setup_and_teardown():
+    event = threading.Event()
+    fake_app_ctx = FakeAppCtx(event)
+
+    fake_app_thread = threading.Thread(
+        target=run_fake_app, args=(fake_app_ctx,)
+    )
+    fake_app_thread.start()
+
+    event.wait()
+
+    assert fake_app_ctx.fake_app is not None
+
+    # Yield control to the test; after the test execution is complete, continue
+    # with the teardown process.
+    yield
+
+    # Teardown part.
+    fake_app_ctx.fake_app.close()
+    fake_app_thread.join()

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/tests/test_extension.py
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/tests/test_extension.py
@@ -1,0 +1,84 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+"""Drives the extension through the TEN runtime.
+
+`test_extension_loads` runs without credentials: the addon registers under
+its manifest name, `mllm-interface.json` resolves, properties are injected
+and `on_init` validates them. With `THUNDERPHONE_API_KEY` set,
+`test_session_becomes_ready` opens a real (billed) inline session and waits
+for `mllm_server_session_ready`.
+"""
+
+import asyncio
+import json
+import os
+
+import pytest
+from ten_runtime import (
+    AsyncExtensionTester,
+    AsyncTenEnvTester,
+    Data,
+)
+
+ADDON_NAME = "thunderphone_mllm_python"
+API_KEY = os.environ.get("THUNDERPHONE_API_KEY", "")
+
+requires_api_key = pytest.mark.skipif(
+    not API_KEY, reason="THUNDERPHONE_API_KEY is not set"
+)
+
+
+def properties(**overrides) -> str:
+    props = {
+        "api_key": API_KEY or "sk_live_invalid_key_used_by_the_load_check",
+        "prompt": "You are a test assistant. Say hello and nothing else.",
+        "language": "en",
+    }
+    props.update(overrides)
+    return json.dumps(props)
+
+
+class SessionReadyTester(AsyncExtensionTester):
+    """Waits for `mllm_server_session_ready` or a timeout."""
+
+    def __init__(self, timeout: float) -> None:
+        super().__init__()
+        self.timeout = timeout
+        self.session_ready = False
+        self._watchdog: asyncio.Task | None = None
+
+    async def on_start(self, ten_env: AsyncTenEnvTester) -> None:
+        self._watchdog = asyncio.create_task(self._stop_after_timeout(ten_env))
+
+    async def on_data(self, ten_env: AsyncTenEnvTester, data: Data) -> None:
+        if data.get_name() == "mllm_server_session_ready":
+            self.session_ready = True
+            if self._watchdog is not None:
+                self._watchdog.cancel()
+            ten_env.stop_test()
+
+    async def _stop_after_timeout(self, ten_env: AsyncTenEnvTester) -> None:
+        await asyncio.sleep(self.timeout)
+        ten_env.stop_test()
+
+
+def test_extension_loads():
+    tester = SessionReadyTester(timeout=5.0)
+    tester.set_test_mode_single(ADDON_NAME, properties(api_key="sk_live_invalid_key_used_by_the_load_check"))
+    err = tester.run()
+    assert err is None, err.error_message()
+    # An invalid key is refused at the WebSocket handshake; the extension
+    # logs it and stops instead of raising, so no session becomes ready.
+    assert tester.session_ready is False
+
+
+@requires_api_key
+def test_session_becomes_ready():
+    tester = SessionReadyTester(timeout=20.0)
+    tester.set_test_mode_single(ADDON_NAME, properties())
+    err = tester.run()
+    assert err is None, err.error_message()
+    assert tester.session_ready, "no mllm_server_session_ready within 20 s"

--- a/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/tests/test_realtime.py
+++ b/ai_agents/agents/ten_packages/extension/thunderphone_mllm_python/tests/test_realtime.py
@@ -1,0 +1,201 @@
+#
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for more information.
+#
+"""Protocol and configuration tests; no credentials or network needed."""
+
+import json
+
+import pytest
+
+from thunderphone_mllm_python.config import (
+    ThunderPhoneRealtimeConfig,
+    inline_session_update,
+)
+from thunderphone_mllm_python.realtime.connection import build_url
+from thunderphone_mllm_python.realtime.struct import (
+    CallEvent,
+    ItemCreated,
+    ResponseAudioDelta,
+    ResponseAudioTranscriptDone,
+    SessionCreated,
+    UnknownMessage,
+    parse_server_message,
+    to_json,
+)
+
+
+class _Param:
+    def __init__(self, name, type_, description, required):
+        self.name, self.type, self.description, self.required = (
+            name,
+            type_,
+            description,
+            required,
+        )
+
+
+class _Tool:
+    name = "check_availability"
+    description = "Free appointment slots on a date"
+    parameters = [_Param("date", "string", "ISO date", True)]
+
+
+def test_saved_agent_config_builds_call_events_query():
+    config = ThunderPhoneRealtimeConfig(
+        api_key="sk_live_x", agent_id=12, from_number="+15550001"
+    )
+    config.validate_for_start()
+    assert config.saved_agent
+    assert config.query() == {
+        "agent_id": "12",
+        "from_number": "+15550001",
+        "input_audio_format": "pcm16",
+        "input_rate": "24000",
+        "output_audio_format": "pcm16",
+        "output_rate": "24000",
+        "call_events": "1",
+    }
+
+
+def test_inline_config_requires_prompt_and_secret_key():
+    with pytest.raises(ValueError, match="sk_live_"):
+        ThunderPhoneRealtimeConfig(api_key="sk-openai", prompt="x").validate_for_start()
+    with pytest.raises(ValueError, match="prompt"):
+        ThunderPhoneRealtimeConfig(api_key="sk_live_x").validate_for_start()
+    with pytest.raises(ValueError, match="sample_rate"):
+        ThunderPhoneRealtimeConfig(
+            api_key="sk_live_x", prompt="x", sample_rate=8000
+        ).validate_for_start()
+    config = ThunderPhoneRealtimeConfig(
+        api_key="sk_live_x", prompt="x", product="bolt", language="es", sample_rate=16000
+    )
+    config.validate_for_start()
+    query = config.query()
+    assert query["product"] == "bolt" and query["language"] == "es"
+    assert query["input_rate"] == query["output_rate"] == "16000"
+    assert "agent_id" not in query
+
+
+def test_build_url_merges_query_into_path():
+    assert (
+        build_url("wss://api.thunderphone.com/", "/v1/realtime", {"agent_id": "1"})
+        == "wss://api.thunderphone.com/v1/realtime?agent_id=1"
+    )
+    assert (
+        build_url("ws://localhost:8002", "/v1/realtime?debug=1", {"a": "b"})
+        == "ws://localhost:8002/v1/realtime?debug=1&a=b"
+    )
+
+
+def test_inline_session_update_carries_everything_that_starts_the_call():
+    config = ThunderPhoneRealtimeConfig(
+        api_key="sk_live_x", prompt="Be brief.", voice="olivia", live_transcripts=True
+    )
+    update = json.loads(to_json(inline_session_update(config, [_Tool()])))
+    session = update["session"]
+    assert update["type"] == "session.update"
+    assert session["instructions"] == "Be brief."
+    assert session["voice"] == "olivia"
+    assert session["config"] == {"call_events": True}
+    assert session["live_transcripts"] is True
+    assert session["tool_choice"] == "auto"
+    assert session["tools"] == [
+        {
+            "type": "function",
+            "name": "check_availability",
+            "description": "Free appointment slots on a date",
+            "parameters": {
+                "type": "object",
+                "properties": {"date": {"type": "string", "description": "ISO date"}},
+                "required": ["date"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+    # Absent keys are omitted rather than sent as null.
+    assert "model" not in session and "turn_detection" not in session
+
+    bare = json.loads(to_json(inline_session_update(config, [])))["session"]
+    assert "tools" not in bare and "tool_choice" not in bare
+
+
+def test_thunderphone_session_created_parses():
+    frame = {
+        "event_id": "evt_1",
+        "type": "session.created",
+        "session": {
+            "id": "sess_1",
+            "object": "realtime.session",
+            "model": "thunderphone-realtime",
+            "call_id": "987",
+            "audio": {"input": {"format": {"type": "audio/pcm", "rate": 24000}}},
+            "voice": "olivia",
+            "turn_detection": {"type": "server_vad"},
+        },
+    }
+    message = parse_server_message(json.dumps(frame))
+    assert isinstance(message, SessionCreated)
+    assert message.session.id == "sess_1"
+    assert message.session.call_id == "987"
+    assert message.session.voice == "olivia"
+
+
+def test_call_events_and_ga_item_events_parse():
+    ended = parse_server_message(
+        json.dumps({"event_id": "e", "type": "call.ended", "reason": "agent_hangup"})
+    )
+    assert isinstance(ended, CallEvent)
+    assert ended.type == "call.ended" and ended.reason == "agent_hangup"
+
+    added = parse_server_message(
+        json.dumps(
+            {
+                "event_id": "e",
+                "type": "conversation.item.added",
+                "previous_item_id": None,
+                "item": {"id": "item_1", "type": "message", "role": "user", "content": []},
+            }
+        )
+    )
+    assert isinstance(added, ItemCreated)
+    assert added.item["id"] == "item_1"
+
+    unknown = parse_server_message(
+        json.dumps({"event_id": "e", "type": "output_audio_buffer.started"})
+    )
+    assert isinstance(unknown, UnknownMessage)
+    assert unknown.type == "output_audio_buffer.started"
+
+
+def test_ga_response_event_names_parse():
+    audio = parse_server_message(
+        json.dumps(
+            {
+                "event_id": "e",
+                "type": "response.output_audio.delta",
+                "response_id": "resp_1",
+                "item_id": "item_1",
+                "output_index": 0,
+                "content_index": 0,
+                "delta": "AAAA",
+            }
+        )
+    )
+    assert isinstance(audio, ResponseAudioDelta) and audio.delta == "AAAA"
+    transcript = parse_server_message(
+        json.dumps(
+            {
+                "event_id": "e",
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp_1",
+                "item_id": "item_1",
+                "output_index": 0,
+                "content_index": 0,
+                "transcript": "Hello.",
+            }
+        )
+    )
+    assert isinstance(transcript, ResponseAudioTranscriptDone)
+    assert transcript.transcript == "Hello."


### PR DESCRIPTION
## Summary

Adds `thunderphone_mllm_python`: [ThunderPhone](https://thunderphone.com) voice agents as a speech-to-speech (MLLM) extension, alongside `openai_mllm_python`, `gemini_mllm_python`, `azure_mllm_python`, `glm_mllm_python` and `stepfun_mllm_python`.

ThunderPhone's Realtime WebSocket API speaks the OpenAI Realtime protocol, so the extension mirrors `openai_mllm_python` (same `mllm-interface.json`, same event mapping) and adds the ThunderPhone-specific parts:

- the endpoint, its query parameters (saved agent, engine, language, caller/callee numbers, wire audio, `call_events`) and `sk_live_` keys;
- **saved agents** (`agent_id`): prompt, voice, engine, languages, tools and greeting live on ThunderPhone, the graph only moves audio;
- **inline sessions** (`prompt`, `product`, `voice`, `language`): graph tools are collected and sent in the single `session.update` that starts the call, because ThunderPhone freezes instructions, tools and voice at that point (the extension waits up to 500 ms for late `tool_register`s unless audio arrives first);
- ThunderPhone's `call.*` events (hang-up reason, transfer, keypad) are parsed and logged, and `call.ended` stops the extension from reconnecting, since a reconnect would start a new, separately billed call.

Also registers the extension in `examples/voice-assistant-realtime` (manifest dependency + README provider list) and adds `THUNDERPHONE_API_KEY` / `THUNDERPHONE_AGENT_ID` to `.env.example`.

## Validation

- `tests/test_realtime.py` (no credentials): 6 passed, covering the connect query, config validation, the inline `session.update`, and parsing of ThunderPhone's `session.created`, GA `conversation.item.added` and `call.*` events.
- `tests/test_extension.py`: a credential-free load test through `AsyncExtensionTester`, plus a live session-ready test when `THUNDERPHONE_API_KEY` is set.
- Verified live against the ThunderPhone API by driving `ThunderPhoneRealtimeExtension` directly (base class stubbed to record emits): saved-agent greeting → caller transcript → reply → hang-up (`call.ended`, no reconnect); inline session with a graph tool → `mllm_server_function_call` → `function_call_output` → reply using the tool result → hang-up.

Disclosure: I'm the founder of ThunderPhone.
