### PR TITLE
fix(tests/video_cmp): initialize grab_failure_cnt before the compare loop

### DIFF
--- a/tests/ten_runtime/integration/cpp/ffmpeg_basic/video_cmp.py
+++ b/tests/ten_runtime/integration/cpp/ffmpeg_basic/video_cmp.py
@@ -41,6 +41,7 @@ def compare(
     frame_count = int(video1.get(cv2.CAP_PROP_FRAME_COUNT))
 
     similar = 0
+    grab_failure_cnt = 0
 
     # grab frame and compare.
     for _ in range(frame_count):

--- a/tests/ten_runtime/integration/cpp/ffmpeg_bypass/video_cmp.py
+++ b/tests/ten_runtime/integration/cpp/ffmpeg_bypass/video_cmp.py
@@ -41,6 +41,7 @@ def compare(
     frame_count = int(video1.get(cv2.CAP_PROP_FRAME_COUNT))
 
     similar = 0
+    grab_failure_cnt = 0
 
     # grab frame and compare.
     for _ in range(frame_count):


### PR DESCRIPTION
### Problem

`compare()` in the ffmpeg integration test helper (`video_cmp.py`) counts consecutive failed frame grabs to bail out of a potential endless loop:

```python
for _ in range(frame_count):
    retval1 = video1.grab()
    retval2 = video2.grab()

    if not retval1 or not retval2:
        grab_failure_cnt += 1          # <-- never initialized
        if grab_failure_cnt >= 10:
            raise Exception("Grab failed too much ...")
    else:
        grab_failure_cnt = 0
```

`grab_failure_cnt` is only ever **assigned** in the `else` branch (reset to `0` after a successful grab). The very first time either `video1.grab()` or `video2.grab()` returns `False`, `grab_failure_cnt += 1` executes before any binding exists, so Python raises `UnboundLocalError: local variable 'grab_failure_cnt' referenced before assignment` — masking the real "grab failed" condition the counter was meant to detect.

### Fix

Initialize `grab_failure_cnt = 0` alongside `similar` before the loop, so the failure path counts as designed and the endless-loop guard can trigger.

Both identical copies (`ffmpeg_basic/` and `ffmpeg_bypass/`) are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
